### PR TITLE
docs: close dependency security launch gate

### DIFF
--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -6,6 +6,14 @@
 - 정본 배포: **https://autohwp.com** (Vercel full Next — 2026-08-06 컷오버, Actions vercel-deploy.yml).
   GitHub Pages(kwakseongjae.github.io/auto-hwp)는 병행 유지 중 — 리다이렉트 스텁 전환 예정.
   GitHub: https://github.com/kwakseongjae/auto-hwp (public, 홈페이지·description=autohwp.com)
+- 갱신: 2026-08-12 · Codex(sol) — **Dependabot actionable open 0, dependency gate 최종 증빙 중**.
+  후속 PR #4는 필수 `build-test` 6m19s·`licenses` 9m25s green 뒤 보호된 `main`의 `3a1b030`으로
+  병합됐다. GitHub는 #16을 `fixed_at=2026-08-11T20:09:34Z`로 재평가했고 전체 분류는 fixed 12·
+  auto-dismissed 3·dismissed 1(`glib` 비도달 위험 수용)·open 0이다. 최종 증빙 브랜치
+  `codex/open-source-launch-final-evidence`에서 STATUS dependency_security를 pass로 전환한다.
+  이 PR 병합 후 자동 게이트는 29/29, 전체는 33/40 예상이다. 남는 7개는 소유자 개인정보/런칭 문구
+  승인→Vercel Production Upstash URL/token→RC SHA·tag/Release·prebuilt 배포→live smoke→ready 순서다.
+  외부 3조건 전 tag/Release/배포/live smoke 금지, npm publish는 별도 명시 승인 없이는 금지.
 - 갱신: 2026-08-12 · Codex(sol) — **PR #2 main 병합 완료, Dependabot 후속 High 패치 검증 중**.
   오픈소스 런칭 RC는 보호된 `main`의 `76cdd8c`로 병합됐다. 병합 후 기존 npm/pnpm actionable alert는
   모두 닫혔으나 새 #16(`quinn-proto 0.11.14`, `GHSA-4w2j-m93h-cj5j`, High)이 유일한 open으로

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,11 @@
 
 ---
 
+## 2026-08-12 (Codex sol) · dependency gate open 0 확정
+- PR #4 필수 checks green 뒤 `main` `3a1b030` 병합; alert #16은 5초 뒤 fixed.
+- Dependabot 최종 fixed 12·auto-dismissed 3·dismissed 1·open 0을 API로 재조회.
+- 최종 증빙 PR에서 dependency pass; 이후는 소유자 승인 2건+Upstash가 라이브 선행 차단.
+
 ## 2026-08-12 (Codex sol) · PR #2 병합 + Rust High 후속
 - PR #2를 보호된 `main` `76cdd8c`로 병합; 기존 npm/pnpm actionable alert는 모두 닫힘.
 - 새 High #16 `quinn-proto 0.11.14`를 0.11.15로 패치, metadata/deny/fmt/launch 29/29/diff green.

--- a/docs/launch/RC-CHECKLIST.md
+++ b/docs/launch/RC-CHECKLIST.md
@@ -22,7 +22,7 @@
 | 게이트 | 담당 | 현재 | 닫는 정확한 방법 | 증거 |
 |---|---|---:|---|---|
 | GitHub 보안 설정 | 작업 에이전트 | 완료 | private reporting·Dependabot·secret scanning·push protection 재조회 | `evidence/2026-08-12-github-security.md` |
