### PR TITLE
chore(security): patch quinn protocol advisory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,8 @@ packages are released in lockstep.)*
   강제 전환 경고와 향후 중단 위험을 제거했다.
 - **런칭 의존성 보안.** demo worker의 `undici` 7.29.0, lab의 `nanoid` 3.3.17, Tauri UI의
   `postcss` 8.5.23을 override/lockfile에 고정하고 각 npm/pnpm audit 0건을 확인했다. Tauri는 2.11.5로
-  갱신했다.
+  갱신했고, GitHub 재평가에서 새로 열린 High advisory를 닫기 위해 잠금파일의 `quinn-proto`도
+  0.11.15로 올렸다.
 - **`DocSession.applyBatch` 원자성.** 중간 Intent가 실패하면 앞서 적용된 op까지 롤백하고 refresh하여
   “실패했는데 일부만 남는” 고아 편집을 막는다.
 - **패널/편집 UX 회귀.** 패널 접기 뒤 채팅 상태를 보존하고, 탭 라벨 정렬·행/칸 선택·undo 안내와

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3748,9 +3748,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -6,6 +6,15 @@
 - 정본 배포: **https://autohwp.com** (Vercel full Next — 2026-08-06 컷오버, Actions vercel-deploy.yml).
   GitHub Pages(kwakseongjae.github.io/auto-hwp)는 병행 유지 중 — 리다이렉트 스텁 전환 예정.
   GitHub: https://github.com/kwakseongjae/auto-hwp (public, 홈페이지·description=autohwp.com)
+- 갱신: 2026-08-12 · Codex(sol) — **PR #2 main 병합 완료, Dependabot 후속 High 패치 검증 중**.
+  오픈소스 런칭 RC는 보호된 `main`의 `76cdd8c`로 병합됐다. 병합 후 기존 npm/pnpm actionable alert는
+  모두 닫혔으나 새 #16(`quinn-proto 0.11.14`, `GHSA-4w2j-m93h-cj5j`, High)이 유일한 open으로
+  나타났다. 활성 cargo graph에는 없는 lockfile 항목이지만 dismiss하지 않고 후속 브랜치
+  `codex/open-source-launch-security-evidence`에서 0.11.15로 갱신했다. metadata locked·deny licenses·
+  fmt·workspace all-targets locked(11m45s)·launch 29/29·diff가 green이다. 다음은 명시 커밋→PR→필수
+  checks→main 병합→Dependabot open 0 재조회→최종 증빙 PR 순서로 닫는다. 그 전까지 dependency gate는
+  pending이다. 라이브 진입 외부 차단은 소유자 개인정보/런칭 문구 승인과 Vercel Production Upstash
+  URL/token 2개이며, 해결 전 tag/Release/배포/live smoke 금지. npm publish는 별도 명시 승인 없이는 금지.
 - 갱신: 2026-08-12 · Codex(sol) — **082+085 RC 검증·PR CI green·main 보호 적용, 증거 반영 후 merge 직전**.
   브랜치 `codex/open-source-launch-085`(base `9784fd2`), 원격 커밋은 `ff0c584`(082 guarded resave)와
   `5bb471e`(agent-first launch RC). 컨셉은 “local-first Rust 코어가 본체, AI는 명시 동의 뒤

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,11 @@
 
 ---
 
+## 2026-08-12 (Codex sol) · PR #2 병합 + Rust High 후속
+- PR #2를 보호된 `main` `76cdd8c`로 병합; 기존 npm/pnpm actionable alert는 모두 닫힘.
+- 새 High #16 `quinn-proto 0.11.14`를 0.11.15로 패치, metadata/deny/fmt/launch 29/29/diff green.
+- 다음은 workspace check→후속 PR CI/merge→Dependabot open 0→dependency gate 최종 증빙 PR.
+
 ## 2026-08-12 (Codex sol) · PR CI green + main 보호 적용
 - PR #2 `b2258e2`: build-test 11m11s·licenses 2m47s green, checkout v6 경고 0.
 - 실제 context 2개 strict+PR 필수+admin+대화 해결, force-push/delete 금지로 main 보호 후 API 재조회.

--- a/docs/launch/RC-CHECKLIST.md
+++ b/docs/launch/RC-CHECKLIST.md
@@ -22,7 +22,7 @@
 | 게이트 | 담당 | 현재 | 닫는 정확한 방법 | 증거 |
 |---|---|---:|---|---|
 | GitHub 보안 설정 | 작업 에이전트 | 완료 | private reporting·Dependabot·secret scanning·push protection 재조회 | `evidence/2026-08-12-github-security.md` |
