### PR TITLE
ci: auto-deploy relevant main changes to Vercel production

### DIFF
--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -1,4 +1,4 @@
-# Vercel(autohwp.com) 배포 — **수동 전용**(workflow_dispatch, 이 레포 CI 원칙 2026-07-11).
+# Vercel(autohwp.com) 배포 — main의 제품 변경은 자동 production, 필요할 때는 수동 preview/production.
 #
 # GitHub Pages 정적 데모(deploy-demo.yml)와 **병행**한다. 이쪽은 서버가 있는 full Next 배포다:
 #   /api/hwp-edit(데모 AI 라우트) + 절대 URL 메타(OG/canonical) + 커스텀 도메인 autohwp.com.
@@ -14,8 +14,8 @@
 #   VERCEL_ORG_ID      — team_4X1lyulthUiBtmklmjAUsXLv   (비밀 아님. .vercel/project.json 의 orgId)
 #   VERCEL_PROJECT_ID  — prj_5ps7tZkirpzDXEaGzLD1Acob6ctR (비밀 아님. .vercel/project.json 의 projectId)
 #
-# autohwp.com 은 2026-08-06 부터 **라이브**다(가비아 DNS 반영 완료, TLS 발급됨). 그래도 기본 target 은
-# preview — 프로덕션 배포는 실행 시 target=production 을 **명시**해야 한다(오배포 방지).
+# autohwp.com 은 2026-08-06 부터 **라이브**다(가비아 DNS 반영 완료, TLS 발급됨). 수동 실행의 기본
+# target은 preview이고, main의 관련 경로 push는 아래 DEPLOY_TARGET 정규화로 production에만 배포한다.
 # 되돌리기: `vercel rollback <이전 배포 URL> --scope kwakseongjaes-projects` 또는 대시보드 Instant Rollback.
 name: vercel-deploy
 
@@ -29,35 +29,40 @@ on:
           - preview
           - production
         default: preview
-  # 컷오버 확정 후에만 주석을 푼다(그 전에는 자동 프로덕션 배포 금지 — 이 레포 CI 원칙).
-  # push:
-  #   branches: [main]
-  #   paths:
-  #     - "apps/hwp-lab/**"
-  #     - "packages/**"
-  #     - "crates/**"
-  #     - ".github/workflows/vercel-deploy.yml"
+  push:
+    branches: [main]
+    paths:
+      - "apps/hwp-lab/**"
+      - "packages/**"
+      - "crates/**"
+      - "external/rhwp"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "vercel.json"
+      - ".github/workflows/vercel-deploy.yml"
 
 permissions:
   contents: read
 
 concurrency:
-  group: vercel-deploy-${{ inputs.target }}
+  group: vercel-deploy-${{ github.event_name == 'push' && 'production' || inputs.target }}
   cancel-in-progress: false
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
     environment:
-      name: vercel-${{ inputs.target }}
+      name: vercel-${{ github.event_name == 'push' && 'production' || inputs.target }}
       url: ${{ steps.deploy.outputs.url }}
     env:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      # push 이벤트에는 inputs.target이 없다. 먼저 production으로 정규화해 preview 오배포를 차단한다.
+      DEPLOY_TARGET: ${{ github.event_name == 'push' && 'production' || inputs.target }}
       # preview 면 빈 문자열, production 이면 "--prod" — build/deploy 양쪽에 같은 값을 준다
       # (한쪽만 --prod 면 프로덕션 env 로 빌드한 산출물을 프리뷰에 올리는 등 조용히 어긋난다).
-      PROD_FLAG: ${{ inputs.target == 'production' && '--prod' || '' }}
+      PROD_FLAG: ${{ (github.event_name == 'push' || inputs.target == 'production') && '--prod' || '' }}
     steps:
       # 토큰 없이 툴체인 20분을 태우지 않도록 fail-fast.
       - name: verify secrets are present
@@ -123,12 +128,12 @@ jobs:
       # 4) 프로젝트 설정 + 환경변수(DEMO_SITE_URL / NEXT_PUBLIC_DEMO_AI / DEMO_AI_MODE …)를 내려받는다.
       #    ⚠️ 레포 루트에서 실행한다 — rootDirectory=apps/hwp-lab 는 project.json 이 들고 있고,
       #    build:deps 가 ../../packages/* 를 필요로 하므로 체크아웃 전체가 있어야 한다.
-      - name: vercel pull (${{ inputs.target }} env)
+      - name: vercel pull (normalized target env)
         run: |
           # whoami는 정보성만 — 팀 스코프 토큰은 user 엔드포인트가 막혀 "User not found"가 나도
           # 유효할 수 있다(7차 오탐 실측). 판정은 아래 --scope pull이 한다.
           vercel whoami --token="$VERCEL_TOKEN" || echo "whoami 실패(팀 스코프 토큰이면 정상) — pull로 판정"
