### PR TITLE
docs: record analytics and search registration evidence

### DIFF
--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,15 +3,17 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
-- 갱신: 2026-08-13 · Codex(sol) — **이슈 #29~#33 성장 계측·검색 등록 구현 및 콘솔 사전 설정 완료, PR 전**.
-  GA4 속성/웹 스트림을 `https://autohwp.com`·Asia/Seoul·KRW로 만들고 Enhanced Measurement를 껐다.
-  Google Search Console URL-prefix와 Naver Search Advisor 사이트를 HTML meta 방식으로 추가해 verification
-  token 2개와 GA 측정 ID를 Vercel Production env에 등록했다. 코드는 명시적 opt-in 전 GA script/request 0,
-  거부·철회 즉시 disable, 파일명·본문·프롬프트·원문 오류 금지, hwp/hwpx·쪽수 bucket·결과 enum만 전송한다.
-  Google/Naver meta와 GA CSP는 ID/env가 있을 때만 출력된다. hwp-lab 208 tests·typecheck·production build,
-  analytics Playwright 2/2, launch 30/30 green; `verify-local --full`은 코드 오류 전 종전 macOS shared-target
-  clippy CPU 0% 정체로 중단했다. 다음: commit/push→PR `Closes #30/#31/#32`→CI/main 자동 production→라이브
-  meta·동의/네트워크 smoke→양 콘솔 Verify+sitemap→Brave submit/CAPTCHA. 선재 `crates/hwp-rhwp/examples/` 무접촉.
+- 갱신: 2026-08-13 · Codex(sol) — **성장 계측 production·Google/Naver 등록·Brave 제출 완료**.
+  main `097929767fd8bec6df42acb18ca74835aa342a24`의 자동 production run `31691376098`은 전체 success.
+  라이브에서 동의 전 GA script/request/cookie 0, 허용 뒤 page_view, 철회 즉시 disable을 확인했고 샘플
+  8쪽 `ws_document_open` payload가 hwp/sample/success/6-10 enum·bucket만 포함함을 검증했다. GA4 별도
+  오토한글 property Realtime 수신, Enhanced Measurement off, custom dimension 6개, `ws_export`·
+  `ws_layout_report_open` key event를 설정했다. Google URL-prefix meta verified, sitemap 15 URL success,
+  homepage indexed/HTTPS; `/docs`·`/bulk`·`/privacy`는 발견됨-pending이고 privacy는 수동 요청했다. Naver
+  meta verified+sitemap+핵심 URL 4개 수집 요청, Brave homepage Submit URL success. 증거=
+  `docs/launch/evidence/2026-08-13-growth-search-registration.md`. 다음 비동기: 2026-08-20 Brave 실제 색인,
+  GA `ws_document_open result=success` 파생 key event, Google/Naver 하위 URL 자연 색인 재확인. 선재
+  `crates/hwp-rhwp/examples/` 무접촉.
 
 - 갱신: 2026-08-13 · Codex(sol) — **이슈 #26 Vercel main 자동 production prebuilt 배포 실증 완료**.
   PR #27 필수 checks green→main `dd527d8` 병합. 별도 수동 실행 없이 동일 SHA의 push event가

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,18 @@
 
 ---
 
+## 2026-08-13 (Codex sol) · GA4·Google/Naver·Brave 등록 완료
+- production `0979297` success; 동의 전 GA 0·허용/철회·비식별 sample event·Realtime 검증.
+- GA custom dimension 6개, export/layout key event; Google verified+sitemap 15·home indexed.
+- Naver verified+sitemap+핵심 URL 4개 수집 요청, Brave Submit URL success.
+- 다음: 2026-08-20 Brave 색인, document_open success key event·하위 URL 상태 재확인; examples 무접촉.
+
+## 2026-08-13 (Codex sol) · 성장 계측 배포 중 안전 중단
+- PR #34 checks green→main `0979297`; production push run `31691376098` 진행 중.
+- 로컬 watcher만 중단했으며 배포는 GitHub/Vercel에서 계속된다. Google/Naver Verify는 아직 미실행.
+- 재개: run 결과→라이브 meta/CSP/GA opt-in smoke→Google/Naver verify+sitemap→Brave→GA 증거화.
+- 체크포인트 문서 외 선재 `crates/hwp-rhwp/examples/` 무접촉.
+
 ## 2026-08-13 (Codex sol) · GA4·검색 등록 준비
 - #29~#33: GA4 property/stream과 Google/Naver HTML meta token을 만들고 Vercel Production env에 등록.
 - 익명 opt-in 전 GA 요청 0·철회 즉시 disable·문서 콘텐츠 금지 typed event/CSP/privacy를 구현.

