### PR TITLE
fix: preserve outer tables when deleting nested tables

### DIFF
--- a/apps/hwp-lab/e2e/nested-cell-caret-gap.spec.ts
+++ b/apps/hwp-lab/e2e/nested-cell-caret-gap.spec.ts
@@ -24,11 +24,17 @@ import { expect, test, type Page } from "@playwright/test";
 //   adapter : WasmAdapter/TauriAdapter + worker RPC 화이트리스트에 path 변형 노출, wasm 재빌드.
 const SAMPLE = path.resolve(process.cwd(), "public", "samples", "sample-8p.hwp");
 const NEEDLE = "생산품";
+const MOD = process.platform === "darwin" ? "Meta" : "Control";
 
 async function open(page: Page) {
   await page.goto("/");
   await page.locator('[data-testid="file-input"]').setInputFiles(SAMPLE);
   await expect(page.locator(".hw-sheet svg").first()).toBeVisible({ timeout: 60_000 });
+}
+
+async function showPage(page: Page, index: number) {
+  await page.locator(`.hw-sheet[data-page="${index}"]`).scrollIntoViewIfNeeded();
+  await expect(page.locator(`.hw-sheet[data-page="${index}"] svg`)).toBeVisible({ timeout: 30_000 });
 }
 
 /** 글리프 단위 <text> 를 y 밴드로 묶어 needle 이 있는 줄의 글리프 박스를 찾는다(옵션: 화면 안으로 스크롤). */
@@ -96,5 +102,34 @@ test.fixme("중첩 셀(1×1 표 안) 문단도 캐럿으로 지우고 ⌘Z 로 �
   await expect.poll(async () => (await findGlyph(page, NEEDLE)) === null, { timeout: 30_000 }).toBe(true);
 
   await page.keyboard.press("Meta+z");
+  await expect.poll(async () => (await findGlyph(page, NEEDLE)) !== null, { timeout: 30_000 }).toBe(true);
+});
+
+test("중첩 표 선택 Backspace는 바깥 표를 보존하고, 즉시 undo도 클릭 없이 복구한다", async ({ page }) => {
+  await open(page);
+  await findGlyph(page, NEEDLE, true);
+  await page.waitForTimeout(800);
+  let hit = await findGlyph(page, NEEDLE);
+  if (!hit) throw new Error("중첩 표 문구를 화면에 올리지 못함");
+  expect(await findGlyph(page, "창업아이템명")).not.toBeNull();
+
+  // 1) 실제 삭제 대상을 확인한다: 중첩 표의 문구만 사라지고 같은 바깥 양식 표의 형제 행은 남는다.
+  await page.mouse.click(hit.x + hit.width / 2, hit.y + hit.height / 2);
+  await expect(page.locator(".hw-mark-table")).toHaveCount(1);
+  await page.keyboard.press("Backspace");
+  await expect.poll(async () => (await findGlyph(page, NEEDLE)) === null, { timeout: 30_000 }).toBe(true);
+  expect(await findGlyph(page, "창업아이템명")).not.toBeNull();
+
+  await page.keyboard.press(`${MOD}+z`);
+  await showPage(page, 1); // undo reflow may virtualize the restored page off-DOM; no click/focus change
+  await expect.poll(async () => (await findGlyph(page, NEEDLE)) !== null, { timeout: 30_000 }).toBe(true);
+
+  // 2) 경쟁 상태 회귀: 재선택 후 삭제와 undo를 기다림/중간 클릭 없이 연달아 보낸다.
+  hit = await findGlyph(page, NEEDLE);
+  if (!hit) throw new Error("undo 뒤 중첩 표 문구가 복구되지 않음");
+  await page.mouse.click(hit.x + hit.width / 2, hit.y + hit.height / 2);
+  await page.keyboard.press("Backspace");
+  await page.keyboard.press(`${MOD}+z`);
+  await showPage(page, 1);
   await expect.poll(async () => (await findGlyph(page, NEEDLE)) !== null, { timeout: 30_000 }).toBe(true);
 });

--- a/crates/hwp-mcp/src/lib.rs
+++ b/crates/hwp-mcp/src/lib.rs
@@ -1389,6 +1389,14 @@ pub enum Intent {
         section: usize,
         index: usize,
     },
+    /// Delete a selected table/block INSIDE a parent cell addressed by descending CellPath. Manual UI
+    /// only (not in the AI whitelist): unlike `DeleteBlock`, this can never remove the outer section
+    /// table that merely contains the selected nested table (issue #19).
+    DeleteNestedBlock {
+        section: usize,
+        path: Vec<hwp_ops::CellStep>,
+        index: usize,
+    },
     /// Image insert (issue 050 — drop / upload) — embed a base64 PNG/JPEG image as a new BinData and
     /// anchor an image paragraph in `section` as ONE undo unit (`InsertImageAt`). A web drop/upload has
     /// BYTES, not a file path, so the payload is `data_b64` (base64, no `data:` prefix); the true format
