### PR TITLE
docs: record pre-live launch handoff

### DIFF
--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -6,6 +6,16 @@
 - 정본 배포: **https://autohwp.com** (Vercel full Next — 2026-08-06 컷오버, Actions vercel-deploy.yml).
   GitHub Pages(kwakseongjae.github.io/auto-hwp)는 병행 유지 중 — 리다이렉트 스텁 전환 예정.
   GitHub: https://github.com/kwakseongjae/auto-hwp (public, 홈페이지·description=autohwp.com)
+- 갱신: 2026-08-12 · Codex(sol) — **오픈소스 런칭 pre-live 안전 정지점 확정, 단독 처리 가능분 완료**.
+  보호된 `main`의 현재 head는 최종 증빙 PR #5 merge `a7e3a85`. 자동 게이트 29/29, 전체 report
+  33/40, `--pre-live --strict`는 33/38이며 남은 P0 5개만 정확히 red다: `release_commit` 미고정,
+  소유자 개인정보 문구 승인, Vercel Production durable Upstash, tag/GitHub Release, 소유자 런칭 문구
+  승인. Dependabot open 0; main 보호는 strict `build-test`+`licenses`, PR/admin/대화해결 적용,
+  force-push/delete 금지 상태를 재확인했다. 다음 순서는 ①소유자가 `docs/launch/OWNER-APPROVAL.md`
+  두 항목 승인 ②Production에 `UPSTASH_REDIS_REST_URL`/`UPSTASH_REDIS_REST_TOKEN` 등록 ③그 뒤 단일
+  RC SHA를 STATUS에 고정 ④같은 SHA로 tag/Release/prebuilt production 배포 ⑤pre-live strict green 후
+  종합 live smoke ⑥성공 증거와 `stage=ready`. tag/Release/배포/live smoke/npm publish는 실행하지 않았다.
+  선재 미추적 `crates/hwp-rhwp/examples/control-audit.rs`는 계속 보존·무접촉.
 - 갱신: 2026-08-12 · Codex(sol) — **Dependabot actionable open 0, dependency gate 최종 증빙 중**.
   후속 PR #4는 필수 `build-test` 6m19s·`licenses` 9m25s green 뒤 보호된 `main`의 `3a1b030`으로
   병합됐다. GitHub는 #16을 `fixed_at=2026-08-11T20:09:34Z`로 재평가했고 전체 분류는 fixed 12·

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,11 @@
 
 ---
 
+## 2026-08-12 (Codex sol) · pre-live 안전 정지점
+- PR #5 `main` `a7e3a85`; launch automated 29/29·report 33/40·pre-live 33/38.
+- open alert 0·보호 설정 유지. 남은 red는 owner 승인 2+Upstash+RC SHA+tag/Release 5개뿐.
+- 다음은 외부 3조건 후 동일 SHA tag/Release/prebuilt 배포→pre-live green→live smoke; publish 미실행.
+
 ## 2026-08-12 (Codex sol) · dependency gate open 0 확정
 - PR #4 필수 checks green 뒤 `main` `3a1b030` 병합; alert #16은 5초 뒤 fixed.
 - Dependabot 최종 fixed 12·auto-dismissed 3·dismissed 1·open 0을 API로 재조회.

--- a/docs/launch/RC-CHECKLIST.md
+++ b/docs/launch/RC-CHECKLIST.md
@@ -32,6 +32,20 @@
 | tag/Release/site | 작업 에이전트 | 대기 | 보호된 main의 RC SHA를 태그·Release·Vercel workflow `--ref`에 동일 사용 | tag/Release/deploy URL+SHA |
 | 라이브 smoke | 작업 에이전트 | 최종 대기 | 배포 뒤 `LAUNCH_BASE_URL=https://autohwp.com scripts/verify-launch.sh --browser`와 실제 문서 퍼널 | live evidence |
 
+## 현재 안전 정지점
+
+`main` `a7e3a85`에서 자동 게이트는 29/29, 전체 report는 33/40이다. 라이브 smoke와 최종 ready를
+제외한 `node scripts/launch-readiness.mjs --pre-live --strict`는 33/38이며 아래 5개만 실패한다.
+
+1. 소유자의 개인정보 문구 승인
+2. 소유자의 런칭 문구 승인
+3. Vercel Production durable Upstash 연결
+4. 위 세 조건 뒤 확정할 단일 `release_commit`
+5. 그 SHA의 tag/GitHub Release
+
+1~3은 계정·운영 정책·비용 선택이 필요한 외부 조건이다. 이들이 닫히기 전에 4~5나 production 배포를
+선행하지 않는다. 5까지 닫힌 뒤 pre-live strict를 다시 통과시키고 그 다음에만 종합 라이브 smoke를 한다.
+
 ## durable rate-limit 판정
 
 비밀 값은 증거에 기록하지 않는다. 배포 뒤 다음 공개 probe 결과만 저장한다.


### PR DESCRIPTION
## Summary
- record the final safe stopping point before live smoke
- record main a7e3a85, automated 29/29, report 33/40, and pre-live 33/38
- list the five intentional pre-live blockers and the exact owner/Upstash/release/deploy/smoke order
- state explicitly that tag, Release, deployment, live smoke, and npm publish were not run

## Verification
- scripts/verify-launch.sh --automated: 29/29 pass
- node scripts/launch-readiness.mjs --pre-live --strict: expected exit 1, exactly 5 documented P0 blockers
- git diff --check

The pre-existing untracked crates/hwp-rhwp/examples directory is excluded.