--- a/docs/launch/evidence/2026-08-13-growth-search-registration.md
+++ b/docs/launch/evidence/2026-08-13-growth-search-registration.md
@@ -1,0 +1,56 @@
+# GA4·검색 등록 프로덕션 증거 — 2026-08-13
+
+정본 이슈: #29–#33. 인증 토큰, 계정 쿠키, 사용자 문서 정보는 이 문서와 저장소에 기록하지 않는다.
+
+## 프로덕션과 개인정보 경계
+
+- main `097929767fd8bec6df42acb18ca74835aa342a24`의 Vercel production push run
+  `31691376098`이 성공했다. build, prebuilt deploy, production alias smoke가 모두 green이다.
+- `autohwp.com`에는 Google/Naver verification meta가 production env를 통해 출력된다.
+- 분석 동의 전 `gtag.js`·Google Analytics 요청·GA 쿠키는 모두 0이었다.
+- 허용 뒤에만 `gtag.js`, `page_view`, GA 쿠키가 생성됐다. 개인정보 페이지의 선택 초기화는 즉시
+  `ga-disable-* = true`로 바꾸고 동의 배너를 복원했다.
+- 라이브 샘플 8쪽 열기의 custom event는 `ws_document_open`과
+  `file_type=hwp`, `source=sample`, `result=success`, `page_count_bucket=6-10`만 담았다.
+  파일명·본문·URL·해시·프롬프트·응답·원문 오류는 없었다.
+- CSP는 GA가 설정됐을 때만 `www.googletagmanager.com` script와 Google Analytics connect 출처를
+  허용하고, HSTS·frame/object 제한은 유지한다.
+
+## GA4
+
+- 별도 `오토한글 (auto-hwp)` property와 `https://autohwp.com` Web stream을 사용한다.
+- Realtime에서 오토한글 페이지와 활성 사용자를 수신했다.
+- Enhanced Measurement는 최종 확인까지 완료해 자동 측정은 기본 `page_view`만 남겼다.
+- event-scoped custom dimensions 6개를 등록했다:
+  `source`, `file_type`, `result`, `page_count_bucket`, `transport`, `format`.
+- `ws_export`, `ws_layout_report_open`을 key event로 생성했고 별표 상태를 확인했다.
+- `ws_document_open`은 실패·취소도 같은 이름을 쓰므로 전체를 key event로 표시하지 않았다.
+  일반 이벤트 처리 후 `result=success` 조건의 파생 key event를 만드는 후속 확인이 필요하다.
+
+## Google Search Console
+
+- URL-prefix property `https://autohwp.com/`를 HTML meta 방식으로 verified했다.
+- `/sitemap.xml`은 제출 직후 잠시 `가져올 수 없음`이었지만 재처리 후 `성공`, 발견 URL 15개가 됐다.
+- homepage URL Inspection은 `Google에 등록되어 있음`, `페이지 색인이 생성됨`, HTTPS 정상이다.
+- `/docs`, `/bulk`, `/privacy`는 sitemap에서 발견됐으나 점검 시점에는
+  `발견됨 - 현재 색인이 생성되지 않음`이었다. `/privacy`는 우선순위 크롤링 대기열에 수동 요청했다.
+
+## Naver Search Advisor
+
+- `https://autohwp.com`을 HTML meta 방식으로 소유 확인했다.
+- `sitemap.xml`을 등록했다.
+- `/`, `/docs`, `/bulk`, `/privacy` 네 URL을 웹 페이지 수집 요청에 등록했다.
+- 신규 사이트이므로 노출·진단·수집 리포트 생성에는 시간이 걸릴 수 있다.
+
+## Brave Search
+
+- 공식 `https://search.brave.com/submit-url`에서 `https://autohwp.com/`을 제출했고 `Success`를 확인했다.
+- `robots.txt`는 전체 공개 경로를 허용하고 sitemap을 선언하며, Googlebot User-Agent로도 sitemap이
+  `application/xml`로 정상 열렸다. BraveBot을 별도로 차단하는 규칙은 없다.
+- 제출은 색인을 보장하지 않는다. 첫 `site:autohwp.com` 후속 확인일은 2026-08-20로 둔다.
+
+## 남은 비동기 확인
+
+1. 2026-08-20 이후 Brave `site:autohwp.com` 노출 확인 및 #33 갱신.
+2. GA4 일반 이벤트 처리 후 `ws_document_open` + `result=success` 파생 key event 등록.
+3. Google `/docs`·`/bulk`·`/privacy`, Naver 수집/색인 리포트의 자연 처리 상태 재확인.


### PR DESCRIPTION
Closes #31
Closes #32
Refs #29
Refs #30
Refs #33

## Summary
- record live GA4 consent and payload verification
- record Google Search Console ownership, sitemap, and indexing state
- record Naver ownership, sitemap, URL collection requests, and Brave submission
- preserve explicit asynchronous follow-ups without overstating index completion

## Verification
- `git diff --check`
- `bash scripts/verify-launch.sh --automated` (30/30)