### PR TITLE
feat: OpenRouter PKCE 연결 v1 — 서버 커스터디 키 + 모델 선택

### DIFF
--- a/apps/hwp-lab/.env.example
+++ b/apps/hwp-lab/.env.example
@@ -11,6 +11,10 @@ OPENROUTER_API_KEY=
 # ("grok 4.2"는 OpenRouter에 없음 — 실제 슬러그는 grok-4.20 / grok-4.3 / grok-4.5)
 # AUTO_HWP_OPENROUTER_MODEL=x-ai/grok-4.20
 
+# 로컬 Models 진입점 + OpenRouter PKCE (이슈 #56). Vercel/공개 데모에는 절대 넣지 않는다.
+# 켜면 /models 와 /api/auth/openrouter/* 가 루프백 호스트에서만 살아난다.
+# AUTO_HWP_LOCAL_MODELS=1
+
 # ── Anthropic (폴백) ─────────────────────────────────────────────────────
 # OPENROUTER_API_KEY가 없을 때만 사용(모델 claude-opus-4-8).
 # ANTHROPIC_API_KEY=

--- a/apps/hwp-lab/next.config.mjs
+++ b/apps/hwp-lab/next.config.mjs
@@ -87,6 +87,10 @@ const nextConfig = {
     // 배지 툴팁의 모델명 **폴백**(1순위는 서버 상태 응답 GET /api/hwp-edit 의 `model`). 서버가 없는
     // 정적 데모에서만 의미가 있고, 비어 있으면 툴팁은 모델명을 지어내지 않는다.
     NEXT_PUBLIC_AI_MODEL: process.env.NEXT_PUBLIC_AI_MODEL ?? "",
+    // 로컬 Models 내비 노출만. 값은 AUTO_HWP_LOCAL_MODELS 에서 파생하고 정적 데모/미설정이면 빈다.
+    // 실제 라우트는 서버 이중 게이트가 막는다 — 이 플래그만으로 키가 열리지 않는다.
+    NEXT_PUBLIC_AUTO_HWP_LOCAL_MODELS:
+      !isDemo && process.env.AUTO_HWP_LOCAL_MODELS === "1" ? "1" : "",
   },
   // 문서 세션 URL(/d/<불투명 키>)은 **클라이언트 전용 라우트**다: 서버가 아는 것은 아무 것도 없고
   // (키는 이 브라우저 안에서만 스냅샷으로 환원된다) 화면도 랜딩과 같은 앱 하나다. 그래서 별도 페이지를

--- a/apps/hwp-lab/src/app/api/auth/openrouter/_guard.ts
+++ b/apps/hwp-lab/src/app/api/auth/openrouter/_guard.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+import { localModelsDeniedReason } from "@/lib/openrouter/gating";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/** Dual-gate failure is a 404 so the local-only surface is not advertised on hosted builds. */
+export function rejectIfGated(req: Request): NextResponse | null {
+  if (!localModelsDeniedReason(req)) return null;
+  return NextResponse.json({ error: "not found" }, { status: 404 });
+}
+
+export function modelsRedirect(req: Request, query: Record<string, string>): NextResponse {
+  const url = new URL("/models", req.url);
+  for (const [key, value] of Object.entries(query)) url.searchParams.set(key, value);
+  return NextResponse.redirect(url);
+}

--- a/apps/hwp-lab/src/app/api/auth/openrouter/callback/route.ts
+++ b/apps/hwp-lab/src/app/api/auth/openrouter/callback/route.ts
@@ -1,0 +1,27 @@
+import { exchangeOpenRouterCode } from "@/lib/openrouter/oauth";
+import { setOpenRouterSessionKey, takePkceVerifier } from "@/lib/openrouter/session";
+import { modelsRedirect, rejectIfGated } from "../_guard";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(req: Request) {
+  const gated = rejectIfGated(req);
+  if (gated) return gated;
+
+  const url = new URL(req.url);
+  const code = url.searchParams.get("code")?.trim() ?? "";
+  // `code` is expected in the URL (it is not the key). Missing/empty is a failed handshake.
+  if (!code) return modelsRedirect(req, { error: "missing_code" });
+
+  const verifier = takePkceVerifier();
+  if (!verifier) return modelsRedirect(req, { error: "missing_verifier" });
+
+  try {
+    const key = await exchangeOpenRouterCode(code, verifier);
+    setOpenRouterSessionKey(key);
+  } catch {
+    return modelsRedirect(req, { error: "exchange_failed" });
+  }
+  return modelsRedirect(req, { connected: "1" });
+}

--- a/apps/hwp-lab/src/app/api/auth/openrouter/connect/route.ts
+++ b/apps/hwp-lab/src/app/api/auth/openrouter/connect/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+import { requestOrigin } from "@/lib/openrouter/gating";
+import { generatePkce, openRouterAuthorizeUrl } from "@/lib/openrouter/oauth";
+import { setPkceVerifier } from "@/lib/openrouter/session";
+import { rejectIfGated } from "../_guard";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(req: Request) {
+  const gated = rejectIfGated(req);
+  if (gated) return gated;
+
+  const { verifier, challenge } = generatePkce();
+  setPkceVerifier(verifier);
+  const callbackUrl = `${requestOrigin(req)}/api/auth/openrouter/callback`;
+  return NextResponse.redirect(openRouterAuthorizeUrl(callbackUrl, challenge));
+}

--- a/apps/hwp-lab/src/app/api/auth/openrouter/disconnect/route.ts
+++ b/apps/hwp-lab/src/app/api/auth/openrouter/disconnect/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { peekOpenRouterKeySource } from "@/lib/openrouter/resolveKey";
+import { openRouterEnvDefaultModel, peekOpenRouterKeySource } from "@/lib/openrouter/resolveKey";
 import { clearOpenRouterSession, getSelectedOpenRouterModel } from "@/lib/openrouter/session";
 import { rejectIfGated } from "../_guard";
 
@@ -14,5 +14,6 @@ export async function POST(req: Request) {
     connected: false,
     keySource: peekOpenRouterKeySource(),
     selectedModel: getSelectedOpenRouterModel(),
+    defaultModel: openRouterEnvDefaultModel(),
   });
 }

--- a/apps/hwp-lab/src/app/api/auth/openrouter/disconnect/route.ts
+++ b/apps/hwp-lab/src/app/api/auth/openrouter/disconnect/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
-import { clearOpenRouterSession } from "@/lib/openrouter/session";
+import { peekOpenRouterKeySource } from "@/lib/openrouter/resolveKey";
+import { clearOpenRouterSession, getSelectedOpenRouterModel } from "@/lib/openrouter/session";
 import { rejectIfGated } from "../_guard";
 
 export const runtime = "nodejs";
@@ -9,5 +10,9 @@ export async function POST(req: Request) {
   const gated = rejectIfGated(req);
   if (gated) return gated;
   clearOpenRouterSession();
-  return NextResponse.json({ connected: false, keySource: null, selectedModel: null });
+  return NextResponse.json({
+    connected: false,
+    keySource: peekOpenRouterKeySource(),
+    selectedModel: getSelectedOpenRouterModel(),
+  });
 }

--- a/apps/hwp-lab/src/app/api/auth/openrouter/disconnect/route.ts
+++ b/apps/hwp-lab/src/app/api/auth/openrouter/disconnect/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from "next/server";
+import { clearOpenRouterSession } from "@/lib/openrouter/session";
+import { rejectIfGated } from "../_guard";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(req: Request) {
+  const gated = rejectIfGated(req);
+  if (gated) return gated;
+  clearOpenRouterSession();
+  return NextResponse.json({ connected: false, keySource: null, selectedModel: null });
+}

--- a/apps/hwp-lab/src/app/api/auth/openrouter/model/route.ts
+++ b/apps/hwp-lab/src/app/api/auth/openrouter/model/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+import { isOpenRouterModelSlug } from "@/lib/openrouter/oauth";
+import { setSelectedOpenRouterModel } from "@/lib/openrouter/session";
+import { rejectIfGated } from "../_guard";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(req: Request) {
+  const gated = rejectIfGated(req);
+  if (gated) return gated;
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "요청 본문 JSON 파싱 실패." }, { status: 400 });
+  }
+  const raw = body && typeof body === "object" ? (body as { model?: unknown }).model : undefined;
+  const model = typeof raw === "string" ? raw.trim() : "";
+  if (!isOpenRouterModelSlug(model)) {
+    return NextResponse.json({ error: "유효한 OpenRouter 모델 슬러그가 필요합니다." }, { status: 400 });
+  }
+  setSelectedOpenRouterModel(model);
+  return NextResponse.json({ selectedModel: model });
+}

--- a/apps/hwp-lab/src/app/api/auth/openrouter/models/route.ts
+++ b/apps/hwp-lab/src/app/api/auth/openrouter/models/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+import { fetchOpenRouterCatalog } from "@/lib/openrouter/oauth";
+import { MissingOpenRouterKeyError, resolveOpenRouterKey } from "@/lib/openrouter/resolveKey";
+import { rejectIfGated } from "../_guard";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(req: Request) {
+  const gated = rejectIfGated(req);
+  if (gated) return gated;
+
+  let resolved: ReturnType<typeof resolveOpenRouterKey>;
+  try {
+    resolved = resolveOpenRouterKey();
+  } catch (e) {
+    if (e instanceof MissingOpenRouterKeyError) {
+      return NextResponse.json({ error: e.message }, { status: 409 });
+    }
+    throw e;
+  }
+
+  try {
+    const models = await fetchOpenRouterCatalog(resolved.key);
+    return NextResponse.json({ models, keySource: resolved.source });
+  } catch {
+    return NextResponse.json({ error: "OpenRouter model catalog could not be loaded." }, { status: 502 });
+  }
+}

--- a/apps/hwp-lab/src/app/api/auth/openrouter/openrouter-auth.test.ts
+++ b/apps/hwp-lab/src/app/api/auth/openrouter/openrouter-auth.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { GET as connect } from "./connect/route";
+import { GET as callback } from "./callback/route";
+import { GET as status } from "./status/route";
+import { POST as disconnect } from "./disconnect/route";
+import { GET as catalog } from "./models/route";
+import { POST as setModel } from "./model/route";
+import { resetOpenRouterSessionForTests, setPkceVerifier } from "@/lib/openrouter/session";
+
+const ENV_KEYS = ["AUTO_HWP_LOCAL_MODELS", "DEMO_STATIC", "NEXT_PUBLIC_DEMO", "DEMO_AI_MODE", "OPENROUTER_API_KEY"] as const;
+
+function req(path: string, init?: RequestInit): Request {
+  return new Request(`http://localhost:3000${path}`, init);
+}
+
+function leak(payload: string, secrets: string[]): void {
+  for (const secret of secrets) {
+    expect(payload, `response must not contain ${secret}`).not.toContain(secret);
+  }
+}
+
+describe("openrouter auth routes", () => {
+  const saved: Partial<Record<(typeof ENV_KEYS)[number], string | undefined>> = {};
+
+  beforeEach(() => {
+    resetOpenRouterSessionForTests();
+    for (const key of ENV_KEYS) {
+      saved[key] = process.env[key];
+      delete process.env[key];
+    }
+    process.env.AUTO_HWP_LOCAL_MODELS = "1";
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    resetOpenRouterSessionForTests();
+    for (const key of ENV_KEYS) {
+      if (saved[key] === undefined) delete process.env[key];
+      else process.env[key] = saved[key];
+    }
+  });
+
+  it("returns 404 when the local-models flag is off", async () => {
+    delete process.env.AUTO_HWP_LOCAL_MODELS;
+    const res = await connect(req("/api/auth/openrouter/connect"));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 in DEMO_AI_MODE even with the flag on", async () => {
+    process.env.DEMO_AI_MODE = "1";
+    const res = await status(req("/api/auth/openrouter/status"));
+    expect(res.status).toBe(404);
+  });
+
+  it("redirects connect to OpenRouter with an S256 challenge and a request-origin callback", async () => {
+    const res = await connect(req("/api/auth/openrouter/connect", { headers: { host: "localhost:3000" } }));
+    expect(res.status).toBeGreaterThanOrEqual(300);
+    expect(res.status).toBeLessThan(400);
+    const location = res.headers.get("location") ?? "";
+    const dest = new URL(location);
+    expect(dest.origin).toBe("https://openrouter.ai");
+    expect(dest.pathname).toBe("/auth");
+    expect(dest.searchParams.get("code_challenge_method")).toBe("S256");
+    expect(dest.searchParams.get("code_challenge")).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(dest.searchParams.get("callback_url")).toBe("http://localhost:3000/api/auth/openrouter/callback");
+    leak(location, ["sk-or-"]);
+  });
+
+  it("exchanges the OAuth code on the server and never puts the key in the redirect", async () => {
+    setPkceVerifier("test-verifier");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ key: "sk-or-test-session-key" }),
+      })),
+    );
+
+    const res = await callback(req("/api/auth/openrouter/callback?code=oauth-code-not-a-key"));
+    expect(res.status).toBeGreaterThanOrEqual(300);
+    expect(res.status).toBeLessThan(400);
+    const location = res.headers.get("location") ?? "";
+    expect(location).toContain("/models");
+    leak(location, ["sk-or-test-session-key", "test-verifier"]);
+
+    const st = await status(req("/api/auth/openrouter/status"));
+    const body = (await st.json()) as { connected: boolean; keySource: string | null };
+    expect(body).toEqual({ connected: true, keySource: "session", selectedModel: null, defaultModel: "x-ai/grok-4.5" });
+    leak(JSON.stringify(body), ["sk-or-test-session-key"]);
+  });
+
+  it("disconnect wipes the in-memory key", async () => {
+    setPkceVerifier("test-verifier");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ key: "sk-or-test-session-key" }),
+      })),
+    );
+    await callback(req("/api/auth/openrouter/callback?code=oauth-code-not-a-key"));
+    const gone = await disconnect(req("/api/auth/openrouter/disconnect", { method: "POST" }));
+    const body = (await gone.json()) as { connected: boolean };
+    expect(body.connected).toBe(false);
+    const st = await (await status(req("/api/auth/openrouter/status"))).json();
+    expect(st.connected).toBe(false);
+    expect(st.keySource).toBeNull();
+    leak(JSON.stringify(st), ["sk-or-test-session-key"]);
+  });
+
+  it("stores an explicit model slug without echoing any key", async () => {
+    process.env.OPENROUTER_API_KEY = "env-only-key";
+    const res = await setModel(
+      req("/api/auth/openrouter/model", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ model: "x-ai/grok-4.5" }),
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { selectedModel: string };
+    expect(body.selectedModel).toBe("x-ai/grok-4.5");
+    leak(JSON.stringify(body), ["env-only-key"]);
+  });
+
+  it("proxies the catalog with the resolved key and returns only id/name", async () => {
+    process.env.OPENROUTER_API_KEY = "env-only-key";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: unknown, init?: RequestInit) => {
+        expect(String(url)).toBe("https://openrouter.ai/api/v1/models");
+        expect(String(init?.headers && (init.headers as Record<string, string>).Authorization)).toBe("Bearer env-only-key");
+        return {
+          ok: true,
+          json: async () => ({
+            data: [
+              { id: "x-ai/grok-4.5", name: "Grok 4.5", extra: "drop-me" },
+              { id: "not a slug", name: "bad" },
+            ],
+          }),
+        };
+      }),
+    );
+    const res = await catalog(req("/api/auth/openrouter/models"));
+    const body = (await res.json()) as { models: Array<{ id: string; name: string }>; keySource: string };
+    expect(body.keySource).toBe("env");
+    expect(body.models).toEqual([{ id: "x-ai/grok-4.5", name: "Grok 4.5" }]);
+    leak(JSON.stringify(body), ["env-only-key"]);
+  });
+});

