### PR TITLE
chore: run release workflows on Node 24 actions

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -47,7 +47,7 @@ jobs:
           curl -sL https://github.com/WebAssembly/binaryen/releases/download/version_119/binaryen-version_119-x86_64-linux.tar.gz | tar xz -C /tmp
           echo "/tmp/binaryen-version_119/bin" >> "$GITHUB_PATH"
           /tmp/binaryen-version_119/bin/wasm-opt --version
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 20.19
       # hwp-lab 의 build:deps 는 pnpm -C 로 각 패키지를 빌드한다(레포 관례).

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,7 @@ jobs:
 
       # 빌드 툴체인을 설치하기 전에 토큰을 fail-fast 검증한다. `npm publish --dry-run`은
       # 토큰이 없어도 경고만 내고 성공할 수 있으므로 whoami가 발행 인증의 정본이다.
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 20.19
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -88,7 +88,7 @@ jobs:
 
       # Node 24 — Vercel 프로젝트 설정(nodeVersion 24.x)과 맞춘다. prebuilt 는 러너에서 빌드한
       # 산출물이 그대로 함수가 되므로, 여기 Node 가 런타임 Node 와 어긋나면 안 된다.
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 24.x
       - name: install pnpm (packages/* 빌드 관례)

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,6 +3,17 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
+- 갱신: 2026-08-13 · Codex(sol) — **정식 런칭 후 버그 2건 수정·프로덕션 배포·issue-first 전환 완료**.
+  이슈 #11/#12/#13 → PR #14로 진행해 필수 checks(issue-link 3s, build-test 5m28s, licenses 2m45s)
+  green 후 보호된 main `2eb29d7`에 병합했고 세 이슈는 자동 close됐다. 같은 전체 SHA
+  `2eb29d7f54f946e7a74206120e9d9e9fc5b96afa`를 Vercel production run 31667859879로 배포해
+  6m16s success, autohwp.com 별칭 smoke와 실제 CSP `frame-src 'self' blob:`을 확인했다. 인앱 브라우저
+  공개 샘플 8쪽에서 PDF blob 미리보기(기존 차단 아이콘·콘솔 오류 없음), AI 제안→`✓ 적용됨`→undo
+  오류 0건을 실검증했다. main 외 종전 브랜치는 로컬·원격 모두 삭제됐다. main 보호는 strict
+  `issue-link`+`build-test`+`licenses`, PR/admin/대화해결 적용, force-push/delete 금지다. 배포 성공 로그의
+  유일한 Node20 deprecation 경고는 이슈 #15를 열어 공식 setup-node v7(Node24) 후속 PR에서 마감 중.
+  선재 `control-audit.rs` 무접촉.
+
 - 갱신: 2026-08-13 · Codex(sol) — **정식 런칭 후 버그 #11·#12 수정 및 issue-first 파이프라인 검증 중**.
   공개 GitHub 이슈 #11(병합 셀 covered 좌표 `no active cell`), #12(PDF blob iframe CSP 차단),
   #13(issue-first 파이프라인)을 생성했다. hwp-ops는 병합 영역 내부 좌표를 유일한 active origin으로

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,12 @@
 
 ---
 
+## 2026-08-13 (Codex sol) · 런칭 후 버그 수정·정식 OSS 파이프라인·프로덕션 배포
+- #11 병합 셀 좌표를 active origin으로 정규화, #12 PDF blob CSP를 최소 허용; PR #14 CI green→main `2eb29d7`.
+- `issue-link` 필수 check·CODEOWNERS·이슈 우선 문서를 추가하고 기존 main 외 브랜치를 모두 정리.
+- 동일 SHA production run 31667859879 success; autohwp.com CSP/PDF/AI 적용·undo 라이브 smoke green.
+- 배포의 setup-node v4 Node20 경고만 #15(v7/Node24) 후속으로 처리 중; `control-audit.rs` 무접촉.
+
 ## 2026-08-12 (Codex sol) · 인앱 브라우저 라이브 퍼널 촬영
 - autohwp.com 랜딩→예시 HWP→8 SVG→레이아웃 제보 실검증, 초안 파일명·본문·해시 없음 확인.
 - 라이브 PNG 2컷 + 실제 프레임 88장 기반 22초 1280×720 MP4 생성, Threads 미디어 갱신.

--- a/scripts/lib/launch-readiness.mjs
+++ b/scripts/lib/launch-readiness.mjs
@@ -372,14 +372,22 @@ export function auditLaunch(source) {
   const staleCheckoutWorkflows = workflowPaths.filter(
     (relative) => !/actions\/checkout@v6/.test(read(relative)),
   );
+  const nodeWorkflowPaths = [
+    ".github/workflows/vercel-deploy.yml",
+    ".github/workflows/publish.yml",
+    ".github/workflows/deploy-demo.yml",
+  ];
+  const staleSetupNodeWorkflows = nodeWorkflowPaths.filter(
+    (relative) => !/actions\/setup-node@v7/.test(read(relative)),
+  );
   add(
     "community.actions-node24",
     "community",
     "P1",
-    staleCheckoutWorkflows.length === 0,
-    "CI·배포·발행 workflow가 Node 24 기반 checkout action을 사용한다",
-    "GitHub hosted runner와 맞는 actions/checkout@v6로 올려 Node 20 강제 전환 경고를 제거한다.",
-    staleCheckoutWorkflows.join(", "),
+    staleCheckoutWorkflows.length === 0 && staleSetupNodeWorkflows.length === 0,
+    "CI·배포·발행 workflow가 Node 24 기반 GitHub action을 사용한다",
+    "actions/checkout@v6와 actions/setup-node@v7을 유지해 Node 20 강제 전환 경고를 제거한다.",
+    [...staleCheckoutWorkflows, ...staleSetupNodeWorkflows].join(", "),
   );
 
   const vercelConfig = safeJson(source, "apps/hwp-lab/vercel.json");

--- a/scripts/tests/launch-readiness.test.mjs
+++ b/scripts/tests/launch-readiness.test.mjs
@@ -97,9 +97,9 @@ function passingFiles() {
     ".github/ISSUE_TEMPLATE/feature_request.yml": "name: Feature",
     ".github/workflows/ci.yml": "on:\n  pull_request:\n  workflow_dispatch:\njobs:\n  issue-link:\nuses: actions/checkout@v6",
     ".github/workflows/vercel-deploy.yml":
-      "on:\n  workflow_dispatch:\nuses: actions/checkout@v6\nrun: vercel deploy --prebuilt",
-    ".github/workflows/publish.yml": "uses: actions/checkout@v6",
-    ".github/workflows/deploy-demo.yml": "uses: actions/checkout@v6",
+      "on:\n  workflow_dispatch:\nuses: actions/checkout@v6\nuses: actions/setup-node@v7\nrun: vercel deploy --prebuilt",
+    ".github/workflows/publish.yml": "uses: actions/checkout@v6\nuses: actions/setup-node@v7",
+    ".github/workflows/deploy-demo.yml": "uses: actions/checkout@v6\nuses: actions/setup-node@v7",
     "apps/hwp-lab/vercel.json": JSON.stringify({ git: { deploymentEnabled: false } }),
     "apps/hwp-lab/next.config.mjs": `Content-Security-Policy X-Content-Type-Options Referrer-Policy
       Permissions-Policy frame-ancestors frame-src 'self' blob:`,


### PR DESCRIPTION
## What changed

- upgrade setup-node from v4 to official v7 (`using: node24`) in demo deploy, production deploy, and npm publish workflows
- lock setup-node v7 in launch readiness so Node 20 deprecation cannot return silently
- record the completed #11/#12 production deployment and live browser evidence in the continuity docs

## Verification

- official `actions/setup-node@v7.0.0` release and `action.yml` verified through GitHub (`using: node24`)
- actionlint on every workflow
- launch readiness 30/30
- node launch tests 7/7
- diff check

Closes #15
