### PR TITLE
docs: ask before merge; require browser QA for UI

### DIFF
--- a/.grok/rules/browser-qa.md
+++ b/.grok/rules/browser-qa.md
@@ -1,0 +1,7 @@
+# Browser QA
+
+If you changed something a user sees or uploads to, drive a real browser
+before calling it done. Prefer chrome-devtools (`upload_file`, snapshot,
+click). Fall back to agent-browser. Follow `.grok/skills/browser-qa/SKILL.md`.
+
+Public fixtures only. A screenshot of first paint is not verification.

--- a/.grok/rules/oss-issue-first.md
+++ b/.grok/rules/oss-issue-first.md
@@ -4,10 +4,11 @@ auto-hwp is public. Do not edit or push `main`. Search or open a GitHub issue,
 branch from `origin/main` as `docs|fix|feat/issue-<n>-<slug>`, and put
 `Closes #<n>` in the PR body.
 
-Required checks: `issue-link`, `build-test`, `licenses`. Merge only when they
-are green and review threads are resolved, then delete the branch. Deploy only
-a protected `main` SHA. No user documents, PII, or `corpus/private` in
-issues/PRs/CI.
+Required checks: `issue-link`, `build-test`, `licenses`. After they are green,
+stop and ask before merge unless the user said 머지/병합/merge or the change
+is trivial (typo, comment, JOURNAL-only, one-line pointer). Then delete the
+branch. Deploy only a protected `main` SHA. No user documents, PII, or
+`corpus/private` in issues/PRs/CI.
 
 Load `.grok/skills/oss-issue-first/SKILL.md` before the first edit.
 Follow `CONTRIBUTING.md` and `AGENTS.md` if they add more constraints.

