### PR TITLE
docs: record nested table fix merge

### DIFF
--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,8 +3,9 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
-- 갱신: 2026-08-13 · Codex(sol) — **이슈 #19 중첩 표 삭제·즉시 undo 수정 완료, push 승인 대기**.
-  공개 이슈 #19를 만들고 브랜치 `codex/issue-19-nested-table-delete-undo`에서 수정했다. `TableBox`가
+- 갱신: 2026-08-13 · Codex(sol) — **이슈 #19 중첩 표 삭제·즉시 undo 수정 main 병합 완료**.
+  공개 이슈 #19→PR #20으로 진행해 필수 checks(issue-link, build-test, licenses) green 후 보호된 main
+  `f32f0ca`에 병합했고 이슈는 자동 close됐다. `TableBox`가
   중첩 표의 부모 CellPath+cell 내부 block index를 보존하고, 수동 전용 additive
   `DeleteNestedBlock` Intent/Op가 해당 자식 블록만 제거한다. 최상위 `DeleteBlock`은 그대로다.
   삭제 중 들어온 undo는 커밋 완료 뒤 직렬화하며, 선택 삭제로 Design→Vibe 탭이 돌아올 때 채팅
@@ -13,8 +14,10 @@
   재삭제 직후 무클릭 undo 복구 1/1 green. hwp-ops 98, MCP schema 14, editor-core 262, React 418,
   hwp-lab 198, 격리 target clippy `-D warnings`, wasm 재빌드+wasm-opt(7,560KB), 게이트
   8==8/18==18/24==24 green. `verify-local --full`은 코드 오류 전 macOS shared-target Tauri/rhwp
-  clippy가 CPU 0%로 재정체되어 중단했고 동일 범위를 격리 target으로 green 확인했다. 다음: 사용자
-  확인 후 commit/push → PR `Closes #19` → 필수 CI → merge/deploy. 선재 `crates/hwp-rhwp/examples/` 무접촉.
+  clippy가 CPU 0%로 재정체되어 중단했고 동일 범위를 격리 target과 PR Linux CI로 green 확인했다.
+  npm 네 패키지의 latest는 모두 `0.0.4`이나 #19 변경은 아직 미배포다. 다음 패키지 배포 시 additive
+  Intent/공개 DTO 변경을 포함해 `0.0.5`로 올린다. 프로덕션 배포는 별도 승인·워크플로 대상이며,
+  선재 `crates/hwp-rhwp/examples/`는 무접촉.
 
 - 갱신: 2026-08-13 · Codex(sol) — **정식 런칭 후 버그 2건 수정·프로덕션 배포·issue-first 전환 완료**.
   이슈 #11/#12/#13 → PR #14로 진행해 필수 checks(issue-link 3s, build-test 5m28s, licenses 2m45s)

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,11 @@
 
 ---
 
+## 2026-08-13 (Codex sol) · #19 main 병합
+- PR #20 필수 checks(issue-link/build-test/licenses) green 후 main `f32f0ca` 병합, #19 자동 close.
+- npm 네 패키지 latest는 `0.0.4`; 이번 additive Intent/DTO 수정은 아직 npm 미배포.
+- 정본 상태 동기화는 이슈 #21 후속 문서 PR로 진행, 선재 examples 무접촉.
+
 ## 2026-08-13 (Codex sol) · #19 중첩 표 삭제·즉시 undo
 - 중첩 표 선택에 부모 CellPath+자식 block 주소를 싣고 `DeleteNestedBlock`으로 바깥 양식 표를 보존.
 - 삭제 커밋/undo를 직렬화하고 Design→Vibe 전환의 채팅 textarea 포커스 탈취를 제거.


### PR DESCRIPTION
## Summary
- record PR #20 and merge commit `f32f0ca` in the continuity state
- clarify that npm `0.0.4` is current latest but does not contain the newly merged #19 change
- preserve the follow-up package release boundary as `0.0.5`

Closes #21