### PR TITLE
fix: stabilize AI table fills and PDF preview

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Keep ownership explicit while the maintainer team is small. Branch protection still allows the
+# repository owner to merge after required checks; this file makes review routing automatic as the
+# contributor base grows.
+* @kwakseongjae

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,9 +2,12 @@
 
 <!-- Describe the user-visible outcome and the narrowest reason for this change. -->
 
+Closes #<!-- required: every PR starts from a public issue -->
+
 ## Contract and risk
 
 - [ ] I read `AGENTS.md` and the relevant issue's invariants and traps.
+- [ ] The linked issue states the reproduction/problem and acceptance criteria before implementation.
 - [ ] I did not add, remove, or expose user document content in fixtures, logs, screenshots, or CI artifacts.
 - [ ] Intent schema changes are additive and unknown fields still fail explicitly.
 - [ ] Geometry remains px (= HWPUNIT/75); edit commits remain HWPUNIT.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,22 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  issue-link:
+    name: issue-link
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Require a closing issue reference
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const body = context.payload.pull_request?.body ?? "";
+            const closesIssue = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#[0-9]+\b/i.test(body);
+            if (!closesIssue) {
+              core.setFailed("PR 본문에 `Closes #<issue>`를 적어 주세요. 모든 변경은 공개 이슈에서 시작합니다.");
+            }
+
   build-test:
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,13 @@ HWP(한글) 자체 엔진: Rust 코어(파싱→IR→조판→렌더→export→
 - 컨텍스트가 요약(compact)된 채 재개되면: 첫 행동으로 context_restore.sh를 실행해 복원한다.
   요약문과 파일이 충돌하면 **파일이 정본**이다.
 
+## 정식 오픈소스 작업 프로토콜
+- 모든 코드·문서 변경은 먼저 공개 GitHub 이슈를 만들거나 기존 이슈를 연결한다.
+- `main` 직접 작업·직접 push 금지: 이슈 브랜치 → PR 본문 `Closes #<issue>` → 필수 CI → merge 순서다.
+- 필수 checks는 `issue-link`·`build-test`·`licenses`; 대화 해결 전 merge 금지. 배포는 보호된
+  `main`의 정확한 commit SHA로만 실행한다.
+- merge 뒤 작업 브랜치를 삭제한다. 사용자 콘텐츠·민감 문서는 이슈/PR/CI 아티팩트에 올리지 않는다.
+
 ## 로드맵/상태 지도 (정본 위치)
 | 무엇 | 어디 |
 |---|---|
@@ -37,7 +44,8 @@ scripts/verify-local.sh          # quick: fmt·clippy·전체 테스트·게이�
 scripts/verify-local.sh --full   # + wasm 재빌드·JS 빌드/vitest·e2e — crates/UI 접촉 시 필수
 ```
 푸시 전 quick은 최소, crates·packages 접촉 시 --full. fmt는 이제 강제(2026-07-11 전체 포맷 완료 —
-fmt-dirty 커밋은 다음 verify에서 걸린다). GitHub Actions는 `gh workflow run ci`로만 수동 실행.
+fmt-dirty 커밋은 다음 verify에서 걸린다). GitHub Actions는 PR마다 자동 실행되며 `gh workflow run ci`로
+수동 재검증도 가능하다.
 
 ## 함정 top 6 (전체는 각 이슈 파일의 "함정" 절)
 - e2e 전 `rm -rf apps/hwp-lab/.next` — 웹팩 캐시가 dist 재빌드를 감지 못해 가짜 통과/실패.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,19 @@
 기여 환영합니다. 이 프로젝트는 **정확도 게이트가 CI보다 우선**하는 코드베이스입니다 —
 아래 불변식을 깨는 PR은 아무리 좋아 보여도 머지되지 않습니다.
 
+## 이슈에서 시작하는 개발 흐름
+
+정식 런칭 이후 모든 코드·문서 변경은 공개 GitHub 이슈에서 시작합니다.
+
+1. 기존 이슈를 검색하고, 없으면 bug/feature/layout 템플릿으로 재현·기대 결과·수용 기준을 적습니다.
+2. `main`에서 짧은 작업 브랜치를 만들고 이슈 범위만 수정합니다. 사용자 문서나 개인정보는 커밋하지 않습니다.
+3. 관련 테스트와 아래 로컬 검증을 통과시킨 뒤 PR을 열고 본문에 `Closes #<issue>`를 적습니다.
+4. 자동 CI의 `issue-link`, `build-test`, `licenses`와 리뷰 대화 해결이 모두 green이어야 merge할 수 있습니다.
+5. merge 뒤 작업 브랜치는 삭제합니다. 프로덕션 배포는 보호된 `main`의 정확한 commit SHA로만 실행합니다.
+
+PR의 이슈 연결은 권고가 아니라 필수 CI 게이트입니다. 작은 문구 수정도 이슈에 목적과 완료 조건을 남겨,
+외부 기여자가 결정 과정과 현재 상태를 GitHub만 보고 이어갈 수 있게 합니다.
+
 ## 개발 환경
 
 ```bash
@@ -22,7 +35,8 @@ scripts/verify-local.sh          # quick: fmt·clippy·전체 테스트·게이�
 scripts/verify-local.sh --full   # + wasm 재빌드·JS 빌드/vitest·e2e — crates/packages 접촉 시 필수
 ```
 
-CI(GitHub Actions)는 수동 트리거 전용입니다 — **로컬 verify가 정본**입니다.
+CI(GitHub Actions)는 모든 `main` 대상 PR에 자동 실행됩니다. **로컬 verify가 정본**이며 CI는 독립적인
+Linux 검증과 이슈 연결·라이선스 게이트를 담당합니다.
 
 ## 조판 이슈 기여
 

--- a/apps/hwp-lab/e2e/smoke.spec.ts
+++ b/apps/hwp-lab/e2e/smoke.spec.ts
@@ -57,7 +57,10 @@ test("업로드 → 8페이지 SVG → 셀 클릭 마킹 → mock 편집이 그 
 // issue 022 + inspector 모드: 열기 직후 기본 폰트(NanumGothic)가 자동 등록되어 화면 @font-face 가
 // 주입되고 PDF 버튼이 즉시 활성화된다. 전역 FontPicker는 선택 디자인과 혼동되지 않도록 노출하지 않는다.
 test("기본 폰트 자동 적용 → 전역 FontPicker 없음 + @font-face 주입 + PDF 다운로드", async ({ page }) => {
-  await page.goto("/");
+  const response = await page.goto("/");
+  // GitHub #12: the PDF bytes are previewed through an in-memory blob iframe. Assert the real app
+  // response permits that narrow lane; merely checking `src=blob:` would still pass on a blocked frame.
+  expect(response?.headers()["content-security-policy"]).toContain("frame-src 'self' blob:");
   await page.locator('[data-testid="file-input"]').setInputFiles(BENCHMARK);
   await expect(page.locator(".hw-sheet svg").first()).toBeVisible({ timeout: 60_000 });
 

--- a/apps/hwp-lab/next.config.mjs
+++ b/apps/hwp-lab/next.config.mjs
@@ -38,6 +38,9 @@ const CONTENT_SECURITY_POLICY = [
   "font-src 'self' data:",
   "connect-src 'self' https://cdn.jsdelivr.net https://*.workers.dev" + (isDevelopment ? " ws: wss:" : ""),
   "worker-src 'self' blob:",
+  // PDF preview uses an in-memory `blob:` URL in our own iframe. Keep external frames blocked while
+  // allowing only this same-origin/generated-document lane (GitHub #12).
+  "frame-src 'self' blob:",
   "object-src 'none'",
   "base-uri 'self'",
   "form-action 'self'",

--- a/crates/hwp-ops/src/lib.rs
+++ b/crates/hwp-ops/src/lib.rs
@@ -709,7 +709,7 @@ fn resolve_cell<'a>(doc: &'a SemanticDoc, section: usize, path: &[CellStep]) -> 
     let mut cell = t
         .cells
         .iter()
-        .find(|c| c.active && c.row == first.row && c.col == first.col)?;
+        .find(|c| cell_covers(c, first.row, first.col))?;
     for step in rest {
         let Block::Table(nt) = cell.blocks.get(step.block)? else {
             return None;
@@ -717,9 +717,21 @@ fn resolve_cell<'a>(doc: &'a SemanticDoc, section: usize, path: &[CellStep]) -> 
         cell = nt
             .cells
             .iter()
-            .find(|c| c.active && c.row == step.row && c.col == step.col)?;
+            .find(|c| cell_covers(c, step.row, step.col))?;
     }
     Some(cell)
+}
+
+/// Resolve any logical grid coordinate inside an ACTIVE cell, including a slot covered by a
+/// row/column span. AI proposals describe the visible table grid and can legitimately point at a
+/// covered coordinate; the edit target is the unique active origin cell that owns that coordinate.
+/// Out-of-range coordinates still match nothing and remain a hard error.
+fn cell_covers(cell: &Cell, row: usize, col: usize) -> bool {
+    cell.active
+        && cell.row <= row
+        && row < cell.row.saturating_add(cell.row_span.max(1))
+        && cell.col <= col
+        && col < cell.col.saturating_add(cell.col_span.max(1))
 }
 
 /// Mutable twin of [`resolve_cell`] — walks the same descending `CellPath` to the LEAF cell for editing.
@@ -737,7 +749,7 @@ fn resolve_cell_mut<'a>(
     let mut cell = t
         .cells
         .iter_mut()
-        .find(|c| c.active && c.row == first.row && c.col == first.col)?;
+        .find(|c| cell_covers(c, first.row, first.col))?;
     for step in rest {
         let Block::Table(nt) = cell.blocks.get_mut(step.block)? else {
             return None;
@@ -745,7 +757,7 @@ fn resolve_cell_mut<'a>(
         cell = nt
             .cells
             .iter_mut()
-            .find(|c| c.active && c.row == step.row && c.col == step.col)?;
+            .find(|c| cell_covers(c, step.row, step.col))?;
     }
     Some(cell)
 }
@@ -4441,6 +4453,75 @@ mod tests {
                 col: 0,
                 runs: vec![run_spec("x")],
             }
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn set_table_cell_normalizes_a_covered_coordinate_to_its_merged_origin() {
+        // GitHub #11: an AI fill can name a visible coordinate that lies inside a merged cell. The
+        // model has not invented a different cell — that coordinate is owned by the active origin.
+        // Applying it must update that origin instead of failing with `no active cell`.
+        let mut doc = doc_with(vec![simple_para(1, "앞")]);
+        let cell = |text: &str, col_span: usize, row_span: usize| CellSpec {
+            text: text.into(),
+            col_span,
+            row_span,
+            ..Default::default()
+        };
+        apply(
+            &mut doc,
+            &Op::InsertTableAt {
+                section: 0,
+                index: 1,
+                rows: vec![
+                    vec![cell("가로 병합", 2, 1), cell("오른쪽", 1, 1)],
+                    vec![
+                        cell("세로 병합", 1, 2),
+                        cell("아래", 1, 1),
+                        cell("끝", 1, 1),
+                    ],
+                    vec![cell("아래2", 1, 1), cell("끝2", 1, 1)],
+                ],
+            },
+        )
+        .unwrap();
+
+        // (0,1) is covered by the origin at (0,0); (2,0) is covered by (1,0).
+        apply(
+            &mut doc,
+            &Op::SetTableCell {
+                section: 0,
+                index: 1,
+                row: 0,
+                col: 1,
+                runs: vec![run_spec("가로 수정")],
+            },
+        )
+        .unwrap();
+        apply(
+            &mut doc,
+            &Op::SetTableCell {
+                section: 0,
+                index: 1,
+                row: 2,
+                col: 0,
+                runs: vec![run_spec("세로 수정")],
+            },
+        )
+        .unwrap();
+
+        assert_eq!(cell_text(&doc, 1, 0, 0), "가로 수정");
+        assert_eq!(cell_text(&doc, 1, 1, 0), "세로 수정");
+        assert!(apply(
+            &mut doc,
+            &Op::SetTableCell {
+                section: 0,
+                index: 1,
+                row: 99,
+                col: 99,
+                runs: vec![run_spec("범위 밖")],
+            },
         )
         .is_err());
     }

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,6 +3,19 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
+- 갱신: 2026-08-13 · Codex(sol) — **정식 런칭 후 버그 #11·#12 수정 및 issue-first 파이프라인 검증 중**.
+  공개 GitHub 이슈 #11(병합 셀 covered 좌표 `no active cell`), #12(PDF blob iframe CSP 차단),
+  #13(issue-first 파이프라인)을 생성했다. hwp-ops는 병합 영역 내부 좌표를 유일한 active origin으로
+  정규화하고 범위 밖은 계속 거절하며 회귀 테스트 97/97 green. 사이트 CSP는 외부 프레임을 닫은 채
+  `frame-src 'self' blob:`만 추가했고 실제 Next 응답 헤더+PDF 다운로드 e2e 2/2 green. PR에
+  `Closes #`를 강제하는 `issue-link` check, CODEOWNERS, CONTRIBUTING/AGENTS 절차를 추가했다. 기존
+  main 외 브랜치는 패치 동등성/merge 여부 확인 후 로컬·원격 모두 정리했고 현재 작업 브랜치만 존재.
+  검증: fmt, hwp-ops clippy/97 tests, wasm rebuild+wasm-opt, JS 64+261+416+198, Next production build,
+  launch 29/29, smoke 2/2. macOS shared target의 workspace clippy는 종전처럼 CPU 0% 정체되어 중단했고
+  격리 target hwp-ops clippy는 green; PR Linux CI로 전체를 독립 검증한다. 다음: 명시 파일만 commit/push
+  → PR(Closes #11/#12/#13) → 필수 checks green → main merge → main SHA Vercel production → 라이브
+  PDF/AI smoke → 이슈 close·브랜치 삭제. 선재 `control-audit.rs` 무접촉.
+
 - 정본 배포: **https://autohwp.com** (Vercel full Next — 2026-08-06 컷오버, Actions vercel-deploy.yml).
   GitHub Pages(kwakseongjae.github.io/auto-hwp)는 병행 유지 중 — 리다이렉트 스텁 전환 예정.
   GitHub: https://github.com/kwakseongjae/auto-hwp (public, 홈페이지·description=autohwp.com)

--- a/scripts/lib/launch-readiness.mjs
+++ b/scripts/lib/launch-readiness.mjs
@@ -352,6 +352,16 @@ export function auditLaunch(source) {
     "외부 pull request가 자동으로 제한된 CI 검증을 받는다",
     "workflow_dispatch를 유지하면서 pull_request에 fmt·clippy·test·문서 게이트의 bounded lane을 추가한다.",
   );
+  const codeowners = read(".github/CODEOWNERS");
+  const pullTemplateBody = pullTemplate ? read(pullTemplate) : "";
+  add(
+    "community.issue-first",
+    "community",
+    "P0",
+    /\bissue-link\s*:/.test(ci) && /Closes\s+#/i.test(pullTemplateBody) && /@kwakseongjae/.test(codeowners),
+    "모든 PR이 공개 이슈에서 시작하고 소유자에게 자동 라우팅된다",
+    "CI issue-link check, PR 템플릿의 Closes #<issue>, CODEOWNERS를 유지한다.",
+  );
 
   const workflowPaths = [
     ".github/workflows/ci.yml",
@@ -396,6 +406,7 @@ export function auditLaunch(source) {
     "Referrer-Policy",
     "Permissions-Policy",
     "frame-ancestors",
+    "frame-src 'self' blob:",
   ];
   const missingHeaders = requiredHeaders.filter((header) => !securityConfig.includes(header));
   add(

--- a/scripts/tests/launch-readiness.test.mjs
+++ b/scripts/tests/launch-readiness.test.mjs
@@ -91,17 +91,18 @@ function passingFiles() {
     "SECURITY.md": "Supported Versions. Report privately with a GitHub security advisory.",
     "CODE_OF_CONDUCT.md": "Contributor Covenant",
     "SUPPORT.md": "Support boundaries",
-    ".github/PULL_REQUEST_TEMPLATE.md": "Checklist",
+    ".github/PULL_REQUEST_TEMPLATE.md": "Checklist\nCloses #123",
+    ".github/CODEOWNERS": "* @kwakseongjae",
     ".github/ISSUE_TEMPLATE/bug_report.yml": "name: Bug",
     ".github/ISSUE_TEMPLATE/feature_request.yml": "name: Feature",
-    ".github/workflows/ci.yml": "on:\n  pull_request:\n  workflow_dispatch:\nuses: actions/checkout@v6",
+    ".github/workflows/ci.yml": "on:\n  pull_request:\n  workflow_dispatch:\njobs:\n  issue-link:\nuses: actions/checkout@v6",
     ".github/workflows/vercel-deploy.yml":
       "on:\n  workflow_dispatch:\nuses: actions/checkout@v6\nrun: vercel deploy --prebuilt",
     ".github/workflows/publish.yml": "uses: actions/checkout@v6",
     ".github/workflows/deploy-demo.yml": "uses: actions/checkout@v6",
     "apps/hwp-lab/vercel.json": JSON.stringify({ git: { deploymentEnabled: false } }),
     "apps/hwp-lab/next.config.mjs": `Content-Security-Policy X-Content-Type-Options Referrer-Policy
-      Permissions-Policy frame-ancestors`,
+      Permissions-Policy frame-ancestors frame-src 'self' blob:`,
     "apps/hwp-lab/src/app/privacy/page.tsx": "Privacy. 전체 400회, Upstash 없이는 best-effort.",
     "apps/hwp-lab/src/app/api/hwp-edit/demo.ts":
       'const DEFAULT_DAILY_CAP = 400; `ah:demo:all:${day}`; canReachUpstash(); [["PING"]]; store_configured',
@@ -157,6 +158,7 @@ test("깨진 사이트 llms·복붙 예제·단위·CI·메타데이터를 각�
     "docs.geometry-unit",
     "release.repository-metadata",
     "community.pull-request-ci",
+    "community.issue-first",
     "community.actions-node24",
     "release.prebuilt-deploy-only",
   ]) assert.equal(failed.has(id), true, id);

--- a/scripts/verify-local.sh
+++ b/scripts/verify-local.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# auto-hwp 로컬 검증 정본 — CI(GitHub Actions)는 workflow_dispatch 수동 전용으로 전환됨(2026-07-11).
+# auto-hwp 로컬 검증 정본 — CI(GitHub Actions)는 main 대상 PR + workflow_dispatch에서 실행된다.
 # 머지/푸시 전 이 스크립트가 그린이어야 한다. CI가 검사하던 것(fmt/clippy/test/wasm/deny)을 전부 포함하고,
 # CI가 못 하던 것(게이트 v2, rhwp 피처 테스트, wasm 재빌드, JS/e2e)까지 --full에서 커버한다.
 #


### PR DESCRIPTION
## What changed

- normalize coordinates covered by merged cells to their unique active origin before applying `SetTableCell`
- allow only same-origin/blob iframe sources so generated PDFs render in the production preview
- require every PR to close a public issue, add CODEOWNERS, and document the issue-first release flow
- remove all previously merged local/remote branches outside `main`

## Root cause

The table edit resolver only accepted an active cell origin, while an AI proposal could name another visible coordinate inside the same merged region. The production CSP had no `frame-src`, so `default-src self` rejected the `blob:` URL used by the PDF iframe.

## Verification

- `cargo fmt --all --check`
- isolated `cargo clippy -p hwp-ops --all-targets -- -D warnings`
- `cargo test -p hwp-ops`: 97 passed
- wasm-size rebuild + wasm-bindgen + wasm-opt + web copy
- Vitest: ai-protocol 64, editor-core 261, React 416, hwp-lab 198
- Next production build
- Playwright smoke: 2 passed, including real CSP header + PDF download
- launch readiness: 30/30
- actionlint

The macOS shared workspace target repeated the known zero-CPU clippy stall; the changed crate passed in a clean target and this PR runs the full Linux workspace CI independently.

Closes #11
Closes #12
Closes #13
