### PR TITLE
docs: record npm 0.0.5 publication

### DIFF
--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,6 +3,15 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
+- 갱신: 2026-08-13 · Codex(sol) — **npm 4종 lockstep 0.0.5 발행·fresh consumer 검증 완료**.
+  이슈 #23→PR #24 필수 checks green 후 main `7a41cb6` 병합. 같은 SHA의 publish workflow
+  run 31678071089를 `dry_run=false`로 실행해 engine→editor-core→ai-protocol→react 네 패키지를
+  모두 발행했다. registry version/license/shasum/unpacked size와 React 의존 `^0.0.5`를 재조회했다.
+  빈 temp에서 Vite·Next production build, Node 24.14.0·Bun 1.3.8 실제 sample-8p 8쪽 렌더
+  (SVG 61,957 B)·HWPX export(25,216 B)까지 green. 증거=`docs/launch/evidence/2026-08-13-npm-0.0.5.md`.
+  Vercel Git auto deploy는 꺼져 있고 수동 prebuilt workflow만 사용하므로 프로덕션은 미배포 상태다.
+  선재 `crates/hwp-rhwp/examples/` 무접촉.
+
 - 갱신: 2026-08-13 · Codex(sol) — **npm lockstep 0.0.5 릴리스 후보 준비·PR 전 검증 완료**.
   소유자 발행 승인에 따라 공개 이슈 #23과 브랜치 `codex/issue-23-npm-0.0.5`를 만들었다. 네 패키지,
   lockfile, engine CDN 핀, 현재 설치 안내를 0.0.5로 맞추고 CHANGELOG Unreleased를 0.0.5(파괴 변경 없음)

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,12 @@
 
 ---
 
+## 2026-08-13 (Codex sol) · npm 0.0.5 발행 완료
+- PR #24 CI green→main `7a41cb6`; publish run 31678071089로 npm 4종 0.0.5 lockstep 발행 성공.
+- registry license/shasum/size와 React `^0.0.5` 형제 의존을 재조회.
+- fresh Vite·Next build, Node/Bun sample-8p 8쪽 렌더·HWPX export green.
+- Vercel은 수동 prebuilt라 미배포; 발행 증거 후속 PR 진행, 선재 examples 무접촉.
+
 ## 2026-08-13 (Codex sol) · npm 0.0.5 릴리스 준비
 - 이슈 #23에서 npm 4종·CDN 핀·현재 소비자 문서를 lockstep 0.0.5로 올리고 CHANGELOG를 확정.
 - launch 30/30, 패키지 64/262/418 tests, 4종 tarball dry-run과 engine wasm 7,560KB green.

--- a/docs/LLM-GUIDE.md
+++ b/docs/LLM-GUIDE.md
@@ -4,7 +4,7 @@
 > 받은 코딩 에이전트(Claude Code·Codex·Cursor·Copilot Workspace 등)가, 추측 없이 **한 번에 맞는 코드**를
 > 쓰도록 만든 문서다. 진입점 인덱스는 루트 [`llms.txt`](../llms.txt).
 >
-> 이 문서의 모든 API·수치는 **npm 발행본 `0.0.4`에 대고 실행해 확인**했다(§5 실측표). 코드가 정본이며,
+> 이 문서의 모든 API·수치는 **npm 발행본 `0.0.5`에 대고 실행해 확인**했다(§5 실측표). 코드가 정본이며,
 > 어긋나면 `node_modules/@auto-hwp/engine/index.d.ts`가 이긴다.
 
 ---
@@ -262,7 +262,7 @@ claude mcp add auto-hwp -- hwp-mcp
 
 ## 2. 함정 목록 — 에이전트가 실제로 틀리는 것들
 
-기존 문서·코드에서 추출했고, 번호 옆 ✔은 이번에 0.0.4로 **재현 확인**한 항목이다.
+기존 문서·코드에서 추출했고, 번호 옆 ✔은 이번에 0.0.5로 **재현 확인**한 항목이다.
 
 1. **버전 pin은 협상 대상이 아니다 — `@latest` 금지.** wasm-bindgen 글루(JS)와 `.wasm` 바이너리는 함께
    컴파일된 **한 벌**이다. 버전이 어긋나면 링크 실패하거나, 더 나쁘게는 링크된 뒤 신규 Intent를
@@ -332,8 +332,8 @@ claude mcp add auto-hwp -- hwp-mcp
     암호(password) `.hwp`는 **열지 못한다**(정직 거부). PDF의 수식·차트는 자리표시 상자다.
 18. **`file:` 의존을 그대로 복사하지 마라.** 이 레포 안의 `packages/*`·`examples/*`는 모노레포라
     `"@auto-hwp/engine": "file:../engine"` 같은 로컬 경로 의존이 섞여 있다. 외부 프로젝트로 옮길 때는