@@ -2112,6 +2120,21 @@ pub fn apply_intent(session: &mut Session, intent: Intent) -> Result<Outcome, St
         }
         Intent::DeleteBlock { section, index } => {
             do_delete_block(session, section, index)?;
+            let pages = page_count_u32(session).unwrap_or(0);
+            Ok(Outcome::Edited { pages })
+        }
+        Intent::DeleteNestedBlock {
+            section,
+            path,
+            index,
+        } => {
+            let doc = session.doc.as_mut().ok_or("no document open")?;
+            doc.do_op(&hwp_ops::Op::DeleteNestedBlock {
+                section,
+                path,
+                index,
+            })
+            .map_err(|e| e.to_string())?;
             let pages = page_count_u32(session).unwrap_or(0);
             Ok(Outcome::Edited { pages })
         }

--- a/crates/hwp-mcp/tests/schema_v0.rs
+++ b/crates/hwp-mcp/tests/schema_v0.rs
@@ -269,6 +269,11 @@ fn examples() -> Vec<Example> {
             r#"{"intent":"DeleteBlock","section":0,"index":0}"#,
             Synthetic,
         ),
+        e(
+            "DeleteNestedBlock",
+            r#"{"intent":"DeleteNestedBlock","section":0,"path":[{"block":1,"row":0,"col":0}],"index":1}"#,
+            DeserializeOnly,
+        ),
         // ---- structural inserts (issue 051 — chat structural edit; Intent exposure of the EXISTING
         //      InsertTableAt / InsertParagraphAt ops). `index` may be an int (at that block; == len
         //      appends) or null/absent (section END — the InsertImage anchor precedent). ----
@@ -335,7 +340,7 @@ fn de_err(v: Value) -> String {
 fn every_intent_variant_has_a_documented_example() {
     assert_eq!(
         examples().len(),
-        45,
+        46,
         "one JSON example per Intent variant (see INTENT-SCHEMA.md)"
     );
 }

--- a/crates/hwp-ops/src/lib.rs
+++ b/crates/hwp-ops/src/lib.rs
@@ -175,6 +175,14 @@ pub enum Op {
         section: usize,
         index: usize,
     },
+    /// Delete one block inside a nested table's PARENT CELL, addressed by its descending CellPath.
+    /// This is the nested structural twin of `DeleteBlock`: the outer section/table remains intact and
+    /// one undo snapshot restores the removed child block (issue #19).
+    DeleteNestedBlock {
+        section: usize,
+        path: Vec<CellStep>,
+        index: usize,
+    },
     /// Move the block at index `from` to index `to` within `section` (removing it, then reinserting at
     /// the post-removal index). Generalizes M4's "move = DeleteBlock + InsertImageAt" to ANY block
     /// (tables, paragraphs) in ONE op so a single undo restores the original order. `to == len` (the
@@ -760,6 +768,32 @@ fn resolve_cell_mut<'a>(
             .find(|c| cell_covers(c, step.row, step.col))?;
     }
     Some(cell)
+}
+
+/// Remove one block from the parent cell reached by `path`. The path must be non-empty: top-level
+/// deletion stays on `DeleteBlock`, which keeps the two address spaces impossible to confuse.
+fn delete_nested_block(
+    doc: &mut SemanticDoc,
+    section: usize,
+    path: &[CellStep],
+    index: usize,
+) -> Result<()> {
+    if path.is_empty() {
+        return Err(Error::Other(
+            "DeleteNestedBlock: empty parent cell path".into(),
+        ));
+    }
+    let cell = resolve_cell_mut(doc, section, path)
+        .ok_or_else(|| Error::Other("DeleteNestedBlock: parent cell path not found".into()))?;
+    if index >= cell.blocks.len() {
+        return Err(Error::Other(format!(
+            "DeleteNestedBlock: block index {index} out of range (cell has {} blocks)",
+            cell.blocks.len()
+        )));
+    }
+    cell.blocks.remove(index);
+    cell.dirty.mark();
+    Ok(())
 }
 
 /// Rebuild the (possibly NESTED) LEAF cell reached by `path` from `runs`, NON-DESTRUCTIVELY (issue 064
