### PR TITLE
docs: record automatic Vercel production deploy

### DIFF
--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,6 +3,15 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
+- 갱신: 2026-08-13 · Codex(sol) — **이슈 #26 Vercel main 자동 production prebuilt 배포 실증 완료**.
+  PR #27 필수 checks green→main `dd527d8` 병합. 별도 수동 실행 없이 동일 SHA의 push event가
+  production run 31680139716을 시작해 6m30s success했다. engine wasm·JS deps·production env pull·
+  Vercel prebuild/deploy가 모두 green이고, autohwp.com `/` 200·`/og.png` 200·canonical·CSP/HSTS/
+  nosniff/frame deny를 재확인했다. native Vercel Git build는 계속 off, 수동 preview/production도 유지.
+  증거=`docs/launch/evidence/2026-08-13-vercel-main-auto-production.md`. 다음: 이 docs-only 증거 PR의
+  필수 CI→merge 뒤 path filter가 추가 production run을 만들지 않는지 확인. 선재
+  `crates/hwp-rhwp/examples/` 무접촉.
+
 - 갱신: 2026-08-13 · Codex(sol) — **이슈 #26 Vercel main→production 자동 prebuilt 배포 구현 완료·PR 전**.
   Vercel native Git build는 계속 `deploymentEnabled=false`로 두고, `vercel-deploy.yml`에 관련 경로
   main push 트리거를 추가했다. push에는 `inputs.target`이 없으므로 event name으로 DEPLOY_TARGET=

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,12 @@
 
 ---
 
+## 2026-08-13 (Codex sol) · Vercel main 자동 production 실증
+- PR #27 CI green→main `dd527d8`; push event가 자동 production run 31680139716 시작.
+- 6m30s prebuilt deploy success, autohwp.com 홈/OG 200·canonical·보안 헤더 green.
+- native Git build off·수동 preview/production 유지; docs-only 증거 PR에서 path filter 무배포 확인 예정.
+- 선재 `crates/hwp-rhwp/examples/` 무접촉.
+
 ## 2026-08-13 (Codex sol) · Vercel main 자동 production 준비
 - 이슈 #26: native Git build는 끈 채 관련 main push→prebuilt production workflow를 추가.
 - push의 빈 inputs를 production env/--prod/smoke로 명시 정규화하고 수동 preview/production은 보존.

--- a/docs/launch/evidence/2026-08-13-vercel-main-auto-production.md
+++ b/docs/launch/evidence/2026-08-13-vercel-main-auto-production.md
@@ -1,0 +1,26 @@
+# Vercel main 자동 production 배포 증거
+
+- 이슈: [#26](https://github.com/kwakseongjae/auto-hwp/issues/26)
+- 구현 PR: [#27](https://github.com/kwakseongjae/auto-hwp/pull/27)
+- main merge: `dd527d8c92c00573541556aacf5a1711d45650df`
+- 자동 run: [31680139716](https://github.com/kwakseongjae/auto-hwp/actions/runs/31680139716)
+
+## 트리거와 대상
+
+- event: `push` — `workflow_dispatch` 수동 실행이 아니다.
+- head SHA: `dd527d8c92c00573541556aacf5a1711d45650df` — main merge와 동일하다.
+- Vercel native Git deployment는 계속 `deploymentEnabled=false`다.
+- workflow가 push를 `DEPLOY_TARGET=production`, `PROD_FLAG=--prod`, `vercel-production` environment로
+  정규화한 뒤 Rust→wasm→JS→Next prebuilt 순서로 배포했다.
+
+## 결과
+
+- run: 6m30s success
+- prebuilt deployment: `https://auto-7d0tfbjl1-kwakseongjaes-projects.vercel.app`
+- production alias `https://autohwp.com/`: HTTP 200
+- `https://autohwp.com/og.png`: HTTP 200
+- canonical: `https://autohwp.com`
+- 실제 응답에서 CSP, HSTS, `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`를 확인했다.
+
+관련 main push만 자동 배포 대상으로 삼으며 docs-only push는 path filter에서 제외한다. 수동 dispatch의
+preview 기본값과 명시적 production 선택은 유지한다.


### PR DESCRIPTION
## Summary
- record the first automatic production deployment triggered by the #27 main merge
- bind the push event, main merge SHA, Actions run, and prebuilt deployment result
- record autohwp.com home/OG/canonical and security-header smoke evidence
- retain the docs-only path-filter verification as the final operational check

## Validation
- push event head SHA matches main merge `dd527d8`
- production run 31680139716: success in 6m30s
- home 200, OG 200, canonical autohwp.com
- launch automated: 30/30

Closes #26