-    **레지스트리 버전(`^0.0.4`)** 으로 바꿔야 한다(발행본 `@auto-hwp/react`는 이미
-    `@auto-hwp/engine ^0.0.4` / `@auto-hwp/editor-core ^0.0.4`를 의존한다 — 확인함).
+    **레지스트리 버전(`^0.0.5`)** 으로 바꿔야 한다(발행본 `@auto-hwp/react`는 이미
+    `@auto-hwp/engine ^0.0.5` / `@auto-hwp/editor-core ^0.0.5`를 의존한다 — 확인함).
 
 ---
 
@@ -370,14 +370,14 @@ try { doc.exportPdf(); } catch (e) { console.log("no-font guard →", e.code); }
 doc.free();
 ```
 
-기대 출력: `engine 0.0.4` / `pages` ≥ 1 / `svg0 bytes` > 0 / `no-font guard → font_missing`.
+기대 출력: `engine 0.0.5` / `pages` ≥ 1 / `svg0 bytes` > 0 / `no-font guard → font_missing`.
 어느 한 줄이라도 다르면 **배선이 틀린 것이지 문서가 틀린 게 아니다** — §2 함정 1·2·12를 다시 보라.
 
 ### 4.2 브라우저 (콘솔/스크래치 페이지)
 
 ```html
 <script type="module">
-  import { initEngine, HwpDoc, sanitizeSvg } from "https://cdn.jsdelivr.net/npm/@auto-hwp/engine@0.0.4/index.js";
+  import { initEngine, HwpDoc, sanitizeSvg } from "https://cdn.jsdelivr.net/npm/@auto-hwp/engine@0.0.5/index.js";
   await initEngine();                       // 인자 없음 = 같은 버전의 wasm을 자동으로
   const bytes = new Uint8Array(await (await fetch("./sample.hwpx")).arrayBuffer());
   const doc = HwpDoc.open(bytes, "sample.hwpx");
@@ -392,13 +392,13 @@ doc.free();
 
 ---
 
-## 5. 실측 기준선 (2026-08-05, npm `0.0.4`, macOS arm64 / Node v24.14.0)
+## 5. 실측 기준선 (2026-08-13, npm `0.0.5`, macOS arm64 / Node v24.14.0)
 
 에이전트가 "이 정도면 정상인가"를 판단할 기준. 재현 방법은 §4.1 + 반복 루프.
 
 | 항목 | 실측값 |
 |---|---|
-| `@auto-hwp/engine@0.0.4` 언팩 크기 / 파일 수 | 8,378,694 B / 14개 |
+| `@auto-hwp/engine@0.0.5` 언팩 크기 / 파일 수 | 8,381,619 B / 14개 |
 | `pkg/hwp_wasm_bg.wasm` (비압축) | 7,725,936 B |
 | `initEngine(bytes)` (로컬 바이트, 캐시 없음) | 23 ms |
 | `benchmark.hwp` (67 KB) → open / 8쪽 SVG / PDF | 14 ms / 1 ms(465 KB) / 61 ms(92 KB) |

--- a/docs/SELF-HOST.md
+++ b/docs/SELF-HOST.md
@@ -4,7 +4,7 @@
 > 당신의 인프라다. 이 문서는 "우리 인프라 안에서 auto-hwp를 돌리고 싶다"는 세 가지 방식을 실물로 다룬다.
 >
 > 이 문서의 모든 커맨드와 수치는 **실제로 실행해 확인**했다(2026-08-05, macOS arm64 / Docker 29.4.3 /
-> Node v24.14.0 / Bun 1.3.8 / npm `@auto-hwp/engine@0.0.4`). 확인하지 못한 것은 그렇게 적었다.
+> Node v24.14.0 / Bun 1.3.8 / npm `@auto-hwp/engine@0.0.5`). 확인하지 못한 것은 그렇게 적었다.
 
 ---
 
@@ -248,7 +248,7 @@ doc.undo();
 doc.free();                         // 문서 스왑마다 명시 호출
 ```
 
-**실측 결과 (Node v24.14.0, `@auto-hwp/engine@0.0.4`):**
+**실측 결과 (Node v24.14.0, `@auto-hwp/engine@0.0.5`):**
 
 | 문서 | 입력 | open | 전 페이지 SVG | PDF |
 |---|---|---|---|---|
@@ -301,7 +301,7 @@ app.listen(8080);
 ```html
 <!-- 클라이언트: 받은 SVG는 여전히 '문서에서 나온 신뢰불가 문자열'이다 -->
 <script type="module">