@@ -1641,6 +1675,9 @@ pub fn apply(doc: &mut SemanticDoc, op: &Op) -> Result<()> {
             sec.blocks.remove(*index);
             sec.dirty.mark();
             Ok(())
+        }
+        Op::DeleteNestedBlock { section, path, index } => {
+            delete_nested_block(doc, *section, path, *index)
         }
         Op::MoveBlock { section, from, to } => {
             let sec = section_mut(doc, *section)?;
@@ -4765,6 +4802,90 @@ mod tests {
             matches!(c00.blocks[0], Block::Paragraph(_))
                 && matches!(c00.blocks[1], Block::Table(_)),
             "outer (0,0) keeps [Paragraph, Table]"
+        );
+    }
+
+    #[test]
+    fn delete_nested_block_removes_only_child_table_and_undo_restores_it() {
+        let mut doc = doc_with(vec![simple_para(1, "앞")]);
+        let cell = |t: &str| CellSpec {
+            text: t.into(),
+            ..Default::default()
+        };
+        apply(
+            &mut doc,
+            &Op::InsertTableAt {
+                section: 0,
+                index: 1,
+                rows: vec![vec![cell("바깥")]],
+            },
+        )
+        .unwrap();
+        let plain = intern_char_shape(&mut doc, CharShape::default());
+        let nested = Table {
+            rows: 1,
+            cols: 1,
+            col_widths: vec![1],
+            cells: vec![Cell {
+                row: 0,
+                col: 0,
+                row_span: 1,
+                col_span: 1,
+                active: true,
+                blocks: vec![Block::Paragraph(Paragraph {
+                    runs: vec![Run {
+                        char_shape: plain,
+                        content: vec![Inline::Text("예시".into())],
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                })],
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        {
+            let Block::Table(outer) = &mut doc.sections[0].blocks[1] else {
+                panic!("outer table")
+            };
+            outer.cells[0].blocks.push(Block::Table(nested)); // child index 1
+        }
+        let mut session = EditSession::new(doc);
+        session
+            .do_op(&Op::DeleteNestedBlock {
+                section: 0,
+                path: vec![CellStep {
+                    block: 1,
+                    row: 0,
+                    col: 0,
+                }],
+                index: 1,
+            })
+            .unwrap();
+
+        assert_eq!(
+            session.doc().sections[0].blocks.len(),
+            2,
+            "outer section blocks stay intact"
+        );
+        let Block::Table(outer) = &session.doc().sections[0].blocks[1] else {
+            panic!("outer table survives")
+        };
+        assert!(
+            outer.cells[0]
+                .blocks
+                .iter()
+                .all(|b| !matches!(b, Block::Table(_))),
+            "only nested table is removed"
+        );
+
+        assert!(session.undo());
+        let Block::Table(outer) = &session.doc().sections[0].blocks[1] else {
+            panic!("outer table restored")
+        };
+        assert!(
+            matches!(outer.cells[0].blocks[1], Block::Table(_)),
+            "one undo restores nested table in place"
         );
     }
 

--- a/crates/hwp-session/src/lib.rs
+++ b/crates/hwp-session/src/lib.rs
@@ -546,6 +546,13 @@ pub struct TableBoxDto {
     pub block: usize,
     pub rows: usize,
     pub cols: usize,
+    /// Descending path to the PARENT CELL when this is a nested table. Empty for a top-level table.
+    /// Together with `self_block` this is a complete, mutation-safe address for deleting only the
+    /// selected nested table instead of its outer top-level table block (issue #19).
+    pub path: Vec<CellAddrDto>,
+    /// This table's block index inside its parent cell. For a top-level table this equals `block` and
+    /// `path` is empty, so existing flat consumers keep using `(section, block)` unchanged.
+    pub self_block: usize,
     /// For a table SPLIT across pages, this fragment's FIRST global row index (0 for a single-page
     /// table). The cell-range selection adds this offset to its fragment-local row indices so a batch
     /// op targets the correct GLOBAL rows of the (possibly frame-wrapped) table.
@@ -584,6 +591,8 @@ pub fn table_bbox_placed(
             block: t.block,
             rows: t.rows,
             cols: t.cols,
+            path: t.ancestors.iter().map(CellAddrDto::from).collect(),
+            self_block: t.self_block,
             first_row: t.first_row,
         })
 }
@@ -626,6 +635,8 @@ pub fn table_at_placed(placed: &PlacedDoc, page: u32, x: f64, y: f64) -> Option<
             block: t.block,
             rows: t.rows,
             cols: t.cols,
+            path: t.ancestors.iter().map(CellAddrDto::from).collect(),
+            self_block: t.self_block,
             first_row: t.first_row,
         })
 }
@@ -3485,6 +3496,20 @@ mod tests {
         let k = HWPUNIT_PER_PX;
         let px = (leaf.x + leaf.w / 2.0) / k;
         let py = (leaf.y + leaf.h / 2.0) / k;
+        let table_hit =
+            table_at_placed(&placed, pi as u32, px, py).expect("nested table hit resolves");
+        assert_eq!(
+            table_hit.path,
+            nt.ancestors
+                .iter()
+                .map(CellAddrDto::from)
+                .collect::<Vec<_>>(),
+            "table selection carries its parent-cell path"
+        );
+        assert_eq!(
+            table_hit.self_block, 1,
+            "table selection carries its block index inside that cell"
+        );
         let hit = table_cell_at_placed(&doc, &placed, pi as u32, px, py)
             .expect("nested cell hit resolves");
         // The DEEPER path wins (rfind picks the innermost table).

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,6 +3,19 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
+- 갱신: 2026-08-13 · Codex(sol) — **이슈 #19 중첩 표 삭제·즉시 undo 수정 완료, push 승인 대기**.
+  공개 이슈 #19를 만들고 브랜치 `codex/issue-19-nested-table-delete-undo`에서 수정했다. `TableBox`가
+  중첩 표의 부모 CellPath+cell 내부 block index를 보존하고, 수동 전용 additive
+  `DeleteNestedBlock` Intent/Op가 해당 자식 블록만 제거한다. 최상위 `DeleteBlock`은 그대로다.
+  삭제 중 들어온 undo는 커밋 완료 뒤 직렬화하며, 선택 삭제로 Design→Vibe 탭이 돌아올 때 채팅
+  textarea가 자동 포커스를 훔치던 두 번째 원인도 `AI에게 전달` focusToken 증가 때만 포커스하도록
+  교정했다. 공개 `sample-8p.hwp` E2E에서 중첩 예시만 삭제·바깥 `창업아이템명` 보존·undo 복구·
+  재삭제 직후 무클릭 undo 복구 1/1 green. hwp-ops 98, MCP schema 14, editor-core 262, React 418,
+  hwp-lab 198, 격리 target clippy `-D warnings`, wasm 재빌드+wasm-opt(7,560KB), 게이트
+  8==8/18==18/24==24 green. `verify-local --full`은 코드 오류 전 macOS shared-target Tauri/rhwp
+  clippy가 CPU 0%로 재정체되어 중단했고 동일 범위를 격리 target으로 green 확인했다. 다음: 사용자
+  확인 후 commit/push → PR `Closes #19` → 필수 CI → merge/deploy. 선재 `crates/hwp-rhwp/examples/` 무접촉.
+
 - 갱신: 2026-08-13 · Codex(sol) — **정식 런칭 후 버그 2건 수정·프로덕션 배포·issue-first 전환 완료**.
   이슈 #11/#12/#13 → PR #14로 진행해 필수 checks(issue-link 3s, build-test 5m28s, licenses 2m45s)
   green 후 보호된 main `2eb29d7`에 병합했고 세 이슈는 자동 close됐다. 같은 전체 SHA

--- a/docs/INTENT-SCHEMA.md
+++ b/docs/INTENT-SCHEMA.md
@@ -500,6 +500,19 @@ visual affinity**를 쓴다. 반면 아래 `CaretRectBody`는 주소의 canonica
 | `section` | integer | 구역 인덱스 | ● |
 | `index` | integer | 블록 인덱스 | ● |
 
+#### `DeleteNestedBlock` — 셀 안의 중첩 블록 삭제(1 undo 단위, 수동 UI 전용)
+```json
+{ "intent": "DeleteNestedBlock", "section": 0, "path": [{"block": 1, "row": 3, "col": 1}], "index": 2 }
+```
+| 필드 | 타입 | 단위/값 | 필수 |
+|------|------|---------|------|
+| `section` | integer | 구역 인덱스 | ● |
+| `path` | CellStep[] | 삭제 대상의 **부모 셀**까지 내려가는 CellPath(비어 있으면 거부) | ● |
+| `index` | integer | 부모 셀 `blocks` 안의 중첩 블록 인덱스 | ● |
+
+`DeleteBlock`과 주소 공간을 분리한다. 중첩 표를 선택한 Backspace/Delete만 이 Intent를 사용하며,
+최상위 바깥 표는 보존된다. AI 화이트리스트에는 넣지 않는다.
+
 ### 6.7 문자 / 문단 서식
 
 > ⚠️ 단위: `size_pt`는 **포인트(pt)**. 색은 `"#RRGGBB"`. `align` ∈

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,12 @@
 
 ---
 
+## 2026-08-13 (Codex sol) · #19 중첩 표 삭제·즉시 undo
+- 중첩 표 선택에 부모 CellPath+자식 block 주소를 싣고 `DeleteNestedBlock`으로 바깥 양식 표를 보존.
+- 삭제 커밋/undo를 직렬화하고 Design→Vibe 전환의 채팅 textarea 포커스 탈취를 제거.
+- Rust/JS 단위·격리 clippy·wasm 재빌드·8/18/24 게이트와 sample-8p 실제 E2E green.
+- 브랜치 `codex/issue-19-nested-table-delete-undo`; commit/push/PR은 사용자 확인 대기, 선재 examples 무접촉.
+
 ## 2026-08-13 (Codex sol) · 런칭 후 버그 수정·정식 OSS 파이프라인·프로덕션 배포
 - #11 병합 셀 좌표를 active origin으로 정규화, #12 PDF blob CSP를 최소 허용; PR #14 CI green→main `2eb29d7`.
 - `issue-link` 필수 check·CODEOWNERS·이슈 우선 문서를 추가하고 기존 main 외 브랜치를 모두 정리.

--- a/packages/editor-core/src/__tests__/selection.test.ts
+++ b/packages/editor-core/src/__tests__/selection.test.ts
@@ -345,7 +345,19 @@ describe("SelectionModel — Figma table drill (issue 06x)", () => {
 // resolve the INNER table box + the nested LEAF cell (length-2 path); outside it resolves the OUTER
 // table + a length-1 cell. The drill stack matches by `sameTable`, so nested levels don't collide with
 // the outer table's `(section, block)`.
-const NESTED_INNER: TableBox = { section: 0, block: 1, x: 0, y: 0, w: 200, h: 200, rows: 2, cols: 2, first_row: 0 };
+const NESTED_INNER: TableBox = {
+  section: 0,
+  block: 1,
+  x: 0,
+  y: 0,
+  w: 200,
+  h: 200,
+  rows: 2,
+  cols: 2,
+  first_row: 0,
+  path: [{ block: 1, row: 0, col: 0 }],
+  self_block: 1,
+};
 const NESTED_OUTER: TableBox = { section: 0, block: 1, x: 0, y: 0, w: 400, h: 400, rows: 2, cols: 1, first_row: 0 };
 // The nested grid occupies the top-left quadrant (x<200 && y<200) — the OUTER cell (0,0). Elsewhere is a
 // plain outer cell (length-1 path).
@@ -379,6 +391,18 @@ const nestedCellAt = (_p: number, x: number, y: number): CellHit => {
 
 describe("SelectionModel — nested table drill (issue 064 Tier-2)", () => {
   const model = () => new SelectionModel(new MockAdapter({ pages: 1, table: nestedTableAt, cell: nestedCellAt }));
+
+  it("a plain click on a nested table keeps its parent-cell path + child block deletion address", async () => {
+    const m = model();
+    await click(m, 0, 50, 50);
+    expect(anchors(m)[0]).toMatchObject({
+      kind: "table",
+      section: 0,
+      block: 1,
+      path: [{ block: 1, row: 0, col: 0 }],
+      nestedBlock: 1,
+    });
+  });
 
   it("drillInto a nested cell descends → the anchor carries the length-2 CellPath", async () => {
     const m = model();

--- a/packages/editor-core/src/edit.ts
+++ b/packages/editor-core/src/edit.ts
@@ -3,7 +3,7 @@ import { coreMessagesKoKR, type CoreMessages } from "./messages";
 import { inheritRuns } from "./runs";
 import type { DocSession } from "./session";
 import type { SelectionModel } from "./selection";
-import type { DocContext, Intent, IntentCard, RunSpec } from "./types";
+import type { CellAddr, DocContext, Intent, IntentCard, RunSpec } from "./types";
 
 /** A rectangular cell range `[r0..=r1] × [c0..=c1]` (inclusive, MODEL-GLOBAL) — the target of a batch
  *  format / shade (INTENT-SCHEMA §6.8). A single cell is `r0==r1 && c0==c1`. */
@@ -175,6 +175,12 @@ export class EditController {
    *  ⌘Z away; the engine throws on an out-of-range index (거짓 성공 없음). */
   async deleteBlock(section: number, index: number): Promise<number> {
     return this.session.applyBatch([{ intent: "DeleteBlock", section, index }]);
+  }
+
+  /** Delete one block inside a nested table's parent cell. `path` addresses the parent cell and
+   *  `index` is the selected nested table's block index inside that cell. One undo batch. */
+  async deleteNestedBlock(section: number, path: CellAddr[], index: number): Promise<number> {
+    return this.session.applyBatch([{ intent: "DeleteNestedBlock", section, path, index }]);
   }
 
   /** 이미지 삽입 (issue 050): embed a dropped/uploaded image (base64 PNG/JPEG bytes, NO `data:` prefix) at

--- a/packages/editor-core/src/selection.ts
+++ b/packages/editor-core/src/selection.ts
@@ -50,10 +50,11 @@ const CELL_PROBE_PX = 3;
 export function selKey(a: Anchor): string {
   const r = a.rows ? `${a.rows[0]}-${a.rows[1]}` : "";
   const c = a.cols ? `${a.cols[0]}-${a.cols[1]}` : "";
-  // A NESTED cell (issue 064 Tier-2): fold the descending path so distinct nesting levels are DISTINCT
-  // selections. A length-1 (or absent) path adds nothing → identical key to before (back-compat).
-  const p = a.path && a.path.length > 1 ? ":" + a.path.map((s) => `${s.block}.${s.row}.${s.col}`).join(">") : "";
-  return `${a.section}:${a.block}:${r}:${c}${p}`;
+  // A nested cell/table folds its descending path so nesting levels are DISTINCT. A nested table's
+  // parent path can be length 1, so `nestedBlock` is the explicit signal that the path must be kept.
+  const p = a.path && (a.path.length > 1 || a.nestedBlock != null) ? ":" + a.path.map((s) => `${s.block}.${s.row}.${s.col}`).join(">") : "";
+  const nb = a.nestedBlock == null ? "" : `:b${a.nestedBlock}`;
+  return `${a.section}:${a.block}:${r}:${c}${p}${nb}`;
 }
 
 /** Cell chip label = a short text snippet + a 1-based "N행 M열" (issue 023). Empty cell → "표 N행 M열".
@@ -129,9 +130,18 @@ export function deriveSel(page: number, table: TableBox | null, cell: CellHit | 
   }
   if (table) {
     const label = messages.tableAt(page + 1);
+    const nested = !!table.path?.length && table.self_block != null;
     return {
       mark: { page, box: { x: table.x, y: table.y, w: table.w, h: table.h }, label, kind: "table" },
-      anchor: { kind: "table", section: table.section, block: table.block, label, page },
+      anchor: {
+        kind: "table",
+        section: table.section,
+        block: table.block,
+        label,
+        page,
+        path: nested ? table.path : undefined,
+        nestedBlock: nested ? table.self_block : undefined,
+      },
     };
   }
   if (hit) {

--- a/packages/editor-core/src/types.ts
+++ b/packages/editor-core/src/types.ts
@@ -29,6 +29,10 @@ export interface TableBox {
   rows: number;
   cols: number;
   first_row: number;
+  /** Descending path to this nested table's PARENT CELL. Empty/absent for a top-level table. */
+  path?: CellAddr[];
+  /** Block index of this table inside its parent cell; meaningful when `path` is non-empty. */
+  self_block?: number;
 }
 
 /** An anchored image's placed box in own-render px space (mirrors @auto-hwp/engine ImageBox / hwp-session
@@ -309,11 +313,11 @@ export interface Anchor {
   label: string;
   page: number;
   text?: string;
-  /** The DESCENDING CellPath for a NESTED cell anchor (issue 064 Tier-2) — present only on a `kind:"cell"`
-   *  anchor whose cell is nested (length ≥ 2). Absent (or length 1) ⇒ a plain top-level cell = the flat
-   *  `(section, block, rows[0], cols[0])`. Threaded into the `SetTableCellRuns` commit so the edit walks
-   *  to the LEAF cell; also folded into `selKey` so distinct nesting levels are distinct selections. */
+  /** DESCENDING CellPath. For a nested cell it reaches that cell; for a nested table it reaches the
+   *  PARENT cell and `nestedBlock` names the table block inside it. Absent means a flat top-level target. */
   path?: CellAddr[];
+  /** Block index of a selected nested table inside the parent cell addressed by `path`. */
+  nestedBlock?: number;
 }
 
 /** The read-only document context handed to the host AI callback alongside the instruction + anchors,

--- a/packages/engine/index.d.ts
+++ b/packages/engine/index.d.ts
@@ -56,6 +56,10 @@ export interface TableBox {
   rows: number;
   cols: number;
   first_row: number;
+  /** Descending path to a nested table's parent cell. Empty for a top-level table. */
+  path: CellAddr[];
+  /** This table's block index inside that parent cell (equals `block` at top level). */
+  self_block: number;
 }
 
 /** An anchored image's placed box (own-render px space; issue 049); null on a miss. `x/y/w/h` is the

--- a/packages/react/src/__tests__/keyboardBasics.test.tsx
+++ b/packages/react/src/__tests__/keyboardBasics.test.tsx
@@ -74,6 +74,61 @@ function drillCell(sheet: HTMLElement, x: number, y: number) {
 }
 
 describe("키보드 기본기 — ⌘Z / ⌘⇧Z 실행취소·재실행", () => {
+  it("중첩 표 Backspace는 바깥 표가 아닌 자식 블록을 지우고, 즉시 ⌘Z도 삭제 커밋 뒤 실행된다", async () => {
+    let releaseApply!: () => void;
+    const gate = new Promise<void>((resolve) => { releaseApply = resolve; });
+    const nestedTable: TableBox = {
+      ...table,
+      path: [{ block: 1, row: 0, col: 0 }],
+      self_block: 2,
+    };
+    const adapter = new MockAdapter({ table: nestedTable, pageGeom: geom, pages: 1, applyGate: () => gate });
+    const { container } = mount(adapter);
+    const sheet = await sheetOf(container);
+
+    fireEvent.pointerDown(sheet, { clientX: 100, clientY: 100, button: 0, pointerId: 1 });
+    fireEvent.pointerUp(sheet, { clientX: 100, clientY: 100, button: 0, pointerId: 1 });
+    await waitFor(() => expect(container.querySelector(".hw-mark-table")).toBeTruthy());
+
+    fireEvent.keyDown(window, { key: "Backspace" });
+    fireEvent.keyDown(window, { key: "z", metaKey: true });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(adapter.undos).toBe(0); // delete is still in flight; undo waits instead of observing empty
+
+    releaseApply();
+    await waitFor(() => expect(adapter.applied[0]).toEqual({
+      intent: "DeleteNestedBlock",
+      section: 0,
+      path: [{ block: 1, row: 0, col: 0 }],
+      index: 2,
+    }));
+    await waitFor(() => expect(adapter.undos).toBe(1));
+    expect(adapter.applied.some((i) => i.intent === "DeleteBlock")).toBe(false);
+  });
+
+  it("표 삭제로 Design→Vibe 탭이 돌아와도 작성창이 포커스를 훔치지 않아 ⌘Z가 바로 동작한다", async () => {
+    const nestedTable: TableBox = {
+      ...table,
+      path: [{ block: 1, row: 0, col: 0 }],
+      self_block: 2,
+    };
+    const adapter = new MockAdapter({ table: nestedTable, pageGeom: geom, pages: 1 });
+    const { container } = mount(adapter);
+    const sheet = await sheetOf(container);
+    const composer = container.querySelector("textarea.hw-textarea") as HTMLTextAreaElement;
+
+    fireEvent.pointerDown(sheet, { clientX: 100, clientY: 100, button: 0, pointerId: 1 });
+    fireEvent.pointerUp(sheet, { clientX: 100, clientY: 100, button: 0, pointerId: 1 });
+    await waitFor(() => expect(container.querySelector(".hw-mark-table")).toBeTruthy());
+    fireEvent.keyDown(window, { key: "Backspace" });
+    await waitFor(() => expect(adapter.applied[0]?.intent).toBe("DeleteNestedBlock"));
+    await new Promise((r) => setTimeout(r, 20)); // panel tab effect + focus RAF
+    expect(document.activeElement).not.toBe(composer);
+
+    fireEvent.keyDown(window, { key: "z", metaKey: true });
+    await waitFor(() => expect(adapter.undos).toBe(1));
+  });
+
   it("⌘Z 는 툴바 ↶ 버튼과 같은 레인으로 실행취소한다", async () => {
     const adapter = new MockAdapter({ table, pageGeom: geom, pages: 1 });
     const { container } = mount(adapter);

--- a/packages/react/src/components/ChatPanel.tsx
+++ b/packages/react/src/components/ChatPanel.tsx
@@ -417,12 +417,11 @@ export function ChatPanel(props: ChatPanelProps) {
   // undefined) so opening the workspace doesn't steal focus. The marked selection is already shown as an
   // anchor chip above — this only routes the user to the composer to type.
   const focusToken = props.focusToken;
-  const firstFocus = useRef(true);
+  const focusedToken = useRef(0);
   useEffect(() => {
-    if (firstFocus.current) {
-      firstFocus.current = false;
-      if (!focusToken) return;
-    }
+    // Design → Vibe after a selection is cleared is NOT an explicit focus request. Focusing merely
+    // because `active` changed steals document ⌘Z until the user clicks the canvas again (issue #19).
+    if (!focusToken || focusToken <= focusedToken.current) return;
     if (props.active === false) return;
     // WorkspacePanel may reveal the previously display:none vibe pane in the same commit. Focus on the
     // next frame, after that visibility change is painted; focusing a hidden textarea is ignored by Chrome.
@@ -430,6 +429,7 @@ export function ChatPanel(props: ChatPanelProps) {
       const el = inputRef.current;
       if (!el) return;
       el.focus();
+      focusedToken.current = focusToken;
       el.scrollIntoView?.({ block: "nearest" });
     });
     return () => cancelAnimationFrame(frame);

--- a/packages/react/src/components/HwpWorkspace.tsx
+++ b/packages/react/src/components/HwpWorkspace.tsx
@@ -656,6 +656,10 @@ export function HwpWorkspace(props: HwpWorkspaceProps) {
   // suppresses the refreshToken editor-close while a Tab commit-move re-enters the next cell.
   const selectionRef = useRef(selection);
   selectionRef.current = selection;
+  // Block deletion is asynchronous (wasm mutation → page recount → undo-book push). A ⌘Z arriving in
+  // that window must wait for the delete to become a complete undo unit instead of observing an empty
+  // stack. The resolved promise remains harmless until the next block edit (issue #19).
+  const pendingBlockEditRef = useRef<Promise<void>>(Promise.resolve());
   const editorRef = useRef(editor);
   editorRef.current = editor;
   // COUNTED shield (issue 055 사후, consumeShield): armed +1 for a Tab commit's OWN re-flow only (a bare
@@ -2409,14 +2413,22 @@ export function HwpWorkspace(props: HwpWorkspaceProps) {
     [core, toast, onTrap, msg],
   );
   const onDeleteSelectedBlock = useCallback(
-    async (section: number, block: number) => {
-      try {
-        await core.edit.deleteBlock(section, block);
-        core.selection.clear(); // the deleted block's mark is gone; drop the stale selection
-        toast(msg.workspace.deleted);
-      } catch (e) {
-        if (!onTrap(e, msg.workspace.trapRecovered)) toast(msg.workspace.deleteFailed(String(e)));
-      }
+    (anchor: Anchor): Promise<void> => {
+      const task = pendingBlockEditRef.current.then(async () => {
+        try {
+          if (anchor.path?.length && anchor.nestedBlock != null) {
+            await core.edit.deleteNestedBlock(anchor.section, anchor.path, anchor.nestedBlock);
+          } else {
+            await core.edit.deleteBlock(anchor.section, anchor.block);
+          }
+          core.selection.clear(); // the deleted block's mark is gone; drop the stale selection
+          toast(msg.workspace.deleted);
+        } catch (e) {
+          if (!onTrap(e, msg.workspace.trapRecovered)) toast(msg.workspace.deleteFailed(String(e)));
+        }
+      });
+      pendingBlockEditRef.current = task;
+      return task;
     },
     [core, toast, onTrap, msg],
   );
@@ -2444,7 +2456,7 @@ export function HwpWorkspace(props: HwpWorkspaceProps) {
       if (a.kind !== "paragraph" && a.kind !== "table") return;
       e.preventDefault();
       if (e.key === "Enter") void onInsertBlankBelow(a.section, a.block);
-      else void onDeleteSelectedBlock(a.section, a.block);
+      else void onDeleteSelectedBlock(a);
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
@@ -3100,10 +3112,12 @@ export function HwpWorkspace(props: HwpWorkspaceProps) {
   // ⌘Z 도 무반응"이라고 느낀 상황의 절반은 실은 "편집이 애초에 커밋되지 않아 되돌릴 것이 없다"였다.
   // 빈 스택을 정직하게 알려야 사용자가 '편집이 안 먹었다'는 진짜 문제를 인지한다.
   const undo = useCallback(async () => {
+    await pendingBlockEditRef.current;
     toast((await core.session.undo()) ? msg.workspace.undoToast : msg.workspace.undoEmpty);
   }, [core, toast, msg]);
 
   const redo = useCallback(async () => {
+    await pendingBlockEditRef.current;
     toast((await core.session.redo()) ? msg.workspace.redoToast : msg.workspace.redoEmpty);
   }, [core, toast, msg]);
 


### PR DESCRIPTION
## Summary
- delete only the selected nested table block while preserving its parent table
- make immediate Command/Ctrl+Z restore the deletion without requiring an extra click
- extend the additive Intent v0 contract and public DTOs for nested block identity
- add Rust, editor-core, React, and real sample-8p.hwp browser regressions

## Validation
- hwp-ops: 98/98
- hwp-mcp schema: 14/14
- editor-core: 262/262
- React: 418/418
- hwp-lab: 198/198
- isolated clippy with -D warnings: hwp-ops, hwp-session, hwp-mcp, hwp-wasm
- layout gates: 8==8, 18==18, 24==24
- Playwright sample-8p.hwp nested delete + immediate undo: green

Closes #19