-          vercel pull --yes --environment=${{ inputs.target }} --scope="$VERCEL_ORG_ID" --token="$VERCEL_TOKEN"
+          vercel pull --yes --environment="$DEPLOY_TARGET" --scope="$VERCEL_ORG_ID" --token="$VERCEL_TOKEN"
 
       # 5) 빌드 — 여기서 apps/hwp-lab 의 installCommand/buildCommand(prebuild→build:deps→
       #    copy-wasm/fonts/samples→next build)가 돌아 .vercel/output 이 만들어진다.
@@ -157,7 +162,7 @@ jobs:
       #       — 프로덕션 생성 URL 조차 `302 → vercel.com/sso-api` 다(2026-08-06 실측). 공개인 건 프로덕션
       #       별칭뿐이므로 스모크는 별칭을 때린다. 프리뷰는 공개 URL 이 없어 검사를 생략한다.
       - name: smoke check (production alias)
-        if: ${{ inputs.target == 'production' }}
+        if: ${{ env.DEPLOY_TARGET == 'production' }}
         env:
           # 2026-08-06 가비아 DNS 반영 완료(A @ → 216.150.1.1, CNAME www → vercel-dns-016) —
           # autohwp.com 이 이미 공개 200 이라 여기를 정본으로 때린다.

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,6 +3,16 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
+- 갱신: 2026-08-13 · Codex(sol) — **이슈 #26 Vercel main→production 자동 prebuilt 배포 구현 완료·PR 전**.
+  Vercel native Git build는 계속 `deploymentEnabled=false`로 두고, `vercel-deploy.yml`에 관련 경로
+  main push 트리거를 추가했다. push에는 `inputs.target`이 없으므로 event name으로 DEPLOY_TARGET=
+  production·PROD_FLAG=--prod·production environment/smoke를 명시 정규화했다. 수동 dispatch의 preview
+  기본값과 production 선택은 유지한다. paths는 hwp-lab/packages/crates/external submodule/Cargo manifests/
+  root vercel config/workflow로 제한해 docs-only merge는 배포하지 않는다. launch regression 8/8,
+  automated 30/30, actionlint(YAML/expression; shellcheck 연동 제외) green. 다음: commit/push→PR `Closes #26`
+  →필수 CI→merge→merge가 자동 생성한 production run과 autohwp.com smoke 확인. 선재
+  `crates/hwp-rhwp/examples/` 무접촉.
+
 - 갱신: 2026-08-13 · Codex(sol) — **npm 4종 lockstep 0.0.5 발행·fresh consumer 검증 완료**.
   이슈 #23→PR #24 필수 checks green 후 main `7a41cb6` 병합. 같은 SHA의 publish workflow
   run 31678071089를 `dry_run=false`로 실행해 engine→editor-core→ai-protocol→react 네 패키지를

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,12 @@
 
 ---
 
+## 2026-08-13 (Codex sol) · Vercel main 자동 production 준비
+- 이슈 #26: native Git build는 끈 채 관련 main push→prebuilt production workflow를 추가.
+- push의 빈 inputs를 production env/--prod/smoke로 명시 정규화하고 수동 preview/production은 보존.
+- docs-only 제외 path filter, launch 8/8·30/30·actionlint green; PR/CI/첫 자동 배포가 다음.
+- 선재 `crates/hwp-rhwp/examples/` 무접촉.
+
 ## 2026-08-13 (Codex sol) · npm 0.0.5 발행 완료
 - PR #24 CI green→main `7a41cb6`; publish run 31678071089로 npm 4종 0.0.5 lockstep 발행 성공.
 - registry license/shasum/size와 React `^0.0.5` 형제 의존을 재조회.

--- a/docs/launch/RC-CHECKLIST.md
+++ b/docs/launch/RC-CHECKLIST.md
@@ -13,7 +13,8 @@
   하나의 `release_commit`에 고정한다. 내용 변화 없는 npm 재발행은 하지 않는다.
 - 다음 npm 발행은 네 패키지를 새 버전으로 lockstep 발행하는 별도 릴리스다.
 - Vercel Git 자동 빌드는 모든 브랜치에서 끈다. preview와 production 모두 Rust·wasm을 먼저 만든
-  `vercel-deploy.yml`의 수동 `--prebuilt` 경로만 사용한다.
+  `vercel-deploy.yml`의 `--prebuilt` 경로만 사용한다. 관련 경로의 main push는 production으로 자동
+  배포하고, 수동 실행은 preview 기본값과 명시적 production 선택을 함께 제공한다.
 - 082의 구현 코드는 `hwp-mcp`의 `rhwp` feature 뒤에 `experimental_guarded` 상태로 존재하지만, 한/글·
   한컴독스 수용 전에는 공개 지원 범위와 런칭 메시지에서 제외한다. 소스 존재를 지원 약속으로 해석하지 않는다.
 

