### PR TITLE
feat: add privacy-safe GA4 and search verification

### DIFF
--- a/apps/hwp-lab/.env.example
+++ b/apps/hwp-lab/.env.example
@@ -43,3 +43,10 @@ OPENROUTER_API_KEY=
 #  공개 배포에는 반드시 Upstash를 붙일 것).
 # UPSTASH_REDIS_REST_URL=
 # UPSTASH_REDIS_REST_TOKEN=
+
+# ── 공개 사이트 검색 인증·익명 분석 ─────────────────────────────────────────────
+# 값이 비어 있으면 인증 태그/GA 스크립트가 전혀 출력되지 않는다. 실제 값은 Vercel 환경변수에만 넣고
+# 이 템플릿에는 커밋하지 않는다.
+# NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION=
+# NEXT_PUBLIC_NAVER_SITE_VERIFICATION=
+# NEXT_PUBLIC_GA_MEASUREMENT_ID=G-XXXXXXXXXX

--- a/apps/hwp-lab/e2e/analytics-consent.spec.ts
+++ b/apps/hwp-lab/e2e/analytics-consent.spec.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "@playwright/test";
+
+test.skip(process.env.PW_ANALYTICS !== "1", "run with PW_ANALYTICS=1 so the dedicated test stream is compiled in");
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    if (sessionStorage.getItem("auto-hwp:analytics-e2e-initialized") === "1") return;
+    localStorage.removeItem("auto-hwp:analytics-consent:v1");
+    sessionStorage.setItem("auto-hwp:analytics-e2e-initialized", "1");
+  });
+  await page.route("https://www.googletagmanager.com/**", (route) => route.fulfill({ status: 200, contentType: "text/javascript", body: "" }));
+});
+
+test("미동의·거부에는 GA 요청이 없고 허용 뒤에만 익명 bucket 이벤트를 보낸다", async ({ page }) => {
+  const googleRequests: string[] = [];
+  page.on("request", (request) => {
+    if (/google(tagmanager|-analytics)|google-analytics/.test(request.url())) googleRequests.push(request.url());
+  });
+
+  await page.goto("/");
+  const consent = page.getByTestId("analytics-consent");
+  await expect(consent).toBeVisible();
+  expect(googleRequests).toEqual([]);
+
+  await consent.getByRole("button", { name: "거부" }).click();
+  await page.reload();
+  await expect(consent).toHaveCount(0);
+  expect(googleRequests).toEqual([]);
+
+  await page.evaluate(() => localStorage.removeItem("auto-hwp:analytics-consent:v1"));
+  await page.reload();
+  await consent.getByRole("button", { name: "익명 분석 허용" }).click();
+  await expect.poll(() => googleRequests.some((url) => url.includes("googletagmanager.com/gtag/js?id=G-TEST123"))).toBe(true);
+
+  await page.getByTestId("sample-sample-8p.hwp").click();
+  await expect(page.locator(".hw-sheet")).toHaveCount(8);
+  const events = await page.evaluate(() =>
+    (window.dataLayer ?? [])
+      .map((args) => Array.from(args as ArrayLike<unknown>))
+      .filter((args) => args[0] === "event"),
+  );
+  expect(events).toContainEqual([
+    "event",
+    "ws_document_open",
+    { file_type: "hwp", source: "sample", result: "success", page_count_bucket: "6-10" },
+  ]);
+  expect(JSON.stringify(events)).not.toContain("sample-8p.hwp");
+});
+
+test("개인정보 화면에서 선택을 초기화하면 즉시 GA를 disable한다", async ({ page }) => {
+  await page.goto("/");
+  await page.getByTestId("analytics-consent").getByRole("button", { name: "익명 분석 허용" }).click();
+  await page.goto("/privacy");
+  await page.getByRole("button", { name: "선택 초기화" }).click();
+  await expect(page.getByTestId("analytics-consent")).toBeVisible();
+  await expect
+    .poll(() => page.evaluate(() => (window as unknown as Record<string, unknown>)["ga-disable-G-TEST123"]))
+    .toBe(true);
+});

--- a/apps/hwp-lab/next.config.mjs
+++ b/apps/hwp-lab/next.config.mjs
@@ -26,17 +26,22 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const isDemo = process.env.DEMO_STATIC === "1";
 const demoBasePath = isDemo ? (process.env.DEMO_BASE_PATH ?? "") : "";
 const isDevelopment = process.env.NODE_ENV === "development";
+const gaEnabled = /^G-[A-Z0-9]+$/.test(process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID ?? "");
 
 // 첫 공식 사이트의 브라우저 경계. Next의 인라인 부트 스크립트와 wasm 컴파일, CDN wasm 및
 // cross-origin module worker의 blob shim만 연다. AI는 full Next에서 same-origin이고 정적 데모의
 // 선택 프록시는 workers.dev만 허용한다. 개발 중에는 HMR websocket/eval을 별도로 추가한다.
 const CONTENT_SECURITY_POLICY = [
   "default-src 'self'",
-  "script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval'" + (isDevelopment ? " 'unsafe-eval'" : ""),
+  "script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval'" +
+    (isDevelopment ? " 'unsafe-eval'" : "") +
+    (gaEnabled ? " https://www.googletagmanager.com" : ""),
   "style-src 'self' 'unsafe-inline'",
   "img-src 'self' data: blob: https:",
   "font-src 'self' data:",
-  "connect-src 'self' https://cdn.jsdelivr.net https://*.workers.dev" + (isDevelopment ? " ws: wss:" : ""),
+  "connect-src 'self' https://cdn.jsdelivr.net https://*.workers.dev" +
+    (gaEnabled ? " https://www.google-analytics.com https://*.google-analytics.com" : "") +
+    (isDevelopment ? " ws: wss:" : ""),
   "worker-src 'self' blob:",
   // PDF preview uses an in-memory `blob:` URL in our own iframe. Keep external frames blocked while
   // allowing only this same-origin/generated-document lane (GitHub #12).

--- a/apps/hwp-lab/playwright.config.ts
+++ b/apps/hwp-lab/playwright.config.ts
@@ -32,6 +32,10 @@ export default defineConfig({
     // 정의된 process.env 키를 .env.local 로 덮어쓰지 않으므로 빈 문자열이 이겨 activeProvider()→mock.
     // (개발자 로컬 .env.local 에 OPENROUTER_API_KEY 가 있으면 e2e 가 실 Grok 을 쳐서 비결정적으로
     // 깨지던 것을 차단 — 라이브 프로바이더 검증은 수동 QA 몫. 066 스테일-dist 회귀 조사에서 발견.)
-    env: { OPENROUTER_API_KEY: "", ANTHROPIC_API_KEY: "" },
+    env: {
+      OPENROUTER_API_KEY: "",
+      ANTHROPIC_API_KEY: "",
+      ...(process.env.PW_ANALYTICS === "1" ? { NEXT_PUBLIC_GA_MEASUREMENT_ID: "G-TEST123" } : {}),
+    },
   },
 });