--- a/apps/hwp-lab/src/app/api/auth/openrouter/openrouter-auth.test.ts
+++ b/apps/hwp-lab/src/app/api/auth/openrouter/openrouter-auth.test.ts
@@ -121,7 +121,12 @@ describe("openrouter auth routes", () => {
     await callback(req("/api/auth/openrouter/callback?code=oauth-code-not-a-key"));
     const gone = await disconnect(req("/api/auth/openrouter/disconnect", { method: "POST" }));
     const body = (await gone.json()) as { connected: boolean; keySource: string | null };
-    expect(body).toEqual({ connected: false, keySource: "env", selectedModel: null });
+    expect(body).toEqual({
+      connected: false,
+      keySource: "env",
+      selectedModel: null,
+      defaultModel: "x-ai/grok-4.5",
+    });
     leak(JSON.stringify(body), ["sk-or-test-session-key", "env-only-key"]);
   });
 

--- a/apps/hwp-lab/src/app/api/auth/openrouter/openrouter-auth.test.ts
+++ b/apps/hwp-lab/src/app/api/auth/openrouter/openrouter-auth.test.ts
@@ -108,6 +108,23 @@ describe("openrouter auth routes", () => {
     leak(JSON.stringify(st), ["sk-or-test-session-key"]);
   });
 
