### PR TITLE
docs: record warning-free Node 24 production deploy

### DIFF
--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -11,8 +11,10 @@
   공개 샘플 8쪽에서 PDF blob 미리보기(기존 차단 아이콘·콘솔 오류 없음), AI 제안→`✓ 적용됨`→undo
   오류 0건을 실검증했다. main 외 종전 브랜치는 로컬·원격 모두 삭제됐다. main 보호는 strict
   `issue-link`+`build-test`+`licenses`, PR/admin/대화해결 적용, force-push/delete 금지다. 배포 성공 로그의
-  유일한 Node20 deprecation 경고는 이슈 #15를 열어 공식 setup-node v7(Node24) 후속 PR에서 마감 중.
-  선재 `control-audit.rs` 무접촉.
+  유일했던 Node20 deprecation 경고는 이슈 #15→PR #16의 공식 setup-node v7(Node24) 전환으로 닫았다.
+  필수 checks(issue-link 5s, build-test 6m10s, licenses 2m46s) green 후 main `86a4cff`에 병합했고, 같은
+  전체 SHA `86a4cff81cc35b403d3e0d6997f03bd00839121e`의 production run 31668877992가 6m8s success,
+  `setup-node@v7`·autohwp.com 별칭 smoke green·Node20 annotation 0을 확인했다. 선재 `control-audit.rs` 무접촉.
 
 - 갱신: 2026-08-13 · Codex(sol) — **정식 런칭 후 버그 #11·#12 수정 및 issue-first 파이프라인 검증 중**.
   공개 GitHub 이슈 #11(병합 셀 covered 좌표 `no active cell`), #12(PDF blob iframe CSP 차단),

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -10,6 +10,7 @@
 - `issue-link` 필수 check·CODEOWNERS·이슈 우선 문서를 추가하고 기존 main 외 브랜치를 모두 정리.
 - 동일 SHA production run 31667859879 success; autohwp.com CSP/PDF/AI 적용·undo 라이브 smoke green.
 - 배포의 setup-node v4 Node20 경고만 #15(v7/Node24) 후속으로 처리 중; `control-audit.rs` 무접촉.
+- #15→PR #16 CI green·main `86a4cff`; Node24 production run 31668877992 6m8s success, 경고 0·별칭 smoke green.
 
 ## 2026-08-12 (Codex sol) · 인앱 브라우저 라이브 퍼널 촬영
 - autohwp.com 랜딩→예시 HWP→8 SVG→레이아웃 제보 실검증, 초안 파일명·본문·해시 없음 확인.


### PR DESCRIPTION
## What changed

Record the completed #15/#16 checks and the warning-free Node 24 production deployment on exact main SHA `86a4cff81cc35b403d3e0d6997f03bd00839121e`.

## Evidence

- PR #16: issue-link 5s, build-test 6m10s, licenses 2m46s
- production run 31668877992: 6m8s success
- setup-node v7 completed; autohwp.com alias smoke passed; Node 20 annotation absent

Closes #17