--- a/apps/hwp-lab/src/app/docs/AgentPromptCard.tsx
+++ b/apps/hwp-lab/src/app/docs/AgentPromptCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { trackAgentPromptCopy } from "@/lib/workspace/analytics";
 import styles from "./docs.module.css";
 
 type Props = {
@@ -29,8 +30,11 @@ export function AgentPromptCard({ title, prompt }: Props) {
       if (navigator.clipboard?.writeText) await navigator.clipboard.writeText(prompt);
       else if (!copyWithTextarea(prompt)) throw new Error("clipboard unavailable");
       setResult("copied");
+      trackAgentPromptCopy({ result: "success" });
     } catch {
-      setResult(copyWithTextarea(prompt) ? "copied" : "failed");
+      const copied = copyWithTextarea(prompt);
+      setResult(copied ? "copied" : "failed");
+      trackAgentPromptCopy({ result: copied ? "success" : "failed" });
     }
   };
 

--- a/apps/hwp-lab/src/app/layout.tsx
+++ b/apps/hwp-lab/src/app/layout.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import "@auto-hwp/react/styles.css";
 import "./globals.css";
 import { THEME_BOOT_SCRIPT } from "@/lib/theme";
+import { AnalyticsConsent } from "@/components/AnalyticsConsent";
 
 // 정적 데모(GitHub Pages)는 basePath(/auto-hwp) 아래에 산다. OG/twitter 는 **절대 URL**만 유효하고
 // (스크래퍼가 상대경로를 못 푼다) favicon 링크는 basePath 접두가 필요하다 — 코드의 다른 절대경로
@@ -17,6 +18,8 @@ const DESCRIPTION =
   "브라우저에서 한글(HWP) 문서를 열고, 고치고, PDF·HTML·HWPX로 내보냅니다. 설치도 회원가입도 없이 — 열기·렌더·편집·내보내기가 전부 기기 안에서(Rust+wasm) 돌아갑니다.";
 const OG_DESCRIPTION = `${DESCRIPTION} 양식 1개 + 명단 N행이면 완성본 N부 일괄 작성까지.`;
 const TITLE = "오토한글 (auto-hwp) — 브라우저에서 열고 고치는 한글(HWP) 문서";