-| 의존성 보안 | 작업 에이전트 | 병합 대기 | lockfile 8건 수정+감사 0; glib 비도달 위험 수용. main 병합 뒤 open alert 0 재조회 | `evidence/2026-08-12-dependency-security.md` |
+| 의존성 보안 | 작업 에이전트 | 후속 병합 대기 | npm/pnpm 경고 해소+감사 0, glib 비도달 위험 수용. 새 High #16은 `quinn-proto` 0.11.15로 패치 후 main 병합·open 0 재조회 | `evidence/2026-08-12-dependency-security.md` |
 | 개인정보 문구 | 소유자 | 대기 | 실제 운영과 `/privacy`를 대조한 뒤 `OWNER-APPROVAL.md`에 승인자/시각 기록 | 승인된 `OWNER-APPROVAL.md` |
 | 런칭 문구 | 소유자 | 대기 | CONTENT-BRIEF의 허용/금지 주장과 README 한·영문 승인 | 승인된 `OWNER-APPROVAL.md` |
 | durable rate limit | 소유자(저장소 생성)→작업 에이전트(연결 검증) | 차단 | Vercel Production에 `UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN`을 등록하고 RC 배포 | `evidence/2026-08-12-vercel-preflight.md` + 아래 probe 로그 |

--- a/docs/launch/evidence/2026-08-12-dependency-security.md
+++ b/docs/launch/evidence/2026-08-12-dependency-security.md
@@ -1,7 +1,9 @@
 # Dependency security preflight — 2026-08-12
 
 브랜치 첫 push 직후 GitHub가 기본 브랜치에 open Dependabot alert 9건(High 3, Moderate 6)을 보고했다.
-비밀 값이나 사용자 문서는 조회하지 않고 advisory·manifest·버전 범위만 REST API로 분류했다.
+비밀 값이나 사용자 문서는 조회하지 않고 advisory·manifest·버전 범위만 REST API로 분류했다. PR #2가
+`main`의 `76cdd8c`로 병합된 뒤 기존 npm/pnpm 경고는 actionable open에서 모두 사라졌다. 전체 이력의
+상태는 fixed 11건, auto-dismissed 3건, 아래 `glib` 위험 수용 1건이었다.
 
 ## 수정한 8건
 
@@ -33,8 +35,25 @@ High/Moderate/Low 포함 **0건**으로 종료했다.
 지원하거나 해당 API가 도달 가능해지면 즉시 재검토한다. 이는 취약 버전이 사라졌다는 주장이 아니라
 현재 제품 경로의 비도달성에 근거한 명시적 위험 수용이다.
 
+## 후속 High alert #16 — `quinn-proto`
+
+- Advisory: `GHSA-4w2j-m93h-cj5j` (High, remote memory exhaustion)
+- manifest: `Cargo.lock`, 취약 범위 `< 0.11.15`, 최초 수정 버전 `0.11.15`
+- PR #2 병합 뒤 REST API 재조회에서 `quinn-proto 0.11.14`가 유일한 actionable open으로 새로 나타났다.
+- `cargo tree --locked --target all -i quinn-proto@0.11.15`는 현재 활성 워크스페이스 그래프에 해당
+  package ID가 없다고 확인했다. 잠금파일에만 남은 항목이라도 GitHub 정본을 흐리지 않도록 dismiss하지
+  않고 `cargo update -p quinn-proto@0.11.14 --precise 0.11.15`로 패치했다.
+
+패치 후 `cargo metadata --locked --no-deps`, `cargo deny check licenses`, `cargo fmt --all --check`,
+`cargo check --workspace --all-targets --locked`(11m45s), `scripts/verify-launch.sh --automated`(29/29),
+`git diff --check`를 통과했다. lockfile diff는 버전과 checksum만 바뀐다.
+
 ## 남은 확인
 
-npm alert 8건은 이 브랜치의 lockfile 수정이 `main`에 병합된 뒤 GitHub가 closed로 재평가해야 한다.
-그 전까지 `dependency_security`는 `pending`이며, 병합 후 open alert가 0인지 REST API로 재조회한 뒤
-이 문서에 결과를 추가하고 gate를 `pass`로 바꾼다.
+`quinn-proto` 후속 PR이 보호된 `main`에 병합되고 GitHub가 alert #16을 closed로 재평가해야 한다.
+그 전까지 `dependency_security`는 `pending`이다. 병합 후 아래 API 결과에서 actionable open이 0인지
+재조회한 뒤 이 문서에 결과와 시각을 추가하고 gate를 `pass`로 바꾼다.
+
+```bash
+gh api --paginate 'repos/kwakseongjae/auto-hwp/dependabot/alerts?state=open'
+```


### PR DESCRIPTION
## Summary
- update Cargo.lock quinn-proto 0.11.14 to 0.11.15 for Dependabot alert #16
- record the post-PR #2 alert reclassification and keep dependency gate pending until default-branch re-evaluation
- update launch checklist, changelog, session state, and journal

## Verification
- cargo metadata --locked --format-version 1 --no-deps
- cargo deny check licenses
- cargo fmt --all --check
- cargo check --workspace --all-targets --locked
- scripts/verify-launch.sh --automated (29/29)
- git diff --check

The pre-existing untracked crates/hwp-rhwp/examples directory is excluded.