--- a/scripts/lib/launch-readiness.mjs
+++ b/scripts/lib/launch-readiness.mjs
@@ -398,9 +398,15 @@ export function auditLaunch(source) {
     "P0",
     vercelConfig?.git?.deploymentEnabled === false &&
       /^\s*workflow_dispatch\s*:/m.test(vercelDeployWorkflow) &&
+      /^\s*push\s*:/m.test(vercelDeployWorkflow) &&
+      /branches:\s*\[main\]/.test(vercelDeployWorkflow) &&
+      /github\.event_name\s*==\s*'push'\s*&&\s*'production'/.test(vercelDeployWorkflow) &&
+      /github\.event_name\s*==\s*'push'\s*\|\|\s*inputs\.target\s*==\s*'production'/.test(
+        vercelDeployWorkflow,
+      ) &&
       /vercel\s+deploy\s+--prebuilt/.test(vercelDeployWorkflow),
-    "Vercel 자동 Git 빌드를 끄고 Rust·wasm을 포함한 수동 prebuilt 배포만 허용한다",
-    "apps/hwp-lab/vercel.json의 git.deploymentEnabled=false와 workflow_dispatch 기반 --prebuilt 배포를 유지한다.",
+    "Vercel Git 빌드를 끄고 main 제품 변경을 Rust·wasm 포함 prebuilt production으로 자동 배포한다",
+    "Git 배포 비활성화, 수동 preview/production, main push→production 정규화와 --prebuilt를 유지한다.",
   );
 
   const securityConfig = [

--- a/scripts/tests/launch-readiness.test.mjs
+++ b/scripts/tests/launch-readiness.test.mjs
@@ -97,7 +97,7 @@ function passingFiles() {
     ".github/ISSUE_TEMPLATE/feature_request.yml": "name: Feature",
     ".github/workflows/ci.yml": "on:\n  pull_request:\n  workflow_dispatch:\njobs:\n  issue-link:\nuses: actions/checkout@v6",
     ".github/workflows/vercel-deploy.yml":
-      "on:\n  workflow_dispatch:\nuses: actions/checkout@v6\nuses: actions/setup-node@v7\nrun: vercel deploy --prebuilt",
+      "on:\n  workflow_dispatch:\n  push:\n    branches: [main]\nenv:\n  DEPLOY_TARGET: ${{ github.event_name == 'push' && 'production' || inputs.target }}\n  PROD_FLAG: ${{ (github.event_name == 'push' || inputs.target == 'production') && '--prod' || '' }}\nuses: actions/checkout@v6\nuses: actions/setup-node@v7\nrun: vercel deploy --prebuilt",
     ".github/workflows/publish.yml": "uses: actions/checkout@v6\nuses: actions/setup-node@v7",
     ".github/workflows/deploy-demo.yml": "uses: actions/checkout@v6\nuses: actions/setup-node@v7",
     "apps/hwp-lab/vercel.json": JSON.stringify({ git: { deploymentEnabled: false } }),
@@ -162,6 +162,19 @@ test("깨진 사이트 llms·복붙 예제·단위·CI·메타데이터를 각�
     "community.actions-node24",
     "release.prebuilt-deploy-only",
   ]) assert.equal(failed.has(id), true, id);
+});
+
+test("Vercel main 자동 배포는 push를 production으로 정규화해야 한다", () => {
+  const files = passingFiles();
+  files[".github/workflows/vercel-deploy.yml"] =
+    "on:\n  workflow_dispatch:\n  push:\n    branches: [main]\nuses: actions/checkout@v6\nuses: actions/setup-node@v7\nrun: vercel deploy --prebuilt";
+
+  const failed = new Set(
+    auditLaunch(createMemorySource(files))
+      .filter((check) => check.status === "fail")
+      .map((check) => check.id),
+  );
+  assert.equal(failed.has("release.prebuilt-deploy-only"), true);
 });
 
 test("pending 수동 게이트와 HWP5 포함 결정은 증거 없이 통과하지 않는다", () => {


### PR DESCRIPTION
## Summary
- trigger the repository-owned Vercel prebuilt workflow on relevant `main` pushes
- normalize push events to the production environment, `--prod`, and production alias smoke
- retain manual preview/production dispatch and keep Vercel native Git builds disabled
- exclude docs-only changes while covering app, SDK, Rust core, Cargo manifests, rhwp submodule, and deployment configuration
- add a launch-readiness regression that rejects a push trigger without explicit production normalization

## Why
The Vercel cloud builder cannot build the Rust/wasm engine, so native Git deployment must stay disabled. The prebuilt workflow was manual-only, which let merged product fixes remain behind production.

## Validation
- launch-readiness unit tests: 8/8
- automated launch checks: 30/30
- actionlint YAML/GitHub expressions: green (`-shellcheck=`; local shellcheck integration stalled without diagnostics)
- diff check: green

## Post-merge verification
Merging this PR changes the deployment workflow itself, so it should start the first automatic production run. The run must finish with the existing autohwp.com home/OG/canonical smoke before #26 is considered operationally complete.

Closes #26