-  import { sanitizeSvg } from "https://cdn.jsdelivr.net/npm/@auto-hwp/engine@0.0.4/index.js";
+  import { sanitizeSvg } from "https://cdn.jsdelivr.net/npm/@auto-hwp/engine@0.0.5/index.js";
   const svg = await (await fetch("/doc/abc/page/0.svg")).text();
   document.querySelector("#page").innerHTML = sanitizeSvg(svg);   // raw innerHTML 금지
 </script>
@@ -458,7 +458,7 @@ console.log(ENGINE_VERSION, "| pages", doc.pageCount(), "| svg0", doc.renderPage
 try { doc.exportPdf(); } catch (e) { console.log("no-font guard →", e.code); }
 doc.free();
 EOF
-node smoke.mjs /경로/문서.hwpx     # 기대: 0.0.4 | pages N | svg0 >0 B  /  no-font guard → font_missing
+node smoke.mjs /경로/문서.hwpx     # 기대: 0.0.5 | pages N | svg0 >0 B  /  no-font guard → font_missing
 bun  smoke.mjs /경로/문서.hwpx     # 동일 출력
 
 # ── C. 정적 wasm ──────────────────────────────────────────────────────────

--- a/docs/launch/evidence/2026-08-13-npm-0.0.5.md
+++ b/docs/launch/evidence/2026-08-13-npm-0.0.5.md
@@ -1,0 +1,31 @@
+# npm 0.0.5 lockstep 발행 증거
+
+- 발행 기준: 보호된 `main` merge `7a41cb663d07891ed23141ab613cfbda66b82a0f`
+- PR: [#24](https://github.com/kwakseongjae/auto-hwp/pull/24)
+- 실제 발행: [publish run 31678071089](https://github.com/kwakseongjae/auto-hwp/actions/runs/31678071089),
+  `workflow_dispatch`, `dry_run=false`, 7m15s success
+- 발행 순서: engine → editor-core → ai-protocol → react
+
+## 레지스트리 실측
+
+| 패키지 | version | license | shasum | unpacked size |
+|---|---:|---|---|---:|
+| `@auto-hwp/engine` | 0.0.5 | Apache-2.0 | `78946a6edb0749a2be0251ff11f494c67ad7752d` | 8,381,619 B |
+| `@auto-hwp/editor-core` | 0.0.5 | Apache-2.0 | `f69b1395cd05559a738a196decbca2e783c160ad` | 522,773 B |
+| `@auto-hwp/ai-protocol` | 0.0.5 | Apache-2.0 | `8d8d5d378870e1a28b27ea62967489270398c837` | 136,052 B |
+| `@auto-hwp/react` | 0.0.5 | Apache-2.0 | `8fa9b769715cd41875857eda3d6b686a759a0d0a` | 1,870,246 B |
+
+React 발행본의 runtime dependencies는 `@auto-hwp/editor-core ^0.0.5`와
+`@auto-hwp/engine ^0.0.5`다.
+
+## fresh consumer
+
+`node scripts/fresh-consumer-smoke.mjs --version=0.0.5`를 빈 임시 루트에서 실행했다.
+
+- Vite: 네 패키지 registry install + production build pass
+- Next 15: React와 ai-protocol registry install + production build pass
+- Node v24.14.0: 공개 `sample-8p.hwp` 8쪽, SVG 61,957 B, HWPX export 25,216 B
+- Bun 1.3.8: 동일하게 8쪽, SVG 61,957 B, HWPX export 25,216 B
+
+Vercel 프로덕션 배포는 이 npm 릴리스와 분리되어 있으며 실행하지 않았다. 사이트는 Git auto deploy가
+아니라 `vercel-deploy.yml`의 수동 prebuilt workflow만 사용한다.


### PR DESCRIPTION
## Summary
- record the successful `0.0.5` lockstep publish workflow and registry metadata
- record fresh Vite, Next, Node, and Bun consumer verification
- update LLM and self-host docs from the measured 0.0.4 baseline to the newly measured 0.0.5 baseline
- explicitly retain Vercel production deployment as a separate manual prebuilt operation

## Validation
- publish run 31678071089: success
- all four registry packages: 0.0.5 / Apache-2.0
- React sibling dependencies: ^0.0.5
- fresh Vite and Next production builds: pass
- Node 24.14.0 and Bun 1.3.8: sample-8p 8 pages, SVG 61,957 B, HWPX 25,216 B
- launch automated: 30/30

Closes #23