--- a/.grok/skills/browser-qa/SKILL.md
+++ b/.grok/skills/browser-qa/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: browser-qa
+description: >
+  Drive a real browser to verify UI work in this repo: upload public samples,
+  click, type. Use when changing /bulk, workspace, layout, routing, or file
+  pickers.
+---
+
+Prefer **chrome-devtools** (`navigate_page`, `take_snapshot`, `click`,
+`upload_file`). Fall back to **agent-browser**.
+
+Start `pnpm -C apps/hwp-lab dev` (port 3000; do not steal Playwright's 3100).
+Clear `apps/hwp-lab/.next` after a wasm rebuild.
+
+Public fixtures only:
+
+- `apps/hwp-lab/public/samples/sample-8p.hwp`
+- `apps/hwp-lab/public/samples/sample-18p.hwpx`
+- `benchmarks/benchmark.hwp`
+- `testdata/roster/ok.xlsx`
+
+Never upload `corpus/private`, `benchmarks/local`, or user documents.
+
+Upload, click, and type the changed flow. A screenshot is not enough. If the
+browser tools cannot run, say so.

--- a/.grok/skills/oss-issue-first/SKILL.md
+++ b/.grok/skills/oss-issue-first/SKILL.md
@@ -13,4 +13,6 @@ Follow `CONTRIBUTING.md` §이슈에서 시작하는 개발 흐름 and `AGENTS.m
 2. Branch from `origin/main`. Do not commit `main`.
 3. PR body must include `Closes #<issue>`. Required checks: `issue-link`, `build-test`, `licenses`.
 4. Verify with `scripts/verify-local.sh` (use `--full` if crates or packages changed).
-5. Merge only with green checks and resolved review threads. Delete the branch. Deploy only a protected `main` SHA.
+5. After the three checks are green, **ask before merge** unless the user said
+   머지/병합/merge or the change is trivial. Then delete the branch. Deploy only
+   a protected `main` SHA. UI work also follows `.grok/skills/browser-qa/SKILL.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,10 +15,14 @@ HWP(한글) 자체 엔진: Rust 코어(파싱→IR→조판→렌더→export→
 ## 정식 오픈소스 작업 프로토콜
 - Grok/다른 에이전트: `.grok/skills/oss-issue-first/SKILL.md` — 구현·문서 변경의 첫 동작은 이슈다.
 - 모든 코드·문서 변경은 먼저 공개 GitHub 이슈를 만들거나 기존 이슈를 연결한다.
-- `main` 직접 작업·직접 push 금지: 이슈 브랜치 → PR 본문 `Closes #<issue>` → 필수 CI → merge 순서다.
+- `main` 직접 작업·직접 push 금지: 이슈 브랜치 → PR 본문 `Closes #<issue>` → 필수 CI 순서다.
 - 필수 checks는 `issue-link`·`build-test`·`licenses`; 대화 해결 전 merge 금지. 배포는 보호된
   `main`의 정확한 commit SHA로만 실행한다.
+- **에이전트는 PR에서 멈춘다.** 사용자가 머지/병합/merge 라고 하거나, 변경이 사소한
+  경우(오타·주석·JOURNAL만·한 줄 포인터)만 병합한다. 그 외에는 물어본다.
 - merge 뒤 작업 브랜치를 삭제한다. 사용자 콘텐츠·민감 문서는 이슈/PR/CI 아티팩트에 올리지 않는다.
+- UI·레이아웃·라우팅·클라이언트 상태·업로드 화면을 바꿨으면 브라우저 MCP로 실제 업로드/클릭
+  검수를 한다(스크린샷 한 장은 검수가 아니다). 절차: `.grok/skills/browser-qa/SKILL.md`.
 
 ## 로드맵/상태 지도 (정본 위치)
 | 무엇 | 어디 |

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,12 +3,11 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
-- 갱신: 2026-08-14 · Grok 4.6 — **#38 머지 · #40 xlsx 명단 구현 중**.
-  PR #39가 main `d24d0b5`에 병합됨(`Closes #38`). 제품 방향 v3=
-  `docs/PRODUCT-DIRECTION-V3.md`. 구현 브랜치 `feat/issue-40-xlsx-roster`:
-  CLI `fill --data *.xlsx` + `/bulk` 파일 열기 첫 시트 계약(추가 시트·병합 셀
-  정직 거부). 픽스처 `testdata/roster/`. 다음: PR `Closes #40` → 필수 CI.
-  082 한컴 수동 게이트는 별건. 056·067 재구현 금지. 선재 사용자 문서 무접촉.
+- 갱신: 2026-08-15 · Grok 4.6 — **에이전트 규율 #43 (PR만, 병합은 질문)**.
+  #40/#41은 main `dbc76ef`에 이미 병합. 이번 브랜치 `docs/issue-43-ask-before-merge`:
+  비사소 PR은 체크 green 후 멈추고 묻는다. UI는 chrome-devtools로 업로드/클릭
+  검수. 전역 `~/.grok`에도 동일 규칙·`browser-qa` 스킬·MCP 핀. 다음: 사용자
+  병합 승인. 082 한컴 게이트는 별건. 선재 사용자 문서 무접촉.
 
 
 - 갱신: 2026-08-13 · Codex(sol) — **성장 계측 production·Google/Naver 등록·Brave 제출 완료**.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,10 @@
 
 ---
 
+## 2026-08-15 (Grok 4.6) · 병합은 묻고, UI는 브라우저 검수
+- #43: 에이전트는 PR에서 멈춤(사소·명시 머지 제외). UI는 chrome-devtools 실검수.
+- 전역 ~/.grok rules/skills + 레포 `.grok` 동기화. 다음: PR 승인 후 머지.
+
 ## 2026-08-14 (Grok 4.6) · #38 머지 후 #40 xlsx 착수
 - PR #39 green→main `d24d0b5`. Grok 전역 rules/hook + 레포 `.grok/rules`에 issue-first 고정.
 - `feat/issue-40-xlsx-roster`에서 CLI·/bulk 첫 시트 xlsx 파서 구현·단위테스트 green.


### PR DESCRIPTION
Closes #43

## What
Agent harness only (not the human CONTRIBUTING flow).

- Stop at a green PR and ask before merge, except trivial edits or an explicit 머지/병합/merge.
- UI / upload / layout work: drive chrome-devtools (fallback agent-browser). A screenshot is not QA.
- Public fixtures only.

## Also on this machine (not in the PR)
`~/.grok/AGENTS.md`, `~/.grok/rules/*`, `~/.grok/skills/browser-qa`, and pinned `chrome-devtools` / `agent-browser` MCP servers.

## Non-scope
Agentation toolbar, CI job changes, 082.