+  it("disconnect reports env as keySource when the env key remains", async () => {
+    process.env.OPENROUTER_API_KEY = "env-only-key";
+    setPkceVerifier("test-verifier");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ key: "sk-or-test-session-key" }),
+      })),
+    );
+    await callback(req("/api/auth/openrouter/callback?code=oauth-code-not-a-key"));
+    const gone = await disconnect(req("/api/auth/openrouter/disconnect", { method: "POST" }));
+    const body = (await gone.json()) as { connected: boolean; keySource: string | null };
+    expect(body).toEqual({ connected: false, keySource: "env", selectedModel: null });
+    leak(JSON.stringify(body), ["sk-or-test-session-key", "env-only-key"]);
+  });
+
   it("stores an explicit model slug without echoing any key", async () => {
     process.env.OPENROUTER_API_KEY = "env-only-key";
     const res = await setModel(

--- a/apps/hwp-lab/src/app/api/auth/openrouter/status/route.ts
+++ b/apps/hwp-lab/src/app/api/auth/openrouter/status/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { DEFAULT_OPENROUTER_MODEL, peekOpenRouterKeySource, resolveOpenRouterModel } from "@/lib/openrouter/resolveKey";
+import { openRouterEnvDefaultModel, peekOpenRouterKeySource } from "@/lib/openrouter/resolveKey";
 import { getOpenRouterSessionKey, getSelectedOpenRouterModel } from "@/lib/openrouter/session";
 import { rejectIfGated } from "../_guard";
 
@@ -16,6 +16,6 @@ export async function GET(req: Request) {
     connected,
     keySource,
     selectedModel: getSelectedOpenRouterModel(),
-    defaultModel: resolveOpenRouterModel() || DEFAULT_OPENROUTER_MODEL,
+    defaultModel: openRouterEnvDefaultModel(),
   });
 }

--- a/apps/hwp-lab/src/app/api/auth/openrouter/status/route.ts
+++ b/apps/hwp-lab/src/app/api/auth/openrouter/status/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server";
+import { DEFAULT_OPENROUTER_MODEL, peekOpenRouterKeySource, resolveOpenRouterModel } from "@/lib/openrouter/resolveKey";
+import { getOpenRouterSessionKey, getSelectedOpenRouterModel } from "@/lib/openrouter/session";
+import { rejectIfGated } from "../_guard";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(req: Request) {
+  const gated = rejectIfGated(req);
+  if (gated) return gated;
+
+  const connected = Boolean(getOpenRouterSessionKey());
+  const keySource = peekOpenRouterKeySource();
+  return NextResponse.json({
+    connected,
+    keySource,
+    selectedModel: getSelectedOpenRouterModel(),
+    defaultModel: resolveOpenRouterModel() || DEFAULT_OPENROUTER_MODEL,
+  });
+}

--- a/apps/hwp-lab/src/app/api/hwp-edit/demo.test.ts
+++ b/apps/hwp-lab/src/app/api/hwp-edit/demo.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { GET, POST } from "./route";
 import { readDemoConfig, resetMemoryCounters } from "./demo";
 import { demoAiHttpError } from "../../../lib/demoAiResponse";
+import { resetOpenRouterSessionForTests } from "@/lib/openrouter/session";
 
 const ORIGIN = "https://demo.test";
 
@@ -52,6 +53,7 @@ describe("hwp-edit — 공개 데모 모드", () => {
   const saved = { ...process.env };
 
   beforeEach(() => {
+    resetOpenRouterSessionForTests();
     resetMemoryCounters();
     process.env.DEMO_AI_MODE = "1";
     process.env.OPENROUTER_API_KEY = "test-only-key";
@@ -447,7 +449,7 @@ describe("hwp-edit — 공개 데모 모드", () => {
 
   // ── ⑥ GET 프로브 ──────────────────────────────────────────────────────────────────────────────
   it("GET: 키·비밀 없는 rate-limit store·실제 cap을 함께 진단한다", async () => {
-    const live = (await (await GET()).json()) as {
+    const live = (await (await GET(new Request("http://localhost/api/hwp-edit"))).json()) as {
       mode: string;
       provider: string;
       model: string;
@@ -482,17 +484,17 @@ describe("hwp-edit — 공개 데모 모드", () => {
       new Response(JSON.stringify([{ result: "PONG" }]), { status: 200, headers: { "content-type": "application/json" } }),
     );
     vi.stubGlobal("fetch", probeFetch);
-    const durable = (await (await GET()).json()) as { rate_limit: { store: string; durable: boolean } };
+    const durable = (await (await GET(new Request("http://localhost/api/hwp-edit"))).json()) as { rate_limit: { store: string; durable: boolean } };
     expect(durable.rate_limit).toEqual(expect.objectContaining({ store: "upstash", durable: true }));
     expect(probeFetch).toHaveBeenCalledTimes(1);
 
     // 같은 warm instance의 공개 GET은 60초 캐시를 써 저장소를 매번 두드리지 않는다.
-    await GET();
+    await GET(new Request("http://localhost/api/hwp-edit"));
     expect(probeFetch).toHaveBeenCalledTimes(1);
 
     resetMemoryCounters();
     vi.stubGlobal("fetch", vi.fn(async () => new Response("unauthorized", { status: 401 })));
-    const unreachable = (await (await GET()).json()) as {
+    const unreachable = (await (await GET(new Request("http://localhost/api/hwp-edit"))).json()) as {
       rate_limit: { store: string; durable: boolean; store_configured: boolean; configuration_valid: boolean };
     };
     expect(unreachable.rate_limit).toEqual(
@@ -500,7 +502,7 @@ describe("hwp-edit — 공개 데모 모드", () => {
     );
 
     delete process.env.OPENROUTER_API_KEY;
-    const off = (await (await GET()).json()) as { mode: string; configured: boolean; message: string };
+    const off = (await (await GET(new Request("http://localhost/api/hwp-edit"))).json()) as { mode: string; configured: boolean; message: string };
     expect(off.mode).toBe("static");
     expect(off.configured).toBe(false);
     expect(off.message).toContain("구성되지 않았습니다");
@@ -510,6 +512,7 @@ describe("hwp-edit — 공개 데모 모드", () => {
 describe("hwp-edit — BYOK 경로 무변경(데모 모드 꺼짐)", () => {
   const saved = { ...process.env };
   beforeEach(() => {
+    resetOpenRouterSessionForTests();
     resetMemoryCounters();
     delete process.env.DEMO_AI_MODE;
     delete process.env.OPENROUTER_API_KEY;
@@ -537,7 +540,7 @@ describe("hwp-edit — BYOK 경로 무변경(데모 모드 꺼짐)", () => {
   });
 
   it("GET 도 기존 계약(mock) 그대로", async () => {
-    const data = (await (await GET()).json()) as { mode: string; provider: string };
+    const data = (await (await GET(new Request("http://localhost/api/hwp-edit"))).json()) as { mode: string; provider: string };
     expect(data).toMatchObject({ mode: "mock", provider: "mock" });
   });
 });

--- a/apps/hwp-lab/src/app/api/hwp-edit/route.openrouter-pkce.test.ts
+++ b/apps/hwp-lab/src/app/api/hwp-edit/route.openrouter-pkce.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { GET, POST } from "./route";
+import { resetOpenRouterSessionForTests, setOpenRouterSessionKey, setSelectedOpenRouterModel } from "@/lib/openrouter/session";
+
+const ENV_KEYS = ["OPENROUTER_API_KEY", "ANTHROPIC_API_KEY", "AUTO_HWP_OPENROUTER_MODEL", "AUTO_HWP_LOCAL_MODELS"] as const;
+
+const OK = {
+  choices: [
+    {
+      message: {
+        content: '[{"intent":"SetParagraphText","section":0,"block":2,"text":"ok"}]',
+        annotations: [],
+      },
+    },
+  ],
+};
+
+function sseStream(chunks: string[]): ReadableStream<Uint8Array> {
+  const enc = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const c of chunks) controller.enqueue(enc.encode(c));
+      controller.close();
+    },
+  });
+}
+
+const SSE_EMIT = [
+  'data: {"choices":[{"delta":{"content":"[{\\"intent\\":\\"SetParagraphText\\",\\"section\\":0,\\"block\\":2,\\"text\\":\\"ok\\"}]"}}]}\n\n',
+  'data: {"choices":[{"finish_reason":"stop"}]}\n\n',
+  "data: [DONE]\n\n",
+];
+
+async function readNdjson(res: Response): Promise<Array<{ type: string }>> {
+  const text = await res.text();
+  return text
+    .split("\n")
+    .map((l) => l.trim())
+    .filter(Boolean)
+    .map((l) => JSON.parse(l) as { type: string });
+}
+
+describe("hwp-edit — OpenRouter PKCE session + explicit model", () => {
+  const saved: Partial<Record<(typeof ENV_KEYS)[number], string | undefined>> = {};
+  let calls: RequestInit[];
+
+  beforeEach(() => {
+    resetOpenRouterSessionForTests();
+    for (const key of ENV_KEYS) {
+      saved[key] = process.env[key];
+      delete process.env[key];
+    }
+    calls = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: unknown, init: RequestInit) => {
+        calls.push(init);
+        const body = JSON.parse(String(init.body ?? "{}")) as { stream?: boolean };
+        if (body.stream) {
+          return { ok: true, body: sseStream(SSE_EMIT) } as unknown as Response;
+        }
+        return { ok: true, json: async () => OK, text: async () => "" } as unknown as Response;
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    resetOpenRouterSessionForTests();
+    for (const key of ENV_KEYS) {
+      if (saved[key] === undefined) delete process.env[key];
+      else process.env[key] = saved[key];
+    }
+  });
+
+  it("routes PKCE session + no env to openrouter (does not silently use anthropic/mock)", async () => {
+    process.env.ANTHROPIC_API_KEY = "anthropic-should-not-win";
+    setOpenRouterSessionKey("session-only-key");
+
+    const probe = (await (await GET(new Request("http://localhost/api/hwp-edit"))).json()) as { provider: string; keySource: string; mode: string };
+    expect(probe).toMatchObject({ provider: "openrouter", keySource: "session", mode: "live" });
+
+    const res = await POST(
+      new Request("http://localhost/api/hwp-edit", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ instruction: "다듬어", anchors: [], docContext: "" }),
+      }),
+    );
+    const data = (await res.json()) as { provider: string; keySource: string; mode: string };
+    expect(data).toMatchObject({ provider: "openrouter", keySource: "session", mode: "live" });
+    expect(calls.length).toBeGreaterThan(0);
+    const auth = (calls[0].headers as Record<string, string>).Authorization;
+    expect(auth).toBe("Bearer session-only-key");
+    expect(JSON.stringify(data)).not.toContain("session-only-key");
+    expect(JSON.stringify(data)).not.toContain("anthropic-should-not-win");
+  });
+
+  it("puts the explicit model on both streaming and non-streaming OpenRouter requests", async () => {
+    process.env.OPENROUTER_API_KEY = "env-key";
+    setSelectedOpenRouterModel("stored/should-lose");
+
+    const nonStream = await POST(
+      new Request("http://localhost/api/hwp-edit", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ instruction: "다듬어", anchors: [], docContext: "", model: "test/explicit-model" }),
+      }),
+    );
+    expect(nonStream.status).toBe(200);
+    const nonStreamBody = JSON.parse(String(calls[0].body)) as { model: string };
+    expect(nonStreamBody.model).toBe("test/explicit-model");
+
+    calls.length = 0;
+    const stream = await POST(
+      new Request("http://localhost/api/hwp-edit?stream=1", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ instruction: "다듬어", anchors: [], docContext: "", model: "test/stream-model" }),
+      }),
+    );
+    expect(stream.headers.get("X-Auto-Hwp-Key-Source")).toBe("env");
+    const events = await readNdjson(stream);
+    expect(events.some((e) => e.type === "intents")).toBe(true);
+    const streamBody = JSON.parse(String(calls[0].body)) as { model: string };
+    expect(streamBody.model).toBe("test/stream-model");
+  });
+
+  it("uses the stored selection when the request does not name a model", async () => {
+    process.env.OPENROUTER_API_KEY = "env-key";
+    setSelectedOpenRouterModel("session/stored-model");
+    await POST(
+      new Request("http://localhost/api/hwp-edit", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ instruction: "다듬어", anchors: [], docContext: "" }),
+      }),
+    );
+    expect(JSON.parse(String(calls[0].body)).model).toBe("session/stored-model");
+  });
+});

--- a/apps/hwp-lab/src/app/api/hwp-edit/route.test.ts
+++ b/apps/hwp-lab/src/app/api/hwp-edit/route.test.ts
@@ -4,6 +4,7 @@
 // additive `citations` on the response. The intents whitelist/validation lane is unchanged.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { POST } from "./route";
+import { resetOpenRouterSessionForTests } from "@/lib/openrouter/session";
 
 // A canned OpenRouter (OpenAI-compatible) success body: JSON intents in `content` + web-search sources in
 // `annotations` (the shape the web plugin returns).
@@ -35,6 +36,7 @@ describe("hwp-edit route — web-search plugin + citations (Feature A)", () => {
   let calls: { url: unknown; init: RequestInit }[];
 
   beforeEach(() => {
+    resetOpenRouterSessionForTests();
     process.env.OPENROUTER_API_KEY = "test-key"; // force the openrouter provider (checked first)
     delete process.env.ANTHROPIC_API_KEY;
     calls = [];
@@ -97,6 +99,7 @@ describe("hwp-edit route — multimodal attachments (image vision + doc text)", 
   const IMG = "data:image/png;base64,iVBORw0KGgoAAAANSU=";
 
   beforeEach(() => {
+    resetOpenRouterSessionForTests();
     process.env.OPENROUTER_API_KEY = "test-key";
     delete process.env.ANTHROPIC_API_KEY;
     calls = [];
@@ -233,6 +236,7 @@ describe("hwp-edit route — agentic streaming (tool-calling loop + NDJSON Agent
   let searchCalls: RequestInit[]; // captured web_search sub-call inits
 
   beforeEach(() => {
+    resetOpenRouterSessionForTests();
     process.env.OPENROUTER_API_KEY = "test-key";
     delete process.env.ANTHROPIC_API_KEY;
     streamCalls = [];

--- a/apps/hwp-lab/src/app/api/hwp-edit/route.ts
+++ b/apps/hwp-lab/src/app/api/hwp-edit/route.ts
@@ -18,6 +18,13 @@ import {
   validateResponse,
 } from "@auto-hwp/ai-protocol";
 import { demoProbe, handleDemoEdit, isDemoAiMode } from "./demo";
+import { localModelsDeniedReason } from "@/lib/openrouter/gating";
+import {
+  MissingOpenRouterKeyError,
+  peekOpenRouterKeySource,
+  resolveOpenRouterKey,
+  resolveOpenRouterModel,
+} from "@/lib/openrouter/resolveKey";
 
 // @anthropic-ai/sdk 는 route handler(Node.js 런타임)에서만 사용. edge 런타임 선언 금지(이슈 §함정).
 // API 키/LLM 코드는 이 서버 전용 모듈에만 존재 — 클라이언트 번들에 절대 포함되지 않는다(R6).
@@ -162,13 +169,8 @@ async function liveIntents(
   return validateResponse(text, { onDrop: (reason) => console.warn(`[hwp-edit] ${reason}`) });
 }
 
-// OpenRouter default model(사용자 선택). env `AUTO_HWP_OPENROUTER_MODEL`로 언제든 override(정확한 슬러그).
-// x-ai/grok-4.5 는 OpenRouter 상 input_modalities = ["text","image","file"] — vision 지원(2026-07 실측).
-// 그래서 이미지 첨부는 별도 vision 모델로 스왑하지 않고 이 모델로 곧장 content-parts 를 보낸다. 혹시
-// 비전 미지원 모델로 override 한 경우를 대비해 `AUTO_HWP_OPENROUTER_VISION_MODEL` 로 이미지 요청 전용
-// 모델을 지정할 수 있다(미지정이면 기본 모델 그대로 — 기본이 vision 이므로 안전).
-const OPENROUTER_MODEL = process.env.AUTO_HWP_OPENROUTER_MODEL || "x-ai/grok-4.5";
-const OPENROUTER_VISION_MODEL = process.env.AUTO_HWP_OPENROUTER_VISION_MODEL || OPENROUTER_MODEL;
+// OpenRouter 모델은 `resolveOpenRouterModel` 이 요청마다 고른다(명시 선택 > 세션 > env > 기본).
+// 명시 선택이 있으면 vision 모델로 조용히 바꾸지 않는다(issue #56 no-silent-fallback).
 
 /** OpenRouter(OpenAI 호환 Chat Completions) 경로. 키는 이 서버 핸들러 밖으로 나가지 않는다(R6).
  *  system/user 프롬프트(R5 펜스·화이트리스트·doc-context)는 Anthropic 경로와 동일하게 ai-protocol이 조립.
@@ -183,6 +185,7 @@ async function openRouterIntents(
   docContext: string,
   webSearch: boolean,
   attachments: Attachment[],
+  model: string,
 ): Promise<{ intents: Intent[]; citations: Citation[] }> {
   // 멀티모달: 이미지 첨부가 있으면 OpenAI content-PARTS 로 유저 메시지를 조립하고(vision), 이미지 지원
   // 모델을 쓴다. 이미지가 없으면 기존 STRING content 그대로(back-compat). 문서 첨부의 텍스트는 두 경로
@@ -192,7 +195,7 @@ async function openRouterIntents(
     ? buildUserMessageParts({ instruction, anchors, docContext, attachments })
     : buildUserMessage({ instruction, anchors, docContext, attachments });
   const body: Record<string, unknown> = {
-    model: hasImage ? OPENROUTER_VISION_MODEL : OPENROUTER_MODEL,
+    model,
     max_tokens: 4096,
     messages: [
       { role: "system", content: buildSystemPrompt() },
@@ -348,7 +351,7 @@ async function streamOpenRouterTurn(
 /** web_search 툴 실행: OpenRouter web 플러그인(`plugins:[{id:"web"}]`)으로 별도 검색 API 키 없이 서버사이드
  *  검색을 수행하는 NON-스트리밍 서브콜. 요약 텍스트(툴 결과로 모델에 되돌림)와 url_citation 근거를 돌려준다.
  *  R5: 결과는 참고 DATA — 호출부가 tool 롤 메시지로 주입한다(지시로 취급하지 않는다). */
-async function execWebSearch(apiKey: string, query: string): Promise<{ content: string; citations: Citation[] }> {
+async function execWebSearch(apiKey: string, query: string, model: string): Promise<{ content: string; citations: Citation[] }> {
   const res = await fetch(OPENROUTER_URL, {
     method: "POST",
     headers: {
@@ -358,7 +361,7 @@ async function execWebSearch(apiKey: string, query: string): Promise<{ content: 
       "X-Title": "auto-hwp",
     },
     body: JSON.stringify({
-      model: OPENROUTER_MODEL,
+      model,
       max_tokens: 1024,
       plugins: [{ id: "web" }],
       messages: [
@@ -378,7 +381,7 @@ async function execWebSearch(apiKey: string, query: string): Promise<{ content: 
 /** OpenRouter tool-calling 에이전트 루프. 각 단계를 emit(AgentEvent)로 스트리밍한다. 모델이 web_search 를
  *  스스로 호출하면 실행 후 tool 결과를 대화에 넣고 다시 부른다. emit_intents(터미널)면 검증 후 intents 이벤트로
  *  종료. AGENT_MAX_ITERS 를 넘기면 빈 intents 로 종료(무한 루프 방지). */
-async function runOpenRouterAgent(apiKey: string, messages: ChatMsg[], emit: (ev: AgentEvent) => void): Promise<void> {
+async function runOpenRouterAgent(apiKey: string, messages: ChatMsg[], emit: (ev: AgentEvent) => void, model: string): Promise<void> {
   const tools = agentToolSchemas();
   let searchCount = 0;
   for (let iter = 0; iter < AGENT_MAX_ITERS; iter++) {
@@ -390,7 +393,7 @@ async function runOpenRouterAgent(apiKey: string, messages: ChatMsg[], emit: (ev
     const forceFinal = iter === AGENT_MAX_ITERS - 1 || searchCount >= AGENT_MAX_SEARCHES;
     const turn = await streamOpenRouterTurn(
       apiKey,
-      { model: OPENROUTER_MODEL, max_tokens: 4096, messages, tools, tool_choice: forceFinal ? "none" : "auto" },
+      { model, max_tokens: 4096, messages, tools, tool_choice: forceFinal ? "none" : "auto" },
       (text) => emit({ type: "thinking_delta", text }),
     );
 
@@ -421,7 +424,7 @@ async function runOpenRouterAgent(apiKey: string, messages: ChatMsg[], emit: (ev
         const query = typeof args.query === "string" ? args.query : "";
         emit({ type: "status", phase: "searching" });
         emit({ type: "tool_call", tool: "web_search", args: { query } });
-        const { content, citations } = await execWebSearch(apiKey, query);
+        const { content, citations } = await execWebSearch(apiKey, query, model);
         emit({ type: "tool_result", tool: "web_search", citations });
         messages.push({ role: "tool", tool_call_id: tc.id, name: "web_search", content });
       } else {
@@ -467,6 +470,7 @@ function buildAgentStream(
   docContext: string,
   attachments: Attachment[],
   history: ChatTurn[],
+  requestedModel?: string,
 ): ReadableStream<Uint8Array> {
   const enc = new TextEncoder();
   return new ReadableStream<Uint8Array>({
@@ -479,19 +483,23 @@ function buildAgentStream(
           await runAnthropicAgent(process.env.ANTHROPIC_API_KEY!, instruction, anchors, docContext, attachments, emit);
         } else {
           // OpenRouter tool-calling 루프. 시스템(에이전트 프롬프트) + 메모리(직전 턴) + 유저 turn 을 조립한다.
+          // 키는 요청 시점에 재검증한다 — HMR 로 세션이 비면 env 폴백 또는 명시 에러(침묵 mock 금지).
+          const { key } = resolveOpenRouterKey();
           const hasImage = attachments.some((a) => a.kind === "image" && typeof a.dataUrl === "string" && a.dataUrl.length > 0);
+          const model = resolveOpenRouterModel(requestedModel, { hasImage });
           const userContent = hasImage
             ? buildUserMessageParts({ instruction, anchors, docContext, attachments })
             : buildUserMessage({ instruction, anchors, docContext, attachments });
           const messages: ChatMsg[] = [{ role: "system", content: buildAgentSystemPrompt() }];
           for (const turn of history) messages.push({ role: turn.role, content: turn.text });
           messages.push({ role: "user", content: userContent });
-          await runOpenRouterAgent(process.env.OPENROUTER_API_KEY!, messages, emit);
+          await runOpenRouterAgent(key, messages, emit, model);
         }
       } catch (e) {
         const detail = e && typeof e === "object" && "message" in e ? String((e as { message: unknown }).message) : String(e);
-        console.error("[hwp-edit] agent stream failed:", detail);
-        emit({ type: "error", message: `에이전트 실패: ${detail}` });
+        const safe = detail.replace(/sk-or-[a-zA-Z0-9_-]+/g, "[redacted]");
+        console.error("[hwp-edit] agent stream failed:", safe);
+        emit({ type: "error", message: `에이전트 실패: ${safe}` });
       } finally {
         controller.close();
       }
@@ -499,19 +507,33 @@ function buildAgentStream(
   });
 }
 
-/** 프로바이더 우선순위: OpenRouter(있으면) → Anthropic → mock. */
+/** 프로바이더 우선순위: OpenRouter(세션 키 또는 env) → Anthropic → mock.
+ *  PKCE 세션만 있고 env 가 없어도 openrouter 로 간다 — anthropic/mock 침묵 폴백 금지. */
 function activeProvider(): "openrouter" | "anthropic" | "mock" {
-  if (process.env.OPENROUTER_API_KEY) return "openrouter";
+  if (peekOpenRouterKeySource()) return "openrouter";
   if (process.env.ANTHROPIC_API_KEY) return "anthropic";
   return "mock";
 }
 
-export async function GET() {
+export async function GET(req: Request) {
   // 공개 데모 모드(DEMO_AI_MODE=1): 프로바이더/모델을 서버가 고정하므로 프로브도 데모 계약으로 답한다.
   if (isDemoAiMode()) return demoProbe();
   const provider = activeProvider();
-  const model = provider === "openrouter" ? OPENROUTER_MODEL : provider === "anthropic" ? "claude-opus-4-8" : null;
-  return NextResponse.json({ mode: provider === "mock" ? "mock" : "live", provider, model });
+  const model = provider === "openrouter" ? resolveOpenRouterModel() : provider === "anthropic" ? "claude-opus-4-8" : null;
+  const payload: {
+    mode: "mock" | "live";
+    provider: "openrouter" | "anthropic" | "mock";
+    model: string | null;
+    keySource: "session" | "env" | null;
+    localModels?: true;
+  } = {
+    mode: provider === "mock" ? "mock" : "live",
+    provider,
+    model,
+    keySource: peekOpenRouterKeySource(),
+  };
+  if (!localModelsDeniedReason(req)) payload.localModels = true;
+  return NextResponse.json(payload);
 }
 
 export async function POST(req: Request) {
@@ -535,6 +557,9 @@ export async function POST(req: Request) {
   // Feature A: 명시적 웹 검색 플래그(선택) — validateRequest 계약(instruction/anchors/docContext) 밖의
   // 부가 필드라 raw body에서 직접 읽는다(boolean 아니면 false). intents 스키마와 무관(요청 부가 옵션).
   const webSearch = typeof (body as { webSearch?: unknown }).webSearch === "boolean" ? (body as { webSearch: boolean }).webSearch : false;
+  // 모델 슬러그(선택, additive) — validateRequest 계약 밖의 부가 필드. 명시 선택이 스트리밍/비스트리밍
+  // 양쪽에 그대로 반영된다. 없거나 비문자면 세션 선택 → env 기본.
+  const requestedModel = typeof (body as { model?: unknown }).model === "string" ? (body as { model: string }).model : undefined;
 
   const provider = activeProvider();
 
@@ -543,31 +568,49 @@ export async function POST(req: Request) {
   // 대화 메모리(history, 바운드)를 모델 messages 에 접는다. 비스트리밍 JSON POST(아래)는 그대로 둔다.
   if (new URL(req.url).searchParams.get("stream") === "1") {
     const history = readHistory(body);
-    const stream = buildAgentStream(provider, instruction, anchors, docContext, attachments, history);
-    return new Response(stream, {
-      headers: {
-        "Content-Type": "application/x-ndjson; charset=utf-8",
-        "Cache-Control": "no-cache, no-transform",
-        "X-Accel-Buffering": "no", // 프록시 버퍼링 비활성(즉시 플러시)
-      },
-    });
+    const stream = buildAgentStream(provider, instruction, anchors, docContext, attachments, history, requestedModel);
+    const headers: Record<string, string> = {
+      "Content-Type": "application/x-ndjson; charset=utf-8",
+      "Cache-Control": "no-cache, no-transform",
+      "X-Accel-Buffering": "no", // 프록시 버퍼링 비활성(즉시 플러시)
+    };
+    const keySource = peekOpenRouterKeySource();
+    if (keySource) headers["X-Auto-Hwp-Key-Source"] = keySource;
+    return new Response(stream, { headers });
   }
 
   if (provider === "mock") {
     // mock 모드 — 결정적 편집 제안(키 없이 전체 플로우 완주 가능). mock은 웹 검색을 하지 않으므로 근거 없음.
-    return NextResponse.json({ intents: mockIntents(instruction, anchors, docContext), citations: [], mode: "mock", provider: "mock" });
+    return NextResponse.json({ intents: mockIntents(instruction, anchors, docContext), citations: [], mode: "mock", provider: "mock", keySource: null });
   }
   try {
     if (provider === "openrouter") {
-      const { intents, citations } = await openRouterIntents(process.env.OPENROUTER_API_KEY!, instruction, anchors, docContext, webSearch, attachments);
-      return NextResponse.json({ intents, citations, mode: "live", provider });
+      let resolved;
+      try {
+        resolved = resolveOpenRouterKey();
+      } catch (e) {
+        const message = e instanceof MissingOpenRouterKeyError ? e.message : "OpenRouter API key is not available.";
+        return NextResponse.json({ error: message }, { status: 502 });
+      }
+      const hasImage = attachments.some((a) => a.kind === "image" && typeof a.dataUrl === "string" && a.dataUrl.length > 0);
+      const { intents, citations } = await openRouterIntents(
+        resolved.key,
+        instruction,
+        anchors,
+        docContext,
+        webSearch,
+        attachments,
+        resolveOpenRouterModel(requestedModel, { hasImage }),
+      );
+      return NextResponse.json({ intents, citations, mode: "live", provider, keySource: resolved.source });
     }
     // Anthropic 경로는 내장 웹 검색이 없다(Grok과 달리) — 근거 없음(빈 배열)으로 형태만 additive 유지.
     const intents = await liveIntents(process.env.ANTHROPIC_API_KEY!, instruction, anchors, docContext, attachments);
     return NextResponse.json({ intents, citations: [], mode: "live", provider });
   } catch (e) {
     const detail = e && typeof e === "object" && "message" in e ? String((e as { message: unknown }).message) : String(e);
-    console.error("[hwp-edit] live LLM call failed:", detail);
-    return NextResponse.json({ error: `LLM 호출 실패: ${detail}` }, { status: 502 });
+    const safe = detail.replace(/sk-or-[a-zA-Z0-9_-]+/g, "[redacted]");
+    console.error("[hwp-edit] live LLM call failed:", safe);
+    return NextResponse.json({ error: `LLM 호출 실패: ${safe}` }, { status: 502 });
   }
 }

--- a/apps/hwp-lab/src/app/models/ModelsPanel.tsx
+++ b/apps/hwp-lab/src/app/models/ModelsPanel.tsx
@@ -108,7 +108,7 @@ export function ModelsPanel() {
         connected: false,
         keySource: data.keySource ?? null,
         selectedModel: data.selectedModel ?? null,
-        defaultModel: data.defaultModel || status?.defaultModel || "x-ai/grok-4.5",
+        defaultModel: data.defaultModel || "x-ai/grok-4.5",
       });
       if (data.keySource) await loadCatalog();
       else setModels(null);

--- a/apps/hwp-lab/src/app/models/ModelsPanel.tsx
+++ b/apps/hwp-lab/src/app/models/ModelsPanel.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import styles from "./models.module.css";
+
+type KeySource = "session" | "env" | null;
+
+type Status = {
+  connected: boolean;
+  keySource: KeySource;
+  selectedModel: string | null;
+  defaultModel: string;
+};
+
+type CatalogEntry = { id: string; name: string };
+
+const ERRORS: Record<string, string> = {
+  missing_code: "인가 코드가 없습니다. 다시 연결해 주세요.",
+  missing_verifier: "인가 세션이 만료됐습니다. 다시 연결해 주세요.",
+  exchange_failed: "인가 코드를 키로 바꾸지 못했습니다. 다시 연결해 주세요.",
+};
+
+export function ModelsPanel() {
+  const [status, setStatus] = useState<Status | null>(null);
+  const [models, setModels] = useState<CatalogEntry[] | null>(null);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  const queryError = useMemo(() => {
+    if (typeof window === "undefined") return null;
+    const code = new URLSearchParams(window.location.search).get("error");
+    return code ? (ERRORS[code] ?? "연결에 실패했습니다. 다시 시도해 주세요.") : null;
+  }, []);
+
+  const loadStatus = useCallback(async () => {
+    const res = await fetch("/api/auth/openrouter/status", { method: "GET" });
+    if (res.status === 404) {
+      setError("로컬 Models 진입점은 이 서버에서 꺼져 있습니다.");
+      return;
+    }
+    if (!res.ok) throw new Error("상태를 읽지 못했습니다.");
+    const data = (await res.json()) as Status;
+    setStatus(data);
+  }, []);
+
+  const loadCatalog = useCallback(async () => {
+    const res = await fetch("/api/auth/openrouter/models", { method: "GET" });
+    if (!res.ok) {
+      setModels([]);
+      return;
+    }
+    const data = (await res.json()) as { models?: CatalogEntry[] };
+    setModels(Array.isArray(data.models) ? data.models : []);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    setError(queryError);
+    if (typeof window !== "undefined" && new URLSearchParams(window.location.search).get("connected") === "1") {
+      setNotice("OpenRouter에 연결했습니다. 아래에서 모델을 고르면 채팅·인라인 편집에 바로 쓰입니다.");
+    }
+    void (async () => {
+      try {
+        await loadStatus();
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [loadStatus, queryError]);
+
+  useEffect(() => {
+    if (!status?.keySource) return;
+    void loadCatalog();
+  }, [status?.keySource, loadCatalog]);
+
+  const onSelect = async (model: string) => {
+    setBusy("모델 저장 중…");
+    setError(null);
+    try {
+      const res = await fetch("/api/auth/openrouter/model", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ model }),
+      });
+      if (!res.ok) throw new Error("모델 선택을 저장하지 못했습니다.");
+      const data = (await res.json()) as { selectedModel?: string };
+      setStatus((prev) => (prev ? { ...prev, selectedModel: data.selectedModel ?? model } : prev));
+      setNotice(`선택한 모델: ${model}`);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const onDisconnect = async () => {
+    setBusy("연결 해제 중…");
+    setError(null);
+    try {
+      const res = await fetch("/api/auth/openrouter/disconnect", { method: "POST" });
+      if (!res.ok) throw new Error("연결을 끊지 못했습니다.");
+      setStatus({ connected: false, keySource: null, selectedModel: null, defaultModel: status?.defaultModel ?? "x-ai/grok-4.5" });
+      setModels(null);
+      setNotice("이 서버 메모리의 키를 지웠습니다. OpenRouter 대시보드의 키는 직접 폐기하세요.");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const currentModel = status?.selectedModel || status?.defaultModel || "";
+  const canSelect = Boolean(status?.keySource);
+
+  return (
+    <section className={styles.card} data-testid="openrouter-card">
+      <header className={styles.cardHead}>
+        <h2>Connect OpenRouter</h2>
+        <p>
+          OAuth PKCE(S256)로 연결합니다. 교환된 키는 이 개발 서버 메모리에만 있고, 브라우저는 연결
+          여부와 키 출처만 봅니다.
+        </p>
+      </header>
+
+      <dl className={styles.meta}>
+        <div>
+          <dt>연결</dt>
+          <dd data-testid="openrouter-connected">{status?.connected ? "연결됨" : "안 됨"}</dd>
+        </div>
+        <div>
+          <dt>키 출처</dt>
+          <dd data-testid="openrouter-key-source">{status?.keySource ?? "없음"}</dd>
+        </div>
+      </dl>
+
+      {error && (
+        <p className={styles.error} role="alert">
+          {error}
+        </p>
+      )}
+      {notice && (
+        <p className={styles.notice} role="status">
+          {notice}
+        </p>
+      )}
+
+      <div className={styles.actions}>
+        <a className={styles.primary} href="/api/auth/openrouter/connect" data-testid="openrouter-connect">
+          {status?.connected ? "다시 연결" : "Connect OpenRouter"}
+        </a>
+        {status?.connected && (
+          <button type="button" className={styles.secondary} onClick={() => void onDisconnect()} disabled={Boolean(busy)}>
+            연결 끊기
+          </button>
+        )}
+      </div>
+
+      {canSelect && (
+        <label className={styles.selectLabel}>
+          모델
+          <select
+            data-testid="openrouter-model"
+            value={currentModel}
+            disabled={Boolean(busy) || !models}
+            onChange={(e) => void onSelect(e.target.value)}
+          >
+            {!models && <option value={currentModel}>{currentModel || "카탈로그 불러오는 중…"}</option>}
+            {models && !models.some((m) => m.id === currentModel) && currentModel && (
+              <option value={currentModel}>{currentModel}</option>
+            )}
+            {models?.map((m) => (
+              <option key={m.id} value={m.id}>
+                {m.id === m.name ? m.id : `${m.name} (${m.id})`}
+              </option>
+            ))}
+          </select>
+        </label>
+      )}
+
+      {busy && (
+        <p className={styles.busy} role="status">
+          {busy}
+        </p>
+      )}
+
+      <p className={styles.footnote}>
+        연결 끊기는 이 서버 메모리만 지웁니다. OpenRouter에 남은 키는{" "}
+        <a href="https://openrouter.ai/settings/keys" target="_blank" rel="noreferrer">
+          OpenRouter 키 설정
+        </a>
+        에서 직접 폐기하세요.
+      </p>
+    </section>
+  );
+}

--- a/apps/hwp-lab/src/app/models/ModelsPanel.tsx
+++ b/apps/hwp-lab/src/app/models/ModelsPanel.tsx
@@ -103,8 +103,15 @@ export function ModelsPanel() {
     try {
       const res = await fetch("/api/auth/openrouter/disconnect", { method: "POST" });
       if (!res.ok) throw new Error("연결을 끊지 못했습니다.");
-      setStatus({ connected: false, keySource: null, selectedModel: null, defaultModel: status?.defaultModel ?? "x-ai/grok-4.5" });
-      setModels(null);
+      const data = (await res.json()) as Status;
+      setStatus({
+        connected: false,
+        keySource: data.keySource ?? null,
+        selectedModel: data.selectedModel ?? null,
+        defaultModel: data.defaultModel || status?.defaultModel || "x-ai/grok-4.5",
+      });
+      if (data.keySource) await loadCatalog();
+      else setModels(null);
       setNotice("이 서버 메모리의 키를 지웠습니다. OpenRouter 대시보드의 키는 직접 폐기하세요.");
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));

--- a/apps/hwp-lab/src/app/models/models.module.css
+++ b/apps/hwp-lab/src/app/models/models.module.css
@@ -1,0 +1,165 @@
+.page {
+  min-height: 100vh;
+  background: var(--ah-bg);
+  color: var(--ah-fg);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Malgun Gothic", "Apple SD Gothic Neo", sans-serif;
+}
+
+.main {
+  width: min(720px, calc(100% - 40px));
+  margin: 0 auto;
+  padding: 54px 0 88px;
+}
+
+.kicker {
+  margin: 0;
+  color: var(--ah-accent-ink-2);
+  font-size: 11px;
+  font-weight: 750;
+  letter-spacing: 0.1em;
+}
+
+.main h1 {
+  margin: 10px 0 0;
+  color: var(--ah-fg-strong);
+  font-size: clamp(30px, 5vw, 44px);
+  letter-spacing: -0.03em;
+}
+
+.lede {
+  max-width: 62ch;
+  margin: 16px 0 0;
+  color: var(--ah-muted);
+  font-size: 16px;
+  line-height: 1.75;
+}
+
+.card {
+  margin-top: 32px;
+  padding: 22px 22px 18px;
+  border: 1px solid var(--ah-line-2);
+  border-radius: 14px;
+  background: var(--ah-surface);
+}
+
+.cardHead h2 {
+  margin: 0;
+  color: var(--ah-fg-strong);
+  font-size: 18px;
+}
+
+.cardHead p {
+  margin: 8px 0 0;
+  color: var(--ah-fg-soft);
+  font-size: 13.5px;
+  line-height: 1.65;
+}
+
+.meta {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+  margin: 18px 0 0;
+}
+
+.meta div {
+  margin: 0;
+}
+
+.meta dt {
+  color: var(--ah-dim);
+  font-size: 11px;
+  font-weight: 650;
+  letter-spacing: 0.04em;
+}
+
+.meta dd {
+  margin: 4px 0 0;
+  color: var(--ah-fg-strong);
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 18px;
+}
+
+.primary,
+.secondary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px 14px;
+  border-radius: 8px;
+  font-size: 13.5px;
+  font-weight: 650;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.primary {
+  color: var(--ah-bg);
+  background: var(--ah-accent-ink);
+  border: 1px solid transparent;
+}
+
+.secondary {
+  color: var(--ah-fg);
+  background: var(--ah-surface-btn);
+  border: 1px solid var(--ah-line-3);
+}
+
+.secondary:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.selectLabel {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 18px;
+  color: var(--ah-fg-strong);
+  font-size: 13px;
+  font-weight: 650;
+}
+
+.selectLabel select {
+  padding: 8px 10px;
+  border: 1px solid var(--ah-line-3);
+  border-radius: 8px;
+  background: var(--ah-bg);
+  color: var(--ah-fg);
+  font-size: 13px;
+}
+
+.error,
+.notice,
+.busy {
+  margin: 14px 0 0;
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+.error {
+  color: #b42318;
+}
+
+.notice,
+.busy {
+  color: var(--ah-muted);
+}
+
+.footnote {
+  margin: 18px 0 0;
+  color: var(--ah-dim);
+  font-size: 12px;
+  line-height: 1.6;
+}
+
+.footnote a {
+  color: var(--ah-accent-ink);
+}

--- a/apps/hwp-lab/src/app/models/page.tsx
+++ b/apps/hwp-lab/src/app/models/page.tsx
@@ -3,7 +3,7 @@ import { headers } from "next/headers";
 import { notFound } from "next/navigation";
 import { SiteFooter } from "@/components/site/SiteFooter";
 import { SiteHeader } from "@/components/site/SiteHeader";
-import { hostnameOf, isDemoStaticBuild, isLocalModelsFlagOn, isLoopbackHostname } from "@/lib/openrouter/gating";
+import { localModelsDeniedReason } from "@/lib/openrouter/gating";
 import { ModelsPanel } from "./ModelsPanel";
 import styles from "./models.module.css";
 
@@ -18,10 +18,17 @@ export const metadata: Metadata = {
 };
 
 export default async function ModelsPage() {
-  if (STATIC_DEMO || !isLocalModelsFlagOn() || isDemoStaticBuild()) notFound();
+  if (STATIC_DEMO) notFound();
   const h = await headers();
-  const host = h.get("x-forwarded-host") || h.get("host");
-  if (!isLoopbackHostname(hostnameOf(host))) notFound();
+  const host = h.get("x-forwarded-host") || h.get("host") || "localhost";
+  const proto = h.get("x-forwarded-proto") || "http";
+  const req = new Request(`${proto}://${host}/models`, {
+    headers: {
+      host,
+      ...(h.get("x-forwarded-host") ? { "x-forwarded-host": h.get("x-forwarded-host")! } : {}),
+    },
+  });
+  if (localModelsDeniedReason(req)) notFound();
 
   return (
     <div className={styles.page}>

--- a/apps/hwp-lab/src/app/models/page.tsx
+++ b/apps/hwp-lab/src/app/models/page.tsx
@@ -1,0 +1,41 @@
+import type { Metadata } from "next";
+import { headers } from "next/headers";
+import { notFound } from "next/navigation";
+import { SiteFooter } from "@/components/site/SiteFooter";
+import { SiteHeader } from "@/components/site/SiteHeader";
+import { hostnameOf, isDemoStaticBuild, isLocalModelsFlagOn, isLoopbackHostname } from "@/lib/openrouter/gating";
+import { ModelsPanel } from "./ModelsPanel";
+import styles from "./models.module.css";
+
+const STATIC_DEMO = process.env.DEMO_STATIC === "1";
+
+export const dynamic = STATIC_DEMO ? "force-static" : "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Models",
+  description: "로컬 전용 OpenRouter 연결과 모델 선택.",
+  robots: { index: false, follow: false },
+};
+
+export default async function ModelsPage() {
+  if (STATIC_DEMO || !isLocalModelsFlagOn() || isDemoStaticBuild()) notFound();
+  const h = await headers();
+  const host = h.get("x-forwarded-host") || h.get("host");
+  if (!isLoopbackHostname(hostnameOf(host))) notFound();
+
+  return (
+    <div className={styles.page}>
+      <SiteHeader current="models" />
+      <main className={styles.main}>
+        <p className={styles.kicker}>LOCAL ONLY</p>
+        <h1>Models</h1>
+        <p className={styles.lede}>
+          이 화면은 로컬 개발 서버에서만 열립니다. OpenRouter 키는 브라우저에 내려가지 않고 이
+          서버 프로세스 메모리에만 있습니다.
+        </p>
+        <ModelsPanel />
+      </main>
+      <SiteFooter />
+    </div>
+  );
+}

--- a/apps/hwp-lab/src/app/robots.ts
+++ b/apps/hwp-lab/src/app/robots.ts
@@ -11,7 +11,7 @@ const SITE = (process.env.NEXT_PUBLIC_SITE_URL || `https://kwakseongjae.github.i
 
 export default function robots(): MetadataRoute.Robots {
   return {
-    rules: [{ userAgent: "*", allow: "/", disallow: ["/api/", "/d/"] }],
+    rules: [{ userAgent: "*", allow: "/", disallow: ["/api/", "/d/", "/models"] }],
     sitemap: `${SITE}/sitemap.xml`,
   };
 }

--- a/apps/hwp-lab/src/components/LabWorkspace.tsx
+++ b/apps/hwp-lab/src/components/LabWorkspace.tsx
@@ -107,6 +107,7 @@ export default function LabWorkspace() {
   // 아니면 빌드타임 env 폴백, 그것도 없으면 null(모델명 없이 성격만 설명한다). 하드코딩 금지.
   const [aiModel, setAiModel] = useState<string | null>(AI_MODEL_FALLBACK);
   const [aiProvider, setAiProvider] = useState<string | null>(null);
+  const [localModels, setLocalModels] = useState(false);
   const [badgeTip, setBadgeTip] = useState(false);
   const [doc, setDoc] = useState<Doc | null>(null);
   const [labError, setLabError] = useState<string | null>(null);
@@ -385,23 +386,30 @@ export default function LabWorkspace() {
       return;
     }
     let cancelled = false;
-    fetch(`${BASE}/api/hwp-edit`, { method: "GET" })
-      .then((r) => r.json())
-      .then((d: { mode?: Mode; provider?: string; model?: string | null }) => {
-        // 데모 라우트 모드에서 서버 키가 없으면 프로브가 "static"(=AI 없음)을 답한다 — mock 배지를
-        // 띄우면 "가짜 편집이라도 동작한다"는 거짓말이 되므로 그 값을 그대로 살린다.
-        if (cancelled) return;
-        setMode(d.mode === "live" ? "live" : d.mode === "static" ? "static" : "mock");
-        // 모델명은 **서버가 말한 것만** 쓴다(하드코딩 금지 — env 를 바꾸면 툴팁도 따라온다).
-        // 서버가 안 알려 주면 빌드타임 env 폴백, 그것도 없으면 모델명 없이 성격만 설명한다.
-        if (typeof d.model === "string" && d.model.trim()) setAiModel(d.model.trim());
-        if (typeof d.provider === "string" && d.provider.trim()) setAiProvider(d.provider.trim());
-      })
-      .catch(() => {
-        if (!cancelled) setMode("mock");
-      });
+    const probe = () => {
+      fetch(`${BASE}/api/hwp-edit`, { method: "GET" })
+        .then((r) => r.json())
+        .then((d: { mode?: Mode; provider?: string; model?: string | null; localModels?: boolean }) => {
+          // 데모 라우트 모드에서 서버 키가 없으면 프로브가 "static"(=AI 없음)을 답한다 — mock 배지를
+          // 띄우면 "가짜 편집이라도 동작한다"는 거짓말이 되므로 그 값을 그대로 살린다.
+          if (cancelled) return;
+          setMode(d.mode === "live" ? "live" : d.mode === "static" ? "static" : "mock");
+          // 모델명은 **서버가 말한 것만** 쓴다(하드코딩 금지 — env 를 바꾸면 툴팁도 따라온다).
+          // 서버가 안 알려 주면 빌드타임 env 폴백, 그것도 없으면 모델명 없이 성격만 설명한다.
+          if (typeof d.model === "string" && d.model.trim()) setAiModel(d.model.trim());
+          if (typeof d.provider === "string" && d.provider.trim()) setAiProvider(d.provider.trim());
+          setLocalModels(d.localModels === true);
+        })
+        .catch(() => {
+          if (!cancelled) setMode("mock");
+        });
+    };
+    probe();
+    // /models 에서 선택·연결하고 돌아오면 배지·요청 모델이 따라오도록 포커스마다 재조회.
+    window.addEventListener("focus", probe);
     return () => {
       cancelled = true;
+      window.removeEventListener("focus", probe);
     };
   }, []);
 
@@ -828,6 +836,8 @@ export default function LabWorkspace() {
       ...(opts?.attachments?.length ? { attachments: opts.attachments } : {}),
       // 대화 메모리(에이전틱 스트리밍): 직전 채팅 턴(바운드). 서버가 모델 messages 에 접는다.
       ...(opts?.history?.length ? { history: opts.history } : {}),
+      // 명시 모델(로컬 Models 선택). 서버 세션 선택이 정본이고, 클라가 알면 요청에도 실어 양 경로가 같다.
+      ...(aiModel ? { model: aiModel } : {}),
     };
 
     // ── 데모 프록시 경로 ──────────────────────────────────────────────────────────────────────────
@@ -919,7 +929,7 @@ export default function LabWorkspace() {
     // Feature A: 근거(출처)를 채팅으로 전달 — intents 반환 계약(Promise<Intent[]>)은 불변(InlineEditPanel 안전).
     if (opts?.onCitations) opts.onCitations(data.citations ?? []);
     return data.intents ?? [];
-  }, [adapter, askDemoAiConsent, demoAiOn, demoAiTransport]);
+  }, [adapter, aiModel, askDemoAiConsent, demoAiOn, demoAiTransport]);
 
   // R8: 폰트는 번들하지 않는다. 기본 NanumGothic 이 자동 등록되므로 PDF 는 곧바로 활성화되지만,
   // (기본 폰트 fetch 실패 등으로) 미주입 상태에서 PDF 를 누르면 이 폴백이 호출된다: 기본 폰트를 다시
@@ -1049,6 +1059,11 @@ export default function LabWorkspace() {
         </a>
         {/* 공개 데모 크롬(레포 링크)은 정적 데모(Pages)와 라우트 데모(Vercel) 양쪽에 붙는다 —
             full Next 배포에는 NEXT_PUBLIC_DEMO=1 이 없으므로 IS_DEMO 만으로는 사라진다. */}
+        {localModels && (
+          <a className="lab-gh-link" href={siteHref("/models")} data-testid="models-link" title="로컬 OpenRouter 연결 · 모델 선택">
+            Models
+          </a>
+        )}
         {(IS_DEMO || DEMO_AI_ROUTE) && (
           <a className="lab-gh-link" href="https://github.com/kwakseongjae/auto-hwp" target="_blank" rel="noreferrer" title="GitHub 저장소">
             GitHub <ExternalLink size={12} />

--- a/apps/hwp-lab/src/components/LabWorkspace.tsx
+++ b/apps/hwp-lab/src/components/LabWorkspace.tsx
@@ -836,8 +836,6 @@ export default function LabWorkspace() {
       ...(opts?.attachments?.length ? { attachments: opts.attachments } : {}),
       // 대화 메모리(에이전틱 스트리밍): 직전 채팅 턴(바운드). 서버가 모델 messages 에 접는다.
       ...(opts?.history?.length ? { history: opts.history } : {}),
-      // 명시 모델(로컬 Models 선택). 서버 세션 선택이 정본이고, 클라가 알면 요청에도 실어 양 경로가 같다.
-      ...(aiModel ? { model: aiModel } : {}),
     };
 
     // ── 데모 프록시 경로 ──────────────────────────────────────────────────────────────────────────
@@ -929,7 +927,7 @@ export default function LabWorkspace() {
     // Feature A: 근거(출처)를 채팅으로 전달 — intents 반환 계약(Promise<Intent[]>)은 불변(InlineEditPanel 안전).
     if (opts?.onCitations) opts.onCitations(data.citations ?? []);
     return data.intents ?? [];
-  }, [adapter, aiModel, askDemoAiConsent, demoAiOn, demoAiTransport]);
+  }, [adapter, askDemoAiConsent, demoAiOn, demoAiTransport]);
 
   // R8: 폰트는 번들하지 않는다. 기본 NanumGothic 이 자동 등록되므로 PDF 는 곧바로 활성화되지만,
   // (기본 폰트 fetch 실패 등으로) 미주입 상태에서 PDF 를 누르면 이 폴백이 호출된다: 기본 폰트를 다시

--- a/apps/hwp-lab/src/components/site/SiteHeader.tsx
+++ b/apps/hwp-lab/src/components/site/SiteHeader.tsx
@@ -7,7 +7,7 @@ import styles from "./site.module.css";
 // 공통 사이트 헤더 — **서버 컴포넌트**다("use client" 금지). 유일한 클라이언트 조각은 ThemeToggle.
 // 편집기 화면(문서를 연 뒤)에는 붙지 않는다 — 거기는 기존 앱 헤더(.lab-header)가 담당한다.
 
-export type SiteNavKey = "home" | "bulk" | "bench" | "docs";
+export type SiteNavKey = "home" | "bulk" | "bench" | "docs" | "models";
 
 // ⚠️ 홈("데모") 항목은 두지 않는다 — 왼쪽 로고가 이미 홈 앵커이고, 랜딩 헤더에 붙은 "데모" 태그는
 // 제품을 스스로 견본 취급하게 만든다(사용자 피드백: 에디터의 "정적 데모·AI" 라벨을 걷어낸 것과 같은
@@ -18,7 +18,18 @@ const NAV: { key: SiteNavKey; href: string; label: string; title: string }[] = [
   { key: "docs", href: siteHref("/docs"), label: "Docs", title: "임베드·CLI·MCP·Intent 스키마 문서" },
 ];
 
+const MODELS_NAV: { key: SiteNavKey; href: string; label: string; title: string } = {
+  key: "models",
+  href: siteHref("/models"),
+  label: "Models",
+  title: "로컬 OpenRouter 연결 · 모델 선택",
+};
+
 export function SiteHeader({ current }: { current?: SiteNavKey }) {
+  const items =
+    process.env.NEXT_PUBLIC_AUTO_HWP_LOCAL_MODELS === "1"
+      ? [...NAV, MODELS_NAV]
+      : NAV;
   return (
     <header className={styles.header}>
       {/* 로고 = 낙관(도장) + 워드텍스트. 도장은 장식이라 alt 를 비운다 — 바로 옆에 같은 뜻의
@@ -31,7 +42,7 @@ export function SiteHeader({ current }: { current?: SiteNavKey }) {
         <small>auto-hwp</small>
       </a>
       <nav className={styles.nav} aria-label="사이트">
-        {NAV.map((n) => (
+        {items.map((n) => (
           <a key={n.key} href={n.href} title={n.title} aria-current={current === n.key ? "page" : undefined}>
             {n.label}
           </a>

--- a/apps/hwp-lab/src/lib/openrouter/gating.ts
+++ b/apps/hwp-lab/src/lib/openrouter/gating.ts
@@ -1,0 +1,70 @@
+// Dual gate for local Models / OpenRouter PKCE routes (issue #56).
+//
+// Both must pass:
+//   1. AUTO_HWP_LOCAL_MODELS=1  (never set on Vercel)
+//   2. the request host is loopback (server-side — build-time gating is not enough
+//      because the hosted demo ships the same route tree)
+//
+// Static demo (DEMO_STATIC / NEXT_PUBLIC_DEMO) and server demo (DEMO_AI_MODE) deny
+// even if someone sets the flag.
+
+export type LocalModelsDenyReason = "flag-off" | "demo-static" | "demo-ai-mode" | "non-loopback";
+
+export function isLocalModelsFlagOn(): boolean {
+  return process.env.AUTO_HWP_LOCAL_MODELS === "1";
+}
+
+export function isDemoStaticBuild(): boolean {
+  return process.env.DEMO_STATIC === "1" || process.env.NEXT_PUBLIC_DEMO === "1";
+}
+
+export function isDemoAiModeOn(): boolean {
+  return process.env.DEMO_AI_MODE === "1";
+}
+
+export function hostnameOf(host: string | null | undefined): string | null {
+  if (!host) return null;
+  const first = host.split(",")[0]?.trim() ?? "";
+  if (!first) return null;
+  if (first.startsWith("[")) {
+    const end = first.indexOf("]");
+    if (end > 1) return first.slice(1, end).toLowerCase();
+  }
+  const noPort = first.replace(/:\d+$/, "");
+  return noPort.toLowerCase();
+}
+
+export function isLoopbackHostname(hostname: string | null | undefined): boolean {
+  if (!hostname) return false;
+  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
+}
+
+export function isLoopbackRequest(req: Request): boolean {
+  const urlHost = hostnameOf(new URL(req.url).host);
+  const host = hostnameOf(req.headers.get("host"));
+  const forwarded = hostnameOf(req.headers.get("x-forwarded-host"));
+  const candidates = [urlHost, host].filter((h): h is string => Boolean(h));
+  if (candidates.length === 0) return false;
+  if (!candidates.every(isLoopbackHostname)) return false;
+  // A non-loopback forwarded host means a proxy in front — treat as public.
+  if (forwarded && !isLoopbackHostname(forwarded)) return false;
+  return true;
+}
+
+export function localModelsDeniedReason(req: Request): LocalModelsDenyReason | null {
+  if (isDemoStaticBuild()) return "demo-static";
+  if (isDemoAiModeOn()) return "demo-ai-mode";
+  if (!isLocalModelsFlagOn()) return "flag-off";
+  if (!isLoopbackRequest(req)) return "non-loopback";
+  return null;
+}
+
+/** Callback / connect URL origin from the request itself — no hardcoded 3000/3100/3110. */
+export function requestOrigin(req: Request): string {
+  const url = new URL(req.url);
+  const host = req.headers.get("host");
+  if (host && isLoopbackHostname(hostnameOf(host))) {
+    return `${url.protocol}//${host}`;
+  }
+  return url.origin;
+}

--- a/apps/hwp-lab/src/lib/openrouter/models-gating.test.ts
+++ b/apps/hwp-lab/src/lib/openrouter/models-gating.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  isLoopbackRequest,
+  localModelsDeniedReason,
+  requestOrigin,
+} from "./gating";
+
+const ENV_KEYS = ["AUTO_HWP_LOCAL_MODELS", "DEMO_STATIC", "NEXT_PUBLIC_DEMO", "DEMO_AI_MODE"] as const;
+
+function req(url: string, headers?: Record<string, string>): Request {
+  return new Request(url, { headers });
+}
+
+describe("models-gating", () => {
+  const saved: Partial<Record<(typeof ENV_KEYS)[number], string | undefined>> = {};
+
+  beforeEach(() => {
+    for (const key of ENV_KEYS) {
+      saved[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      if (saved[key] === undefined) delete process.env[key];
+      else process.env[key] = saved[key];
+    }
+  });
+
+  it("denies when AUTO_HWP_LOCAL_MODELS is off, even on loopback", () => {
+    expect(localModelsDeniedReason(req("http://127.0.0.1:3000/api/auth/openrouter/status"))).toBe("flag-off");
+  });
+
+  it("allows flag-on loopback across the local ports (dev 3000 / e2e 3100 / launch 3110)", () => {
+    process.env.AUTO_HWP_LOCAL_MODELS = "1";
+    expect(localModelsDeniedReason(req("http://localhost:3000/api/auth/openrouter/connect"))).toBeNull();
+    expect(localModelsDeniedReason(req("http://127.0.0.1:3100/api/auth/openrouter/connect"))).toBeNull();
+    expect(
+      localModelsDeniedReason(
+        req("http://localhost:3110/api/auth/openrouter/connect", { host: "localhost:3110" }),
+      ),
+    ).toBeNull();
+  });
+
+  it("denies a non-loopback host even when the flag is on", () => {
+    process.env.AUTO_HWP_LOCAL_MODELS = "1";
+    expect(
+      localModelsDeniedReason(req("https://autohwp.com/api/auth/openrouter/status", { host: "autohwp.com" })),
+    ).toBe("non-loopback");
+  });
+
+  it("denies a spoofed X-Forwarded-Host in front of a loopback URL", () => {
+    process.env.AUTO_HWP_LOCAL_MODELS = "1";
+    expect(
+      localModelsDeniedReason(
+        req("http://127.0.0.1:3000/api/auth/openrouter/status", {
+          host: "127.0.0.1:3000",
+          "x-forwarded-host": "autohwp.com",
+        }),
+      ),
+    ).toBe("non-loopback");
+  });
+
+  it("denies the static demo build (DEMO_STATIC=1)", () => {
+    process.env.AUTO_HWP_LOCAL_MODELS = "1";
+    process.env.DEMO_STATIC = "1";
+    expect(localModelsDeniedReason(req("http://localhost:3000/api/auth/openrouter/status"))).toBe("demo-static");
+  });
+
+  it("denies NEXT_PUBLIC_DEMO=1 the same way as a static export", () => {
+    process.env.AUTO_HWP_LOCAL_MODELS = "1";
+    process.env.NEXT_PUBLIC_DEMO = "1";
+    expect(localModelsDeniedReason(req("http://localhost:3000/api/auth/openrouter/status"))).toBe("demo-static");
+  });
+
+  it("denies the hosted server demo (DEMO_AI_MODE=1) even on loopback", () => {
+    process.env.AUTO_HWP_LOCAL_MODELS = "1";
+    process.env.DEMO_AI_MODE = "1";
+    expect(localModelsDeniedReason(req("http://localhost:3000/api/auth/openrouter/status"))).toBe("demo-ai-mode");
+  });
+
+  it("treats only localhost / 127.0.0.1 / ::1 as loopback", () => {
+    expect(isLoopbackRequest(req("http://localhost/"))).toBe(true);
+    expect(isLoopbackRequest(req("http://127.0.0.1:3100/", { host: "127.0.0.1:3100" }))).toBe(true);
+    expect(isLoopbackRequest(req("http://[::1]:3000/", { host: "[::1]:3000" }))).toBe(true);
+    expect(isLoopbackRequest(req("http://192.168.0.10:3000/", { host: "192.168.0.10:3000" }))).toBe(false);
+    expect(isLoopbackRequest(req("https://example.com/", { host: "example.com" }))).toBe(false);
+  });
+
+  it("derives the callback origin from the request host (no hardcoded port)", () => {
+    expect(requestOrigin(req("http://localhost:3100/api/auth/openrouter/connect", { host: "localhost:3100" }))).toBe(
+      "http://localhost:3100",
+    );
+    expect(requestOrigin(req("http://127.0.0.1:3110/x", { host: "127.0.0.1:3110" }))).toBe("http://127.0.0.1:3110");
+  });
+});

--- a/apps/hwp-lab/src/lib/openrouter/oauth.ts
+++ b/apps/hwp-lab/src/lib/openrouter/oauth.ts
@@ -1,0 +1,81 @@
+// OpenRouter official PKCE (S256) helpers.
+// https://openrouter.ai/docs/guides/overview/auth/oauth
+//
+// The OAuth `code` travels in the callback URL by design. The boundary is the
+// exchanged **key**, which never leaves this server process.
+
+import { createHash, randomBytes } from "node:crypto";
+
+export const OPENROUTER_AUTH_URL = "https://openrouter.ai/auth";
+export const OPENROUTER_KEY_EXCHANGE_URL = "https://openrouter.ai/api/v1/auth/keys";
+export const OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models";
+
+const MODEL_SLUG = /^[a-zA-Z0-9][a-zA-Z0-9+_./:-]{0,199}$/;
+
+export function isOpenRouterModelSlug(value: string): boolean {
+  return MODEL_SLUG.test(value);
+}
+
+export function generatePkce(): { verifier: string; challenge: string } {
+  const verifier = randomBytes(32).toString("base64url");
+  const challenge = createHash("sha256").update(verifier).digest("base64url");
+  return { verifier, challenge };
+}
+
+export function openRouterAuthorizeUrl(callbackUrl: string, challenge: string): string {
+  const url = new URL(OPENROUTER_AUTH_URL);
+  url.searchParams.set("callback_url", callbackUrl);
+  url.searchParams.set("code_challenge", challenge);
+  url.searchParams.set("code_challenge_method", "S256");
+  return url.toString();
+}
+
+export async function exchangeOpenRouterCode(code: string, verifier: string): Promise<string> {
+  const res = await fetch(OPENROUTER_KEY_EXCHANGE_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      code,
+      code_verifier: verifier,
+      code_challenge_method: "S256",
+    }),
+  });
+  if (!res.ok) {
+    throw new Error(`OpenRouter key exchange failed (${res.status})`);
+  }
+  let data: { key?: unknown };
+  try {
+    data = (await res.json()) as { key?: unknown };
+  } catch {
+    throw new Error("OpenRouter key exchange returned a non-JSON body");
+  }
+  if (typeof data.key !== "string" || !data.key.trim()) {
+    throw new Error("OpenRouter key exchange returned no key");
+  }
+  return data.key.trim();
+}
+
+export type OpenRouterCatalogEntry = { id: string; name: string };
+
+export async function fetchOpenRouterCatalog(apiKey: string): Promise<OpenRouterCatalogEntry[]> {
+  const res = await fetch(OPENROUTER_MODELS_URL, {
+    headers: { Authorization: `Bearer ${apiKey}` },
+  });
+  if (!res.ok) {
+    throw new Error(`OpenRouter models catalog failed (${res.status})`);
+  }
+  const body = (await res.json()) as { data?: unknown };
+  if (!Array.isArray(body.data)) return [];
+  const out: OpenRouterCatalogEntry[] = [];
+  for (const row of body.data) {
+    if (!row || typeof row !== "object") continue;
+    const rec = row as { id?: unknown; name?: unknown };
+    if (typeof rec.id !== "string" || !rec.id.trim()) continue;
+    const id = rec.id.trim();
+    if (!isOpenRouterModelSlug(id)) continue;
+    const name = typeof rec.name === "string" && rec.name.trim() ? rec.name.trim() : id;
+    out.push({ id, name });
+  }
+  out.sort((a, b) => a.id.localeCompare(b.id));
+  return out;
+}

--- a/apps/hwp-lab/src/lib/openrouter/resolveKey.test.ts
+++ b/apps/hwp-lab/src/lib/openrouter/resolveKey.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  MissingOpenRouterKeyError,
+  peekOpenRouterKeySource,
+  resolveOpenRouterKey,
+  resolveOpenRouterModel,
+} from "./resolveKey";
+import {
+  resetOpenRouterSessionForTests,
+  setOpenRouterSessionKey,
+  setSelectedOpenRouterModel,
+} from "./session";
+
+const ENV_KEYS = ["OPENROUTER_API_KEY", "AUTO_HWP_OPENROUTER_MODEL", "AUTO_HWP_OPENROUTER_VISION_MODEL"] as const;
+
+describe("resolveOpenRouterKey", () => {
+  const saved: Partial<Record<(typeof ENV_KEYS)[number], string | undefined>> = {};
+
+  beforeEach(() => {
+    resetOpenRouterSessionForTests();
+    for (const key of ENV_KEYS) {
+      saved[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    resetOpenRouterSessionForTests();
+    for (const key of ENV_KEYS) {
+      if (saved[key] === undefined) delete process.env[key];
+      else process.env[key] = saved[key];
+    }
+  });
+
+  it("prefers the PKCE session key over env (verbatim, no masking)", () => {
+    process.env.OPENROUTER_API_KEY = "env-fallback-key";
+    setOpenRouterSessionKey("session-priority-key");
+    expect(resolveOpenRouterKey()).toEqual({ key: "session-priority-key", source: "session" });
+    expect(peekOpenRouterKeySource()).toBe("session");
+  });
+
+  it("falls back to env when the session store is empty", () => {
+    process.env.OPENROUTER_API_KEY = "env-only-key";
+    expect(resolveOpenRouterKey()).toEqual({ key: "env-only-key", source: "env" });
+    expect(peekOpenRouterKeySource()).toBe("env");
+  });
+
+  it("throws an explicit error when neither session nor env has a key", () => {
+    expect(() => resolveOpenRouterKey()).toThrow(MissingOpenRouterKeyError);
+    expect(() => resolveOpenRouterKey()).toThrow(/no PKCE session key and no OPENROUTER_API_KEY/);
+    expect(peekOpenRouterKeySource()).toBeNull();
+  });
+
+  it("treats blank/whitespace env as missing (no silent empty key)", () => {
+    process.env.OPENROUTER_API_KEY = "   ";
+    expect(() => resolveOpenRouterKey()).toThrow(MissingOpenRouterKeyError);
+    expect(peekOpenRouterKeySource()).toBeNull();
+  });
+
+  it("does not silently mask the resolved key as another provider source", () => {
+    setOpenRouterSessionKey("session-priority-key");
+    process.env.OPENROUTER_API_KEY = "env-fallback-key";
+    const resolved = resolveOpenRouterKey();
+    expect(resolved.source).not.toBe("env");
+    expect(resolved.key).not.toBe("env-fallback-key");
+    expect(resolved.key).not.toMatch(/^\*+$/);
+    expect(resolved.key).toBe("session-priority-key");
+  });
+});
+
+describe("resolveOpenRouterModel", () => {
+  const saved: Partial<Record<(typeof ENV_KEYS)[number], string | undefined>> = {};
+
+  beforeEach(() => {
+    resetOpenRouterSessionForTests();
+    for (const key of ENV_KEYS) {
+      saved[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    resetOpenRouterSessionForTests();
+    for (const key of ENV_KEYS) {
+      if (saved[key] === undefined) delete process.env[key];
+      else process.env[key] = saved[key];
+    }
+  });
+
+  it("uses the request model over the stored selection and env default", () => {
+    process.env.AUTO_HWP_OPENROUTER_MODEL = "env/default-model";
+    setSelectedOpenRouterModel("session/stored-model");
+    expect(resolveOpenRouterModel("request/chosen-model")).toBe("request/chosen-model");
+  });
+
+  it("uses the stored selection when the request does not name a model", () => {
+    process.env.AUTO_HWP_OPENROUTER_MODEL = "env/default-model";
+    setSelectedOpenRouterModel("session/stored-model");
+    expect(resolveOpenRouterModel(undefined, { hasImage: true })).toBe("session/stored-model");
+  });
+
+  it("does not silently swap an explicit model for the vision override", () => {
+    process.env.AUTO_HWP_OPENROUTER_VISION_MODEL = "env/vision-model";
+    expect(resolveOpenRouterModel("request/chosen-model", { hasImage: true })).toBe("request/chosen-model");
+  });
+
+  it("keeps the env default / vision override when nothing is selected", () => {
+    process.env.AUTO_HWP_OPENROUTER_MODEL = "env/default-model";
+    process.env.AUTO_HWP_OPENROUTER_VISION_MODEL = "env/vision-model";
+    expect(resolveOpenRouterModel()).toBe("env/default-model");
+    expect(resolveOpenRouterModel(null, { hasImage: true })).toBe("env/vision-model");
+  });
+});

--- a/apps/hwp-lab/src/lib/openrouter/resolveKey.ts
+++ b/apps/hwp-lab/src/lib/openrouter/resolveKey.ts
@@ -1,0 +1,51 @@
+// OpenRouter key + model resolver (issue #56).
+//
+// `resolveOpenRouterKey() = session key ?? env`. Callers that already decided the
+// provider is OpenRouter must use this — they must not fall back to Anthropic/mock
+// and must not invent or mask a key. Missing both sources is an explicit error.
+
+import { getOpenRouterSessionKey, getSelectedOpenRouterModel } from "./session";
+
+export const DEFAULT_OPENROUTER_MODEL = "x-ai/grok-4.5";
+
+export type OpenRouterKeySource = "session" | "env";
+
+export class MissingOpenRouterKeyError extends Error {
+  readonly code = "missing_openrouter_key" as const;
+  constructor() {
+    super("OpenRouter API key is not available (no PKCE session key and no OPENROUTER_API_KEY).");
+    this.name = "MissingOpenRouterKeyError";
+  }
+}
+
+export function peekOpenRouterKeySource(): OpenRouterKeySource | null {
+  if (getOpenRouterSessionKey()) return "session";
+  if (process.env.OPENROUTER_API_KEY?.trim()) return "env";
+  return null;
+}
+
+/** Session key wins. Env is the fallback. Neither → throw (no silent empty/masked key). */
+export function resolveOpenRouterKey(): { key: string; source: OpenRouterKeySource } {
+  const session = getOpenRouterSessionKey();
+  if (session) return { key: session, source: "session" };
+  const env = process.env.OPENROUTER_API_KEY?.trim() ?? "";
+  if (env) return { key: env, source: "env" };
+  throw new MissingOpenRouterKeyError();
+}
+
+/**
+ * Explicit request/session selection wins and is never swapped for a vision model.
+ * Without an explicit choice, env default (and the existing vision override) apply.
+ */
+export function resolveOpenRouterModel(requested?: string | null, opts?: { hasImage?: boolean }): string {
+  const fromRequest = typeof requested === "string" ? requested.trim() : "";
+  const fromSession = getSelectedOpenRouterModel() ?? "";
+  const explicit = fromRequest || fromSession;
+  if (explicit) return explicit;
+
+  const envModel = process.env.AUTO_HWP_OPENROUTER_MODEL?.trim() || DEFAULT_OPENROUTER_MODEL;
+  if (opts?.hasImage) {
+    return process.env.AUTO_HWP_OPENROUTER_VISION_MODEL?.trim() || envModel;
+  }
+  return envModel;
+}

--- a/apps/hwp-lab/src/lib/openrouter/resolveKey.ts
+++ b/apps/hwp-lab/src/lib/openrouter/resolveKey.ts
@@ -37,6 +37,11 @@ export function resolveOpenRouterKey(): { key: string; source: OpenRouterKeySour
  * Explicit request/session selection wins and is never swapped for a vision model.
  * Without an explicit choice, env default (and the existing vision override) apply.
  */
+/** Env/default slug only — never the wiped session selection. */
+export function openRouterEnvDefaultModel(): string {
+  return process.env.AUTO_HWP_OPENROUTER_MODEL?.trim() || DEFAULT_OPENROUTER_MODEL;
+}
+
 export function resolveOpenRouterModel(requested?: string | null, opts?: { hasImage?: boolean }): string {
   const fromRequest = typeof requested === "string" ? requested.trim() : "";
   const fromSession = getSelectedOpenRouterModel() ?? "";

--- a/apps/hwp-lab/src/lib/openrouter/session.ts
+++ b/apps/hwp-lab/src/lib/openrouter/session.ts
@@ -1,0 +1,74 @@
+// OpenRouter PKCE session — process memory only (issue #56).
+//
+// Next dev HMR re-evaluates modules, so a module-level `let` would drop the key and a stale
+// `connected=true` on the client could silently fall through to env. The store lives on
+// `globalThis` (Symbol.for) and every status/edit request re-reads it.
+
+export type OpenRouterSession = {
+  key: string | null;
+  codeVerifier: string | null;
+  selectedModel: string | null;
+};
+
+const STORE = Symbol.for("auto-hwp.openrouter.session.v1");
+
+type GlobalBag = typeof globalThis & {
+  [STORE]?: OpenRouterSession;
+};
+
+function emptySession(): OpenRouterSession {
+  return { key: null, codeVerifier: null, selectedModel: null };
+}
+
+export function getOpenRouterSession(): OpenRouterSession {
+  const g = globalThis as GlobalBag;
+  if (!g[STORE]) g[STORE] = emptySession();
+  return g[STORE];
+}
+
+export function getOpenRouterSessionKey(): string | null {
+  const key = getOpenRouterSession().key?.trim() ?? "";
+  return key || null;
+}
+
+export function setOpenRouterSessionKey(key: string): void {
+  const trimmed = key.trim();
+  if (!trimmed) throw new Error("OpenRouter session key must be non-empty.");
+  getOpenRouterSession().key = trimmed;
+}
+
+export function setPkceVerifier(verifier: string): void {
+  const trimmed = verifier.trim();
+  if (!trimmed) throw new Error("PKCE verifier must be non-empty.");
+  getOpenRouterSession().codeVerifier = trimmed;
+}
+
+/** Read-and-clear the pending verifier so a code cannot be exchanged twice. */
+export function takePkceVerifier(): string | null {
+  const session = getOpenRouterSession();
+  const verifier = session.codeVerifier?.trim() ?? "";
+  session.codeVerifier = null;
+  return verifier || null;
+}
+
+export function getSelectedOpenRouterModel(): string | null {
+  const model = getOpenRouterSession().selectedModel?.trim() ?? "";
+  return model || null;
+}
+
+export function setSelectedOpenRouterModel(model: string | null): void {
+  getOpenRouterSession().selectedModel = model?.trim() || null;
+}
+
+/** Wipe every in-memory field. Does not revoke the key on OpenRouter's side. */
+export function clearOpenRouterSession(): void {
+  const session = getOpenRouterSession();
+  session.key = null;
+  session.codeVerifier = null;
+  session.selectedModel = null;
+}
+
+export function resetOpenRouterSessionForTests(): void {
+  const g = globalThis as GlobalBag;
+  g[STORE] = emptySession();
+}

--- a/apps/hwp-lab/vitest.config.ts
+++ b/apps/hwp-lab/vitest.config.ts
@@ -1,10 +1,17 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
+
+const root = path.dirname(fileURLToPath(import.meta.url));
 
 // issue 052 — hwp-lab 단위 테스트 (자동저장/복구 영속 계층). node 환경: AutosaveController 는
 // 헤드리스(React/DOM 无)이고, 스토어 정책 테스트는 MemorySnapshotStore(IndexedDB mock)로 돈다.
 // goldenRecovery.test.ts 는 실엔진(wasm) 테스트라 packages/engine/pkg(015 레시피 산출물)가 필요하다.
 // 배너/IndexedDB 실구현은 Playwright e2e(autosave-recovery-052.spec.ts)가 실브라우저로 검증한다.
 export default defineConfig({
+  resolve: {
+    alias: { "@": path.join(root, "src") },
+  },
   test: {
     environment: "node",
     include: ["src/**/*.test.ts"],

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,6 +3,18 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
+- 갱신: 2026-08-19 · Grok 4.6 — **#56 OpenRouter PKCE v1 · PR 전**.
+  `feat/issue-56-openrouter-pkce`: 서버 커스터디 키(`globalThis`) +
+  `resolveOpenRouterKey`(세션 ?? env, 명시 에러) + `/api/auth/openrouter/*` 이중 게이트
+  (`AUTO_HWP_LOCAL_MODELS=1`+루프백; DEMO_STATIC/DEMO_AI_MODE 차단) + `/models`
+  Connect 카드·카탈로그 셀렉트. 선택이 스트리밍/비스트리밍 양쪽에 반영. `demo.ts` diff 0.
+  vitest: resolveKey·models-gating·auth·hwp-edit PKCE. hwp-lab 239, ai-protocol 64,
+  editor-core 265, react 418. e2e 85 passed / 3 skipped. 브라우저: Connect →
+  OpenRouter Sign Up/Sign in(사람 로그인 경계). 콜백 이후는 모의 교환 테스트.
+  `verify-local --full`은 crates 무접촉이라 workspace clippy/wasm 재빌드 스킵(종전
+  macOS clippy 정체). 다음: 푸시·PR `Closes #56` + Part of #50, CI 3종, **머지 금지**.
+  실계정 E2E는 소유자 QA 대기.
+
 - 갱신: 2026-08-19 · Grok 4.6 — **PR #46 Cursor High 2건 수리 · 머지 대기**.
   `fix/issue-42-layout-gap`: (1) `set_page_size` 여백 안내선이 `display_paper`의
   (pw, ph)에서 빼도록 교정 — landscape에서 margin_right=0/bottom 팽창 해소.

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,17 +3,12 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
-- 갱신: 2026-08-19 · Grok 4.6 — **#56 OpenRouter PKCE v1 · PR 전**.
-  `feat/issue-56-openrouter-pkce`: 서버 커스터디 키(`globalThis`) +
-  `resolveOpenRouterKey`(세션 ?? env, 명시 에러) + `/api/auth/openrouter/*` 이중 게이트
-  (`AUTO_HWP_LOCAL_MODELS=1`+루프백; DEMO_STATIC/DEMO_AI_MODE 차단) + `/models`
-  Connect 카드·카탈로그 셀렉트. 선택이 스트리밍/비스트리밍 양쪽에 반영. `demo.ts` diff 0.
-  vitest: resolveKey·models-gating·auth·hwp-edit PKCE. hwp-lab 239, ai-protocol 64,
-  editor-core 265, react 418. e2e 85 passed / 3 skipped. 브라우저: Connect →
-  OpenRouter Sign Up/Sign in(사람 로그인 경계). 콜백 이후는 모의 교환 테스트.
-  `verify-local --full`은 crates 무접촉이라 workspace clippy/wasm 재빌드 스킵(종전
-  macOS clippy 정체). 다음: 푸시·PR `Closes #56` + Part of #50, CI 3종, **머지 금지**.
-  실계정 E2E는 소유자 QA 대기.
+- 갱신: 2026-08-19 · Grok 4.6 — **#56 OpenRouter PKCE v1 · PR #59 · CI 3종 green**.
+  https://github.com/kwakseongjae/auto-hwp/pull/59 `Closes #56` · Part of #50 ·
+  설계 크레딧 @SEUNGJU-PARK-KR. 서버 커스터디 키 + 이중 게이트 + 모델 셀렉트.
+  `demo.ts` diff 0. Cursor Medium 3건 수리(`0733493`)·스레드 답글만(resolve는 검수자).
+  브라우저: Connect → OpenRouter Sign Up/Sign in. 실계정 E2E는 소유자 QA 대기.
+  **머지 금지**.
 
 - 갱신: 2026-08-19 · Grok 4.6 — **PR #46 Cursor High 2건 수리 · 머지 대기**.
   `fix/issue-42-layout-gap`: (1) `set_page_size` 여백 안내선이 `display_paper`의

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,10 @@
 
 ---
 
+## 2026-08-19 (Grok 4.6) · #56 OpenRouter PKCE v1
+- 서버 커스터디 키 + 모델 셀렉트 + 이중 게이트. demo.ts 무접촉.
+- Connect→OpenRouter 로그인 화면까지. 실계정 E2E는 소유자. 다음: PR, 머지 금지.
+
 ## 2026-08-19 (Grok 4.6) · PR #46 Cursor High 2건 수리
 - 여백 안내선=`display_paper`. 섹션 머리말 시작쪽=fresh-page 이후.
 - 잠금 테스트 2. 게이트 유지. 다음: CI + 스레드 답글, 머지 금지.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -7,7 +7,7 @@
 
 ## 2026-08-19 (Grok 4.6) · #56 OpenRouter PKCE v1
 - 서버 커스터디 키 + 모델 셀렉트 + 이중 게이트. demo.ts 무접촉.
-- Connect→OpenRouter 로그인 화면까지. 실계정 E2E는 소유자. 다음: PR, 머지 금지.
+- PR #59 CI 3종 green. Cursor 3건 수리·답글. 실계정 E2E는 소유자. 머지 금지.
 
 ## 2026-08-19 (Grok 4.6) · PR #46 Cursor High 2건 수리
 - 여백 안내선=`display_paper`. 섹션 머리말 시작쪽=fresh-page 이후.

--- a/docs/issues/050-adapter-contract.md
+++ b/docs/issues/050-adapter-contract.md
@@ -1,0 +1,43 @@
+# 050 — 모델 프로바이더 어댑터 계약 (GitHub #50)
+
+- 상태: **부분** — OpenRouter PKCE v1은 GitHub **#56**. Copilot SDK·격리 Codex CLI는 우산 #50 잔류.
+- 설계 공로: @SEUNGJU-PARK-KR (#50 제안)
+- 이 파일은 파일 이슈 `050-image-insert-sdk.md`(이미지 삽입 SDK)와 **다른 문서**다. GitHub 이슈 번호 기준.
+
+우산 이슈 #50의 세 프로바이더를 같은 capability 축으로 설계한다. 구현은 additive로 한 프로바이더씩 착지한다. 첫 슬라이스는 OpenRouter만.
+
+## Capability 축
+
+| 축 | OpenRouter (#56) | Copilot SDK (후속) | 격리 Codex CLI (후속) |
+|---|---|---|---|
+| 인증 | OAuth PKCE S256, 서버 커스터디 | SDK 번들 CLI OAuth | 앱 격리 `CODEX_HOME` 로그인 |
+| 키/세션 보관 | 서버 프로세스 메모리만 (`globalThis` 고정) | SDK confined session | 격리 CLI 저장소 |
+| 카탈로그 | `GET https://openrouter.ai/api/v1/models` | SDK model catalog | CLI 카탈로그 |
+| 요청 경로 | 기존 `/api/hwp-edit` 하드닝 재사용 | SDK inference 어댑터 | structured exec |
+| capability | `AUTO_HWP_LOCAL_MODELS=1` + 루프백 검사 이중 게이트 (additive — 프로바이더별 프로덕션 승격은 별도 이슈) | 동일 | 동일 |
+| 상태 표시 | `connected` 불리언 + 키 출처(`session` \| `env`) 메타 | honest status | honest status |
+
+축을 줄이거나 프로바이더 전용 비밀 필드를 브라우저에 노출하는 확장은 금지한다. 새 축은 additive로만 더한다.
+
+## OpenRouter v1 경계 (#56)
+
+- code→key 교환은 서버에서만. 키는 `globalThis` 고정 스토어에만 둔다.
+- 브라우저는 `connected`와 `keySource`(`session` \| `env` \| `null`)만 본다. 키·계정 식별자는 브라우저 스토리지·URL·로그·분석·픽스처에 넣지 않는다.
+- OAuth `code`가 콜백 URL을 경유하는 것은 정상이다. 노출 금지 경계는 **키**에만 적용한다.
+- `resolveOpenRouterKey() = 세션 키 ?? env`. 둘 다 없으면 명시 에러. PKCE 연결 + env 부재 때 Anthropic/mock으로 침묵 폴백하지 않는다.
+- 연결 후 카탈로그에서 고른 모델이 스트리밍·비스트리밍 `/api/hwp-edit` 양쪽에 반영된다. 명시 선택은 vision 모델로 조용히 바뀌지 않는다.
+- 콜백 URL은 요청 오리진에서 도출한다. 포트 하드코딩 금지 (dev 3000 / e2e 3100 / launch 3110).
+- `disconnect`는 서버 메모리를 지운다. OpenRouter 계정에 남은 키 revoke는 대시보드 수동 절차다.
+
+## 이중 게이트
+
+새 라우트(`/api/auth/openrouter/*`, `/models`)는 아래를 **모두** 통과해야 산다.
+
+1. `AUTO_HWP_LOCAL_MODELS=1` (Vercel에 설정하지 않는다)
+2. 요청 호스트가 루프백 (`localhost` / `127.0.0.1` / `::1`)
+
+정적 빌드(`DEMO_STATIC=1` / `NEXT_PUBLIC_DEMO=1`)와 서버형 데모(`DEMO_AI_MODE=1`)는 플래그가 켜져 있어도 거부한다. `demo.ts`는 무접촉.
+
+## 비범위 (우산 #50 잔류)
+
+Models 내비 위치·375/768/1280 반응형 검수, Copilot/격리 Codex 어댑터, guided dual action, first-transmission disclosure, 취소·프로세스 정리, 공개 BYOK 프로덕션 승격.

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -2,6 +2,8 @@
 
 깃 저장소가 아직 없어 이슈를 파일로 관리한다. 각 이슈는 `NNN-slug.md`. 상태: `open` · `in-progress` · `done` · `wontfix`.
 
+GitHub 우산 **#50** 어댑터 계약(파일 이슈 050 이미지 삽입과 별개): [050-adapter-contract.md](050-adapter-contract.md). 첫 슬라이스는 #56.
+
 | # | 제목 | 상태 | 우선순위 | 비고 |
 |---|------|------|----------|------|
 | [001](001-native-numbering-bullets.md) | 네이티브 자동번호/글머리표 풀(`hh:numbering`/`hh:bullet`) | **long-term** | P2 | 코퍼스 근거 0 + 오라클 검증 불가. 외부 샘플 확보 필요. 현재 행잉인덴트+마커로 대체 |


### PR DESCRIPTION
Closes #56
Part of #50

설계 크레딧: @SEUNGJU-PARK-KR (#50 제안)

## 무엇을
로컬 전용 Models 진입점에서 OpenRouter OAuth PKCE(S256)를 연결한다. code→key 교환은 서버가 하고, 키는 `globalThis` 고정 프로세스 메모리에만 둔다. 브라우저는 `connected` 불리언과 키 출처(`session`|`env`)만 본다.

## 계약
- `resolveOpenRouterKey() = 세션 키 ?? env`. 둘 다 없으면 명시 에러. PKCE 연결 + env 부재 때 anthropic/mock 침묵 폴백 없음.
- 연결 후 OpenRouter `GET /models` 카탈로그에서 고른 모델이 스트리밍·비스트리밍 `/api/hwp-edit` 양쪽에 반영된다.
- 이중 게이트: `AUTO_HWP_LOCAL_MODELS=1` + 루프백 호스트. `DEMO_STATIC`/`NEXT_PUBLIC_DEMO`와 `DEMO_AI_MODE`에서는 거부.
- 콜백 URL은 요청 오리진에서 도출(포트 하드코딩 없음).
- `demo.ts` 무접촉. 기존 Anthropic / env OpenRouter / mock / ai-protocol 동작 보존.
- 어댑터 계약: `docs/issues/050-adapter-contract.md`

## 검증
- vitest: `resolveOpenRouterKey` 우선순위·폴백·명시 에러·no-silent-masking + `models-gating` (플래그 off / 비루프백 / 데모 모드) + auth 라우트 모의 교환 + hwp-edit 세션 라우팅/모델 반영
- hwp-lab 239, ai-protocol 64, editor-core 265, react 418
- e2e 85 passed / 3 skipped (e2e 전 `.next` 삭제). crates 무접촉이라 workspace clippy·wasm 재빌드는 스킵(종전 macOS clippy 정체)
- 브라우저: 로컬 `AUTO_HWP_LOCAL_MODELS=1`에서 Connect → OpenRouter Sign Up/Sign in까지. 사람 로그인이 필요한 단계에서 정지. 콜백 이후는 테스트 더블(모의 교환). **실계정 E2E는 소유자 QA 대기.**

## 사용
```
AUTO_HWP_LOCAL_MODELS=1 pnpm -C apps/hwp-lab dev
```
`/models` → Connect OpenRouter. disconnect는 서버 메모리만 지운다. OpenRouter 대시보드 키 폐기는 수동.

머지하지 않는다.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches authentication, API key custody, and LLM routing; mis-gating or key leakage on non-loopback hosts would be critical, though 404 gating and tests aim to prevent that.
> 
> **Overview**
> Adds a **local-only** OpenRouter flow (#56): OAuth PKCE (S256) under `/api/auth/openrouter/*`, a `/models` page to connect, pick a catalog model, and disconnect (server memory only). Keys stay in process memory (`globalThis` session store); the client only sees `connected` and `keySource` (`session` | `env`).
> 
> **Dual gate** (`AUTO_HWP_LOCAL_MODELS=1` + loopback host; blocked for static/demo and `DEMO_AI_MODE`) returns **404** on gated routes so hosted builds do not advertise the surface. Nav exposes Models when `NEXT_PUBLIC_AUTO_HWP_LOCAL_MODELS` is set.
> 
> **`/api/hwp-edit`** now resolves OpenRouter via `resolveOpenRouterKey()` (session over env; explicit error if neither) and `resolveOpenRouterModel()` (request body `model` → session selection → env defaults; no silent vision swap on explicit choice). PKCE session alone routes to OpenRouter without falling back to Anthropic/mock. Probe responses add `keySource` / `localModels`; streaming sets `X-Auto-Hwp-Key-Source`. API keys are redacted in error paths.
> 
> Adds vitest coverage for gating, key/model resolution, auth routes, and hwp-edit integration; documents the adapter slice in `docs/issues/050-adapter-contract.md`. **`demo.ts` unchanged.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit add164aeb49c282f2c51d655426f1a574de8fcc0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->