-| 의존성 보안 | 작업 에이전트 | 후속 병합 대기 | npm/pnpm 경고 해소+감사 0, glib 비도달 위험 수용. 새 High #16은 `quinn-proto` 0.11.15로 패치 후 main 병합·open 0 재조회 | `evidence/2026-08-12-dependency-security.md` |
+| 의존성 보안 | 작업 에이전트 | 완료 | npm/pnpm 경고 해소+감사 0, `quinn-proto` 0.11.15 패치, glib 비도달 위험 수용. PR #4 병합 뒤 REST API open 0 | `evidence/2026-08-12-dependency-security.md` |
 | 개인정보 문구 | 소유자 | 대기 | 실제 운영과 `/privacy`를 대조한 뒤 `OWNER-APPROVAL.md`에 승인자/시각 기록 | 승인된 `OWNER-APPROVAL.md` |
 | 런칭 문구 | 소유자 | 대기 | CONTENT-BRIEF의 허용/금지 주장과 README 한·영문 승인 | 승인된 `OWNER-APPROVAL.md` |
 | durable rate limit | 소유자(저장소 생성)→작업 에이전트(연결 검증) | 차단 | Vercel Production에 `UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN`을 등록하고 RC 배포 | `evidence/2026-08-12-vercel-preflight.md` + 아래 probe 로그 |

--- a/docs/launch/STATUS.json
+++ b/docs/launch/STATUS.json
@@ -29,7 +29,7 @@
       "evidence": "docs/launch/evidence/2026-08-12-github-security.md"
     },
     "dependency_security": {
-      "status": "pending",
+      "status": "pass",
       "evidence": "docs/launch/evidence/2026-08-12-dependency-security.md"
     },
     "branch_protection": {

--- a/docs/launch/evidence/2026-08-12-dependency-security.md
+++ b/docs/launch/evidence/2026-08-12-dependency-security.md
@@ -48,11 +48,18 @@ High/Moderate/Low 포함 **0건**으로 종료했다.
 `cargo check --workspace --all-targets --locked`(11m45s), `scripts/verify-launch.sh --automated`(29/29),
 `git diff --check`를 통과했다. lockfile diff는 버전과 checksum만 바뀐다.
 
-## 남은 확인
+## 기본 브랜치 최종 결과
 
-`quinn-proto` 후속 PR이 보호된 `main`에 병합되고 GitHub가 alert #16을 closed로 재평가해야 한다.
-그 전까지 `dependency_security`는 `pending`이다. 병합 후 아래 API 결과에서 actionable open이 0인지
-재조회한 뒤 이 문서에 결과와 시각을 추가하고 gate를 `pass`로 바꾼다.
+- [PR #4](https://github.com/kwakseongjae/auto-hwp/pull/4)의 `build-test`(6m19s)와
+  `licenses`(9m25s)가 [CI run 31530666444](https://github.com/kwakseongjae/auto-hwp/actions/runs/31530666444)에서
+  통과했다.
+- 보호된 `main`의 merge commit은 `3a1b03011b99f337bb7cd4e6f1de8a1bb46af9da`다.
+- GitHub는 alert #16을 merge 5초 뒤인 `2026-08-11T20:09:34Z`에 `fixed`로 재평가했다
+  (`dismissed_at=null`).
+- 최종 REST API 분류는 fixed 12, auto-dismissed 3, dismissed 1, **open 0**이다.
+
+따라서 actionable Dependabot alert가 없고, 유일한 위험 수용은 위에 근거를 명시한 `glib` #1이다.
+`dependency_security` gate를 `pass`로 전환한다. 재조회 명령은 아래와 같다.
 
 ```bash
 gh api --paginate 'repos/kwakseongjae/auto-hwp/dependabot/alerts?state=open'


### PR DESCRIPTION
## Summary
- record protected-main merge and Dependabot alert #16 fixed evidence
- record final Dependabot classification: fixed 12, auto-dismissed 3, dismissed 1, open 0
- change only dependency_security from pending to pass
- keep owner approvals, Upstash, release, deployment, live smoke, and ready state pending

## Verification
- scripts/verify-launch.sh --automated: 29/29 pass
- scripts/verify-launch.sh --report: 33/40 pass, remaining 7 P0 gates fail as designed
- jq empty docs/launch/STATUS.json
- git diff --check

The pre-existing untracked crates/hwp-rhwp/examples directory is excluded.