+const GOOGLE_SITE_VERIFICATION = process.env.NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION || "";
+const NAVER_SITE_VERIFICATION = process.env.NEXT_PUBLIC_NAVER_SITE_VERIFICATION || "";
 
 export const metadata: Metadata = {
   metadataBase: new URL(`${SITE}/`),
@@ -25,6 +28,10 @@ export const metadata: Metadata = {
   applicationName: "오토한글 (auto-hwp)",
   keywords: ["한글 문서", "HWP", "HWPX", "HWP 뷰어", "HWP 편집", "PDF 변환", "양식 일괄 작성", "auto-hwp", "오토한글"],
   alternates: { canonical: "/" },
+  verification: {
+    ...(GOOGLE_SITE_VERIFICATION ? { google: GOOGLE_SITE_VERIFICATION } : {}),
+    ...(NAVER_SITE_VERIFICATION ? { other: { "naver-site-verification": NAVER_SITE_VERIFICATION } } : {}),
+  },
   icons: {
     icon: [
       { url: `${BASE}/favicon.ico`, sizes: "48x48 32x32 16x16", type: "image/x-icon" },
@@ -67,6 +74,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             그 사이 data-theme 이 서므로 다크↔라이트 깜빡임이 없다(정적 export 에서도 동작). */}
         <script dangerouslySetInnerHTML={{ __html: THEME_BOOT_SCRIPT }} />
         {children}
+        <AnalyticsConsent />
       </body>
     </html>
   );

--- a/apps/hwp-lab/src/app/privacy/PrivacyControls.tsx
+++ b/apps/hwp-lab/src/app/privacy/PrivacyControls.tsx
@@ -2,26 +2,45 @@
 
 import { useState } from "react";
 import { revokeDemoAiConsent } from "@/lib/demoAiConsent";
+import { clearAnalyticsConsent } from "@/lib/analyticsConsent";
 import styles from "./privacy.module.css";
 
 export function PrivacyControls() {
   const [revoked, setRevoked] = useState(false);
+  const [analyticsReset, setAnalyticsReset] = useState(false);
 
   return (
-    <div className={styles.controlBox}>
-      <div>
-        <b>데모 AI 전송 동의 철회</b>
-        <p>이 브라우저의 동의 플래그만 지웁니다. 다음 AI 요청 때 전송 범위를 다시 확인합니다.</p>
+    <>
+      <div className={styles.controlBox}>
+        <div>
+          <b>데모 AI 전송 동의 철회</b>
+          <p>이 브라우저의 동의 플래그만 지웁니다. 다음 AI 요청 때 전송 범위를 다시 확인합니다.</p>
+        </div>
+        <button
+          type="button"
+          onClick={() => {
+            revokeDemoAiConsent();
+            setRevoked(true);
+          }}
+        >
+          {revoked ? "철회됨" : "동의 철회"}
+        </button>
       </div>
-      <button
-        type="button"
-        onClick={() => {
-          revokeDemoAiConsent();
-          setRevoked(true);
-        }}
-      >
-        {revoked ? "철회됨" : "동의 철회"}
-      </button>
-    </div>
+      <div className={styles.controlBox}>
+        <div>
+          <b>익명 사용 분석 선택 초기화</b>
+          <p>저장된 허용·거부 선택을 지웁니다. 다음 방문에서 익명 분석 여부를 다시 묻습니다.</p>
+        </div>
+        <button
+          type="button"
+          onClick={() => {
+            clearAnalyticsConsent();
+            setAnalyticsReset(true);
+          }}
+        >
+          {analyticsReset ? "초기화됨" : "선택 초기화"}
+        </button>
+      </div>
+    </>
   );
 }

--- a/apps/hwp-lab/src/app/privacy/page.tsx
+++ b/apps/hwp-lab/src/app/privacy/page.tsx
@@ -24,7 +24,7 @@ export default function PrivacyPage() {
           오토한글(auto-hwp)의 기본 문서 경로는 브라우저 안에서 동작합니다. AI 편집은 별도 선택 사항이며,
           그때만 아래에 적은 문맥이 명시적 동의 뒤 외부 처리자에게 전달됩니다.
         </p>
-        <p className={styles.updated}>최종 갱신: 2026-08-12 · 적용 대상: autohwp.com 라이브 데모</p>
+        <p className={styles.updated}>최종 갱신: 2026-08-13 · 적용 대상: autohwp.com 라이브 데모</p>
 
         <section>
           <h2>한눈에 보는 데이터 경계</h2>
@@ -60,6 +60,11 @@ export default function PrivacyPage() {
                     서버 메모리 또는 Upstash 카운터 키. 약 25시간 뒤 만료. 기본 한도는 IP당 20회·전체
                     400회이며, Upstash가 없으면 서버 인스턴스별 best-effort입니다.
                   </td>
+                </tr>
+                <tr>
+                  <th>선택적 익명 사용 분석</th>
+                  <td>페이지 방문, 문서 형식·쪽수 구간, 열기·AI 요청·내보내기·제보 이동의 성공 여부</td>
+                  <td>명시적으로 허용한 브라우저에서만 Google Analytics로 전송. 문서명·본문·프롬프트·응답은 제외</td>
                 </tr>
               </tbody>
             </table>
@@ -109,8 +114,10 @@ export default function PrivacyPage() {
         <section>
           <h2>분석·쿠키·외부 제품에 임베드할 때</h2>
           <p>
-            현재 데모에는 광고, 행동 분석 SDK, 제3자 추적 쿠키가 없습니다. CDN에서 엔진 바이트를 받는 기본
-            설정은 네트워크 요청이며, 폐쇄망에서는 임베드 가이드의 자기호스팅 경로로 바꿀 수 있습니다.
+            광고는 없습니다. 익명 사용 분석은 별도 선택 사항이며, 허용하기 전에는 Google Analytics 스크립트나
+            요청을 보내지 않습니다. 허용하면 페이지 방문과 기능 단계의 제한된 enum·구간 값만 전송하고,
+            파일명·문서 본문·표 내용·AI 지시문과 응답·선택 위치·문서 해시·원문 오류는 보내지 않습니다.
+            선택은 이 브라우저의 localStorage에 저장되며 아래에서 초기화할 수 있습니다.
           </p>
           <p>
             npm 패키지·CLI·MCP를 자신의 제품이나 인프라에 붙인 운영자는 별도의 데이터 처리자입니다. 어떤

--- a/apps/hwp-lab/src/components/AnalyticsConsent.module.css
+++ b/apps/hwp-lab/src/components/AnalyticsConsent.module.css
@@ -1,0 +1,35 @@
+.banner {
+  position: fixed;
+  z-index: 10000;
+  right: 20px;
+  bottom: 20px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 18px;
+  width: min(720px, calc(100vw - 40px));
+  padding: 18px;
+  color: #17171b;
+  background: rgba(255, 255, 255, 0.98);
+  border: 1px solid #d7d7df;
+  border-radius: 16px;
+  box-shadow: 0 18px 60px rgba(20, 20, 30, 0.22);
+}
+
+.banner b { display: block; margin-bottom: 6px; font-size: 15px; }
+.banner p { margin: 0; color: #575763; font-size: 13px; line-height: 1.55; }
+.banner a { color: inherit; text-decoration: underline; text-underline-offset: 2px; }
+.actions { display: flex; align-items: flex-end; gap: 8px; }
+.actions button { padding: 9px 13px; white-space: nowrap; border: 1px solid #c9cad2; border-radius: 9px; background: #fff; cursor: pointer; }
+.actions .accept { color: #fff; border-color: #5b31ff; background: #5b31ff; font-weight: 700; }
+
+@media (max-width: 680px) {
+  .banner { right: 12px; bottom: 12px; grid-template-columns: 1fr; width: calc(100vw - 24px); }
+  .actions { justify-content: flex-end; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .banner { color: #f7f7fb; background: rgba(27, 27, 33, 0.98); border-color: #484852; }
+  .banner p { color: #c5c5ce; }
+  .actions button { color: #f7f7fb; border-color: #555561; background: #303038; }
+  .actions .accept { border-color: #795cff; background: #6a49ff; }
+}

--- a/apps/hwp-lab/src/components/AnalyticsConsent.tsx
+++ b/apps/hwp-lab/src/components/AnalyticsConsent.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import Script from "next/script";
+import { useEffect, useState } from "react";
+import {
+  ANALYTICS_CONSENT_EVENT,
+  readAnalyticsConsent,
+  writeAnalyticsConsent,
+  type AnalyticsConsent as Consent,
+} from "@/lib/analyticsConsent";
+import styles from "./AnalyticsConsent.module.css";
+
+const RAW_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID || "";
+const MEASUREMENT_ID = /^G-[A-Z0-9]+$/.test(RAW_MEASUREMENT_ID) ? RAW_MEASUREMENT_ID : "";
+const BASE = process.env.NEXT_PUBLIC_BASE_PATH || "";
+
+export function AnalyticsConsent() {
+  const [consent, setConsent] = useState<Consent>(null);
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    const sync = () => setConsent(readAnalyticsConsent());
+    sync();
+    setReady(true);
+    window.addEventListener(ANALYTICS_CONSENT_EVENT, sync);
+    return () => window.removeEventListener(ANALYTICS_CONSENT_EVENT, sync);
+  }, []);
+
+  useEffect(() => {
+    if (!MEASUREMENT_ID) return;
+    (window as unknown as Record<string, unknown>)[`ga-disable-${MEASUREMENT_ID}`] = consent !== "granted";
+  }, [consent]);
+
+  if (!MEASUREMENT_ID || !ready) return null;
+
+  return (
+    <>
+      {consent === "granted" && (
+        <>
+          <Script src={`https://www.googletagmanager.com/gtag/js?id=${MEASUREMENT_ID}`} strategy="afterInteractive" />
+          <Script id="auto-hwp-ga4" strategy="afterInteractive">
+            {`window.dataLayer=window.dataLayer||[];window.gtag=function(){dataLayer.push(arguments)};gtag('js',new Date());gtag('config','${MEASUREMENT_ID}',{anonymize_ip:true});`}
+          </Script>
+        </>
+      )}
+      {consent === null && (
+        <aside className={styles.banner} role="dialog" aria-label="방문 분석 선택" data-testid="analytics-consent">
+          <div>
+            <b>오토한글을 더 잘 만들기 위한 익명 사용 흐름</b>
+            <p>
+              동의하면 Google Analytics로 페이지 방문과 문서 열기·AI 요청·내보내기 같은 성공 여부만 봅니다.
+              파일명·문서 내용·AI 지시문과 응답은 보내지 않습니다. 거부해도 모든 기능을 그대로 쓸 수 있습니다.
+              {" "}<a href={`${BASE}/privacy`}>자세히 보기</a>
+            </p>
+          </div>
+          <div className={styles.actions}>
+            <button type="button" onClick={() => writeAnalyticsConsent("denied")}>
+              거부
+            </button>
+            <button type="button" className={styles.accept} onClick={() => writeAnalyticsConsent("granted")}>
+              익명 분석 허용
+            </button>
+          </div>
+        </aside>
+      )}
+    </>
+  );
+}

--- a/apps/hwp-lab/src/components/LabWorkspace.tsx
+++ b/apps/hwp-lab/src/components/LabWorkspace.tsx
@@ -11,6 +11,16 @@ import { DOC_URL_MISSING_MESSAGE, docUrlPath, homePath, lookupDocUrl, parseDocUr
 import { limitMessage, oversizeMessage } from "@/lib/limits";
 import { layoutReportFormat, layoutReportUrl } from "@/lib/layoutReport";
 import {
+  fileType,
+  trackAiRequest,
+  trackDocumentOpen,
+  trackExport,
+  trackLayoutReportOpen,
+  trackUploadStart,
+  type DocumentSource,
+  type ExportFormat,
+} from "@/lib/workspace/analytics";
+import {
   demoAiAttachmentError,
   ensureDemoAiConsent,
   splitConsentMessage,
@@ -448,12 +458,15 @@ export default function LabWorkspace() {
   // 이슈 055 사후 #2: 거부/취소/실패 경로는 busy/probe 상태만 정리하고 **현재 doc 은 유지**한다 — 두
   // 번째 파일 열기가 거부됐다고 이미 열린 문서를 언마운트하지 않는다(열린 문서가 없었다면 그대로 없음).
   const openBytes = useCallback(
-    async (bytes: Uint8Array, name: string): Promise<boolean> => {
+    async (bytes: Uint8Array, name: string, source: DocumentSource = "unknown"): Promise<boolean> => {
+      const format = fileType(name);
       if (!/\.(hwp|hwpx)$/i.test(name)) {
+        trackDocumentOpen({ fileType: format, source, result: "unsupported" });
         setLabError(`지원하지 않는 형식입니다: ${name}\n.hwp 또는 .hwpx 파일만 열 수 있습니다.`);
         return false;
       }
       if (bytes.length === 0) {
+        trackDocumentOpen({ fileType: format, source, result: "empty" });
         setLabError(`빈 파일입니다: ${name}`);
         return false;
       }
@@ -461,6 +474,7 @@ export default function LabWorkspace() {
       // 파싱(워커 복사)을 시작하기 전에 정직한 사유로 거부한다.
       const tooBig = oversizeMessage(bytes.length, name);
       if (tooBig) {
+        trackDocumentOpen({ fileType: format, source, result: "too_large" });
         setLabError(tooBig);
         return false;
       }
@@ -472,14 +486,16 @@ export default function LabWorkspace() {
       const probe = new WasmAdapter(wasmUrl, adapterOptions);
       probeRef.current = probe; // 취소 버튼이 이 핸들의 dispose()로 파싱을 중단한다(워커 종료)
       try {
-        await probe.open(bytes, name);
+        const opened = await probe.open(bytes, name);
         probe.dispose();
         if (!latest()) return false; // 더 새 open 이 시작됨 — 그쪽 결과가 이긴다
+        trackDocumentOpen({ fileType: format, source, result: "success", pages: opened.pages });
         setDoc({ bytes, name });
         return true;
       } catch (err) {
         // 이슈 055: 사용자가 취소(워커 종료)한 경우 — 오류가 아니다. 조용히 접는다(현재 문서 유지).
         if ((err as { code?: string })?.code === "worker_terminated") {
+          trackDocumentOpen({ fileType: format, source, result: "cancelled" });
           return false;
         }
         if (workerMode) {
@@ -495,6 +511,7 @@ export default function LabWorkspace() {
           }
         }
         if (!latest()) return false; // 뒤에 새 open 이 시작됐다 — 그쪽 표면을 어지럽히지 않는다
+        trackDocumentOpen({ fileType: format, source, result: "failed" });
         // 이슈 055 한도 UX: DocLimit/형식 계열 오류는 사람이 읽는 사유로 매핑, 모르는 오류는 기존 문구.
         const friendly = limitMessage(msg(err));
         setLabError(
@@ -524,7 +541,8 @@ export default function LabWorkspace() {
       const file = e.target.files?.[0];
       e.target.value = ""; // 같은 파일 재선택 허용
       if (!file) return;
-      await openBytes(new Uint8Array(await file.arrayBuffer()), file.name);
+      trackUploadStart({ fileType: fileType(file.name), source: "picker" });
+      await openBytes(new Uint8Array(await file.arrayBuffer()), file.name, "upload");
     },
     [openBytes],
   );
@@ -537,7 +555,7 @@ export default function LabWorkspace() {
       try {
         const r = await fetch(`${BASE}/samples/${file}`);
         if (!r.ok) throw new Error(`샘플이 배치되지 않았습니다 (${r.status}) — apps/hwp-lab에서 npm run dev/build를 다시 실행하세요.`);
-        await openBytes(new Uint8Array(await r.arrayBuffer()), file);
+        await openBytes(new Uint8Array(await r.arrayBuffer()), file, "sample");
       } catch (e) {
         setLabError(msg(e));
       }
@@ -608,7 +626,11 @@ export default function LabWorkspace() {
           setResuming(true);
           // 시드(편집 전 원본)는 원래 파일명 그대로 연다 — 바이트가 .hwp 인데 " (복구본).hwpx" 로
           // 열면 확장자와 내용이 어긋난다. 편집본 스냅샷은 진짜 HWPX 라 기존 이름 규칙 유지.
-          const ok = await openBytes(rec.bytes, rec.seed && rec.sourceName ? rec.sourceName : recoveredName(rec.docName));
+          const ok = await openBytes(
+            rec.bytes,
+            rec.seed && rec.sourceName ? rec.sourceName : recoveredName(rec.docName),
+            fromUrl ? "url" : "recovery",
+          );
           if (cancelled) return;
           setResuming(false);
           if (ok) {
@@ -648,7 +670,7 @@ export default function LabWorkspace() {
   const onRestore = useCallback(async () => {
     if (!recovery) return;
     pendingRecoveryRef.current = recovery; // 열기 성공 시 [doc] 이펙트가 소비(adoptRecovered)한다
-    const ok = await openBytes(recovery.bytes, recoveredName(recovery.docName));
+    const ok = await openBytes(recovery.bytes, recoveredName(recovery.docName), "recovery");
     if (!ok) {
       // 열기 실패 — 재귀속되지 않았다. 스냅샷은 보존하고 사유만 알린다(다시 시도/무시는 사용자의 선택).
       pendingRecoveryRef.current = null;
@@ -726,6 +748,15 @@ export default function LabWorkspace() {
       window.setTimeout(() => URL.revokeObjectURL(a.href), 4000);
       await autosave.markExported();
       setSavedLabel(null);
+      const format: ExportFormat =
+        mime === "application/pdf"
+          ? "pdf"
+          : mime === "text/html"
+            ? "html"
+            : mime === "application/hwp+zip"
+              ? "hwpx"
+              : "unknown";
+      trackExport({ format, result: "success" });
     },
     [autosave],
   );
@@ -751,6 +782,7 @@ export default function LabWorkspace() {
         throw new Error("AI 전송에 동의하지 않아 요청을 보내지 않았습니다. 수동 편집과 내보내기는 계속 사용할 수 있습니다.");
       }
     }
+    trackAiRequest({ transport: demoAiOn ? "demo" : "byok" });
     // 066: 표/셀 앵커마다 엔진에서 그 표의 셀 그리드(행×열·각 셀 텍스트·빈칸)를 조회해 doc-context 에
     // 첨부한다 — 그래야 모델이 "표 채워줘"·라벨 옆 값칸 지정·구조편집(행 N개)을 정확히 한다(얇은 앵커
     // 컨텍스트에선 intents 0 이었음). 표가 아니거나 조회 실패면 null(첨부 없음 → 기존 동작, 회귀 방지).
@@ -1029,6 +1061,7 @@ export default function LabWorkspace() {
           href={layoutReportUrl(layoutReportFormat(doc.name))}
           target="_blank"
           rel="noreferrer"
+          onClick={trackLayoutReportOpen}
           title="파일명·본문·해시 없이 형식과 빈 비교 항목만 GitHub 공개 이슈 초안에 채웁니다"
         >
           <MessageSquareWarning size={14} />
@@ -1161,7 +1194,8 @@ export default function LabWorkspace() {
             className={theme === "light" ? undefined : "hw-studio"}
             // 이슈 050: 페이지 위에 이미지를 드롭하면 삽입, .hwp/.hwpx 를 드롭하면 이 콜백으로 열기.
             onOpenFile={async (bytes, name) => {
-              await openBytes(bytes, name); // 성공 여부는 복구 배너 전용 — 드롭 열기는 결과 무시(050 동작 유지)
+              trackUploadStart({ fileType: fileType(name), source: "drop" });
+              await openBytes(bytes, name, "drop"); // 성공 여부는 복구 배너 전용 — 드롭 열기는 결과 무시(050 동작 유지)
             }}
             // 이슈 052: 내보내기는 웹 기본(브라우저 다운로드)을 그대로 수행하고 스냅샷을 정리한다.
             onExport={onExport}

--- a/apps/hwp-lab/src/lib/analyticsConsent.test.ts
+++ b/apps/hwp-lab/src/lib/analyticsConsent.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import {
+  ANALYTICS_CONSENT_STORAGE_KEY,
+  clearAnalyticsConsent,
+  readAnalyticsConsent,
+  writeAnalyticsConsent,
+  type AnalyticsConsentStorage,
+} from "./analyticsConsent";
+
+function memoryStorage(seed?: string): AnalyticsConsentStorage & { value: string | null } {
+  const storage: AnalyticsConsentStorage & { value: string | null } = {
+    value: seed ?? null,
+    getItem: () => storage.value,
+    setItem: (_key, value) => {
+      storage.value = value;
+    },
+    removeItem: () => {
+      storage.value = null;
+    },
+  };
+  return storage;
+}
+
+describe("analytics consent", () => {
+  it("treats missing and unknown values as undecided", () => {
+    expect(readAnalyticsConsent(memoryStorage())).toBeNull();
+    expect(readAnalyticsConsent(memoryStorage("yes"))).toBeNull();
+  });
+
+  it("persists only the explicit granted or denied decision", () => {
+    const storage = memoryStorage();
+    writeAnalyticsConsent("granted", storage);
+    expect(storage.value).toBe("granted");
+    expect(readAnalyticsConsent(storage)).toBe("granted");
+    writeAnalyticsConsent("denied", storage);
+    expect(readAnalyticsConsent(storage)).toBe("denied");
+  });
+
+  it("can forget the choice so the banner asks again", () => {
+    const storage = memoryStorage("granted");
+    clearAnalyticsConsent(storage);
+    expect(storage.value).toBeNull();
+  });
+
+  it("uses a versioned, product-scoped key", () => {
+    expect(ANALYTICS_CONSENT_STORAGE_KEY).toBe("auto-hwp:analytics-consent:v1");
+  });
+});

--- a/apps/hwp-lab/src/lib/analyticsConsent.ts
+++ b/apps/hwp-lab/src/lib/analyticsConsent.ts
@@ -1,0 +1,37 @@
+export const ANALYTICS_CONSENT_STORAGE_KEY = "auto-hwp:analytics-consent:v1";
+export const ANALYTICS_CONSENT_EVENT = "auto-hwp:analytics-consent-change";
+
+export type AnalyticsConsent = "granted" | "denied" | null;
+
+export interface AnalyticsConsentStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+function defaultStorage(): AnalyticsConsentStorage | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+export function readAnalyticsConsent(storage: AnalyticsConsentStorage | null = defaultStorage()): AnalyticsConsent {
+  const value = storage?.getItem(ANALYTICS_CONSENT_STORAGE_KEY);
+  return value === "granted" || value === "denied" ? value : null;
+}
+
+export function writeAnalyticsConsent(
+  consent: Exclude<AnalyticsConsent, null>,
+  storage: AnalyticsConsentStorage | null = defaultStorage(),
+): void {
+  storage?.setItem(ANALYTICS_CONSENT_STORAGE_KEY, consent);
+  if (typeof window !== "undefined") window.dispatchEvent(new Event(ANALYTICS_CONSENT_EVENT));
+}
+
+export function clearAnalyticsConsent(storage: AnalyticsConsentStorage | null = defaultStorage()): void {
+  storage?.removeItem(ANALYTICS_CONSENT_STORAGE_KEY);
+  if (typeof window !== "undefined") window.dispatchEvent(new Event(ANALYTICS_CONSENT_EVENT));
+}

--- a/apps/hwp-lab/src/lib/gtag.test.ts
+++ b/apps/hwp-lab/src/lib/gtag.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ANALYTICS_CONSENT_STORAGE_KEY } from "./analyticsConsent";
+import { event } from "./gtag";
+
+afterEach(() => {
+  Reflect.deleteProperty(globalThis, "window");
+});
+
+function installWindow(consent: string | null) {
+  const gtag = vi.fn();
+  const localStorage = {
+    getItem: (key: string) => (key === ANALYTICS_CONSENT_STORAGE_KEY ? consent : null),
+    setItem: vi.fn(),
+    removeItem: vi.fn(),
+  };
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: { gtag, localStorage },
+  });
+  return gtag;
+}
+
+describe("gtag privacy gate", () => {
+  it.each([null, "denied", "unexpected"])("does not emit without granted consent (%s)", (consent) => {
+    const gtag = installWindow(consent);
+    event("ws_export", { format: "pdf" });
+    expect(gtag).not.toHaveBeenCalled();
+  });
+
+  it("emits the finite event payload after explicit consent", () => {
+    const gtag = installWindow("granted");
+    event("ws_export", { format: "pdf", result: "success" });
+    expect(gtag).toHaveBeenCalledWith("event", "ws_export", { format: "pdf", result: "success" });
+  });
+});

--- a/apps/hwp-lab/src/lib/gtag.ts
+++ b/apps/hwp-lab/src/lib/gtag.ts
@@ -1,0 +1,15 @@
+import { readAnalyticsConsent } from "./analyticsConsent";
+
+export type GtagParams = Record<string, string | number | boolean>;
+
+declare global {
+  interface Window {
+    dataLayer?: unknown[];
+    gtag?: (...args: unknown[]) => void;
+  }
+}
+
+export function event(name: string, params: GtagParams = {}): void {
+  if (typeof window === "undefined" || readAnalyticsConsent() !== "granted" || typeof window.gtag !== "function") return;
+  window.gtag("event", name, params);
+}

--- a/apps/hwp-lab/src/lib/workspace/analytics.test.ts
+++ b/apps/hwp-lab/src/lib/workspace/analytics.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { fileType, pageCountBucket } from "./analytics";
+
+describe("workspace analytics privacy buckets", () => {
+  it("reduces filenames to a finite file type", () => {
+    expect(fileType("민감한 사업계획서.HWP")).toBe("hwp");
+    expect(fileType("people.hwpx")).toBe("hwpx");
+    expect(fileType("secret.pdf")).toBe("unknown");
+  });
+
+  it("buckets page counts instead of sending continuous values", () => {
+    expect(pageCountBucket(undefined)).toBe("unknown");
+    expect(pageCountBucket(1)).toBe("1");
+    expect(pageCountBucket(8)).toBe("6-10");
+    expect(pageCountBucket(25)).toBe("11-25");
+    expect(pageCountBucket(51)).toBe("51+");
+  });
+});

--- a/apps/hwp-lab/src/lib/workspace/analytics.ts
+++ b/apps/hwp-lab/src/lib/workspace/analytics.ts
@@ -1,0 +1,56 @@
+import { event } from "../gtag";
+
+export type DocumentSource = "upload" | "sample" | "drop" | "recovery" | "url" | "unknown";
+export type FileType = "hwp" | "hwpx" | "unknown";
+export type OpenResult = "success" | "unsupported" | "empty" | "too_large" | "cancelled" | "failed";
+export type ExportFormat = "html" | "pdf" | "hwpx" | "unknown";
+
+export function fileType(name: string): FileType {
+  if (/\.hwpx$/i.test(name)) return "hwpx";
+  if (/\.hwp$/i.test(name)) return "hwp";
+  return "unknown";
+}
+
+export function pageCountBucket(pages: number | undefined): string {
+  if (!pages || pages < 1) return "unknown";
+  if (pages === 1) return "1";
+  if (pages <= 5) return "2-5";
+  if (pages <= 10) return "6-10";
+  if (pages <= 25) return "11-25";
+  if (pages <= 50) return "26-50";
+  return "51+";
+}
+
+export function trackUploadStart(args: { fileType: FileType; source: "picker" | "drop" }): void {
+  event("ws_upload_start", { file_type: args.fileType, source: args.source });
+}
+
+export function trackDocumentOpen(args: {
+  fileType: FileType;
+  source: DocumentSource;
+  result: OpenResult;
+  pages?: number;
+}): void {
+  event("ws_document_open", {
+    file_type: args.fileType,
+    source: args.source,
+    result: args.result,
+    page_count_bucket: pageCountBucket(args.pages),
+  });
+}
+
+export function trackAiRequest(args: { transport: "demo" | "byok" }): void {
+  event("ws_ai_request", { transport: args.transport });
+}
+
+export function trackExport(args: { format: ExportFormat; result: "success" }): void {
+  event("ws_export", args);
+}
+
+export function trackLayoutReportOpen(): void {
+  event("ws_layout_report_open");
+}
+
+export function trackAgentPromptCopy(args: { result: "success" | "failed" }): void {
+  event("docs_agent_prompt_copy", args);
+}

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,6 +3,16 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
+- 갱신: 2026-08-13 · Codex(sol) — **이슈 #29~#33 성장 계측·검색 등록 구현 및 콘솔 사전 설정 완료, PR 전**.
+  GA4 속성/웹 스트림을 `https://autohwp.com`·Asia/Seoul·KRW로 만들고 Enhanced Measurement를 껐다.
+  Google Search Console URL-prefix와 Naver Search Advisor 사이트를 HTML meta 방식으로 추가해 verification
+  token 2개와 GA 측정 ID를 Vercel Production env에 등록했다. 코드는 명시적 opt-in 전 GA script/request 0,
+  거부·철회 즉시 disable, 파일명·본문·프롬프트·원문 오류 금지, hwp/hwpx·쪽수 bucket·결과 enum만 전송한다.
+  Google/Naver meta와 GA CSP는 ID/env가 있을 때만 출력된다. hwp-lab 208 tests·typecheck·production build,
+  analytics Playwright 2/2, launch 30/30 green; `verify-local --full`은 코드 오류 전 종전 macOS shared-target
+  clippy CPU 0% 정체로 중단했다. 다음: commit/push→PR `Closes #30/#31/#32`→CI/main 자동 production→라이브
+  meta·동의/네트워크 smoke→양 콘솔 Verify+sitemap→Brave submit/CAPTCHA. 선재 `crates/hwp-rhwp/examples/` 무접촉.
+
 - 갱신: 2026-08-13 · Codex(sol) — **이슈 #26 Vercel main 자동 production prebuilt 배포 실증 완료**.
   PR #27 필수 checks green→main `dd527d8` 병합. 별도 수동 실행 없이 동일 SHA의 push event가
   production run 31680139716을 시작해 6m30s success했다. engine wasm·JS deps·production env pull·

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,12 @@
 
 ---
 
+## 2026-08-13 (Codex sol) · GA4·검색 등록 준비
+- #29~#33: GA4 property/stream과 Google/Naver HTML meta token을 만들고 Vercel Production env에 등록.
+- 익명 opt-in 전 GA 요청 0·철회 즉시 disable·문서 콘텐츠 금지 typed event/CSP/privacy를 구현.
+- app 208 tests·typecheck·build, 전용 Playwright 2/2, launch 30/30 green; full은 기존 shared clippy 정체.
+- 다음: PR/CI/main 자동 배포→Google/Naver verify+sitemap→Brave submit; 선재 examples 무접촉.
+
 ## 2026-08-13 (Codex sol) · Vercel main 자동 production 실증
 - PR #27 CI green→main `dd527d8`; push event가 자동 production run 31680139716 시작.
 - 6m30s prebuilt deploy success, autohwp.com 홈/OG 200·canonical·보안 헤더 green.

--- a/docs/analytics/GA4-TRACKING-PLAN.md
+++ b/docs/analytics/GA4-TRACKING-PLAN.md
@@ -1,0 +1,68 @@
+# 오토한글(auto-hwp) GA4 트래킹 플랜
+
+정본 이슈: GitHub #29, 구현: #30. 프로덕션 측정 ID가 없으면 GA 스크립트와 네트워크 요청은 0이다.
+사용자가 익명 분석을 명시적으로 허용한 뒤에만 `gtag.js`를 로드한다.
+
+## Primary funnel
+
+1. GA4 자동 `page_view`
+2. `ws_upload_start` 또는 샘플 진입
+3. `ws_document_open` (`result=success`)
+4. `ws_ai_request` (선택 경로)
+5. `ws_export` (`result=success`)
+6. `ws_layout_report_open` (집단지성 기여 경로)
+
+초기 버전은 “문서를 열어 실제 산출물을 만들었는가”와 “레이아웃 제보로 기여했는가”를 본다.
+수동 편집 완료와 AI 적용 완료는 SDK의 host callback 계약을 별도 설계한 뒤 additive event로 확장한다.
+
+## Events
+
+| 이름 | 발화 조건 | 목적 |
+|---|---|---|
+| `ws_upload_start` | 파일 picker/drop에서 파일을 선택 | 열기 시도 진입 |
+| `ws_document_open` | 열기 검증이 성공·거부·실패·취소됨 | 브라우저 렌더 성공률 |
+| `ws_ai_request` | 동의 게이트를 통과하고 AI 요청을 만들기 직전 | 선택적 AI 사용률 |
+| `ws_export` | 브라우저 다운로드가 시작되고 autosave 정리가 완료됨 | 산출물 전환 |
+| `ws_layout_report_open` | 비식별 GitHub 제보 초안 링크 클릭 | 기여 전환 |
+| `docs_agent_prompt_copy` | Docs의 에이전트 시작 프롬프트 복사 결과 | agent-first 온보딩 전환 |
+
+## Parameters
+
+| 이름 | 타입/허용 값 | 사용처 | 카디널리티·개인정보 규율 |
+|---|---|---|---|
+| `source` | upload/sample/drop/recovery/url/unknown 또는 picker/drop | upload/open | 유한 enum |
+| `file_type` | hwp/hwpx/unknown | upload/open | 파일명은 폐기하고 확장자 분류만 보냄 |
+| `result` | success/unsupported/empty/too_large/cancelled/failed | open/export/copy | 원문 오류 금지 |
+| `page_count_bucket` | 1/2-5/6-10/11-25/26-50/51+/unknown | open | 실제 쪽수 대신 구간 |
+| `transport` | demo/byok | AI | 제공자·모델·프롬프트 없음 |
+| `format` | html/pdf/hwpx/unknown | export | 유한 enum |
+
+절대 금지: 파일명, URL/query, 문서 본문·표 값, AI 지시문·응답, CellPath/선택 위치, 문서 해시,
+원문 오류 문자열, IP나 사용자 식별자를 custom parameter로 보내는 것.
+
+## One-time GA4 admin setup
+
+1. Account/property 생성 후 Web data stream URL을 `https://autohwp.com`으로 설정한다.
+2. Vercel Production에 `NEXT_PUBLIC_GA_MEASUREMENT_ID=G-...`를 등록한다.
+3. 자동 스크롤·외부 링크 URL 등을 추가 수집하지 않도록 Enhanced Measurement는 끈다.
+4. event-scoped custom dimensions: `source`, `file_type`, `result`, `page_count_bucket`, `transport`, `format`.
+5. Key events: 성공한 `ws_document_open`, `ws_export`, `ws_layout_report_open`은 UI에서 조건을 분리해 설정한다.
+6. 내부 개발 트래픽 필터와 데이터 보존 기간을 소유자가 확정한다.
+
+## Funnel Exploration
+
+- Step 1: `page_view`, page location host=`autohwp.com`
+- Step 2: `ws_document_open`, `result=success`
+- Step 3: 선택 분기 `ws_ai_request`
+- Step 4: `ws_export`, `result=success`
+- Step 5: 선택 분기 `ws_layout_report_open`
+
+## Debug checklist
+
+- [ ] 동의 미선택/거부 상태에서 `googletagmanager.com`, `google-analytics.com` 요청 0
+- [ ] 허용 후 `page_view` 1회(중복 없음)
+- [ ] sample과 local upload의 source/file_type 구분
+- [ ] 성공·거부 파일에 원문 이름·오류·본문이 payload에 없음
+- [ ] PDF/HTML/HWPX 성공 이벤트 구분
+- [ ] layout report와 agent prompt copy 이벤트 확인
+- [ ] GA4 DebugView/Realtime 증거 캡처

--- a/docs/launch/SEARCH-REGISTRATION.md
+++ b/docs/launch/SEARCH-REGISTRATION.md
@@ -1,0 +1,39 @@
+# autohwp.com 검색 등록 운영 절차
+
+정본 이슈: Google #31, Naver #32, Brave #33. 등록·소유권 인증·사이트맵 제출·실제 색인은 서로 다른
+상태다. “제출됨”을 “색인됨”으로 기록하지 않는다.
+
+## 공통 사전 조건
+
+- `https://autohwp.com/robots.txt` 200, `/api/`와 `/d/`만 disallow
+- `https://autohwp.com/sitemap.xml` 200
+- canonical은 `https://autohwp.com/`
+- 인증 값은 Git에 커밋하지 않고 Vercel Production env로만 주입
+
+## Google Search Console — HTML tag
+
+1. URL-prefix property `https://autohwp.com/`을 추가한다.
+2. HTML tag 방식에서 `content` 값만 복사한다.
+3. Vercel Production의 `NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION`에 넣고 배포한다.
+4. 라이브 `<head>`에 `name="google-site-verification"` meta가 정확히 한 개 있는지 확인한다.
+5. Search Console에서 Verify한다. 인증 뒤에도 환경변수와 meta를 제거하지 않는다.
+6. `/sitemap.xml`을 제출하고 주요 URL을 URL Inspection으로 확인한다.
+
+## Naver Search Advisor — HTML tag
+
+1. `https://autohwp.com`을 사이트로 추가한다.
+2. HTML 태그 방식에서 `content` 값만 복사한다.
+3. Vercel Production의 `NEXT_PUBLIC_NAVER_SITE_VERIFICATION`에 넣고 배포한다.
+4. 라이브 `<head>`에 `name="naver-site-verification"` meta가 정확히 한 개 있는지 확인한다.
+5. 소유 확인 후 sitemap URL을 제출하고 Yeti 수집 상태를 확인한다.
+
+## Brave Search
+
+1. 공식 Submit URL에서 `https://autohwp.com/`을 제출한다.
+2. CAPTCHA는 소유자가 직접 완료한다.
+3. 제출 시각과 결과를 기록하고, 후속 날짜에 `site:autohwp.com` 결과를 확인한다.
+
+## 증거 형식
+
+`docs/launch/evidence/YYYY-MM-DD-search-registration.md`에 property, 인증 방식, 제출 URL, 콘솔 결과,
+후속 점검 날짜를 기록한다. 계정 이메일·verification token·쿠키·스크린샷의 개인정보는 남기지 않는다.


### PR DESCRIPTION
Closes #30
Refs #29, #31, #32

## What changed

- adds an explicit GA4 opt-in banner; no Google script or request is made before consent
- disables GA immediately after consent reset and keeps the feature off when the measurement ID is absent/invalid
- records only typed, low-cardinality workspace funnel events; filenames, document content, prompts, responses, hashes, cell paths, URLs, and raw errors are excluded
- adds environment-driven Google Search Console and Naver Search Advisor meta verification
- opens the minimum GA CSP origins only when a valid measurement ID is configured
- updates the privacy surface, Vercel env template, tracking plan, and search registration runbook
- adds unit and dedicated Playwright regressions for consent/network/payload behavior

## Console preparation already completed

- GA4 property + web stream for https://autohwp.com
- Enhanced Measurement disabled
- Google Search Console URL-prefix property and Naver site created with HTML meta verification
- GA measurement ID and both verification tokens added to Vercel Production env

## Validation

- hwp-lab Vitest: 208 passed
- hwp-lab typecheck: passed
- Next production build with GA + both verification envs: passed
- analytics Playwright: 2 passed
- launch readiness: 30/30
- local production CSP + both meta tags verified
- browser-harness: undecided/denied Google requests 0; consent loads gtag; sample-8p sends only hwp/sample/success/6-10
- verify-local --full: stopped in the known macOS shared-target clippy 0% CPU stall before any diagnostic; PR Linux CI is the independent full gate

## After merge

The relevant-path main push should auto-deploy production. Then verify the live meta tags, consent network boundary, GA Realtime, Search Console ownership + sitemap, and Naver ownership + sitemap.
