### PR TITLE
docs: record #56 real-account PKCE QA evidence

### DIFF
--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,6 +3,21 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
+- 갱신: 2026-08-20 · Claude(Fable) — **#56 실계정 QA 통과 · PR #59 머지**(main `a53006f`, #56 close).
+  소유자 Chrome(claude-in-chrome)으로 종단 검증: `/models` LOCAL ONLY·카드 1장 →
+  Connect → OpenRouter 인가(QA 키에 크레딧 상한 $1·라벨 localhost:3000) → 콜백 →
+  `connected=true·keySource=session` 전환 → 카탈로그 **403종** 로드 → 모델 명시 선택
+  (`anthropic/claude-haiku-4.5`, 기본 grok-4.5와 다름) → sample-8p에서 실제 AI 편집
+  (SetTableCell 제안→적용→되돌리기 정상). **`GET /api/hwp-edit`가
+  `provider:openrouter·model:anthropic/claude-haiku-4.5·keySource:session`을 반환해
+  "선택 모델이 요청을 구동한다"를 확증**. disconnect 후 `keySource:env·model:grok-4.5`로
+  정확히 복귀. 게이트 실측: 비루프백 Host → 404, connect는 `code_challenge_method=S256`
+  + 요청 오리진 기반 callback_url. dev 로그·status 응답에 키 유출 0건.
+  보안 리뷰 MEDIUM 2건(Host 기반 루프백 검사·소비 경로 무게이트)은 v1 잔여 위험으로
+  **우산 #50에 후속 하드닝 등록** 후 스레드 해결. ⚠️ 소유자 조치: OpenRouter 대시보드에
+  남은 QA 키(`localhost:3000`) 수동 폐기 — disconnect는 서버 메모리만 지운다.
+  다음: Grok 트랙은 #51(Tauri blockRunsPath) 또는 T1(제보→픽스처 절차) 또는 B0(블로그).
+
 - 갱신: 2026-08-19 · Grok 4.6 — **#56 OpenRouter PKCE v1 · PR #59 · CI 3종 green**.
   https://github.com/kwakseongjae/auto-hwp/pull/59 `Closes #56` · Part of #50 ·
   설계 크레딧 @SEUNGJU-PARK-KR. 서버 커스터디 키 + 이중 게이트 + 모델 셀렉트.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -17,6 +17,11 @@
 - 부분집합 22/301 + extras 핀. 머리말 표·폼·가로 자체 픽스처. 7==7.
 - 게이트 유지. sample-8p 업로드/렌더 검수. 다음: CI green 후 머지 질문.
 
+## 2026-08-20 (Claude Fable) · #56 실계정 QA 통과 → PR #59 머지
+- 소유자 Chrome으로 PKCE 종단 검증: 인가→session 키→카탈로그 403종→모델 선택→AI 편집→undo→disconnect.
+- `GET /api/hwp-edit`가 선택 모델·session 출처 확증. 보안 MEDIUM 2건은 #50에 잔여 위험 등록.
+- main `a53006f`, #56 close. 소유자 조치: OpenRouter QA 키 수동 폐기. 다음: #51 / T1 / B0.
+
 ## 2026-08-18 (Claude Fable) · #50 인수 + 우로보로스 인터뷰로 계획 확정
 - #50 타당성 검증 후 인수(크레딧 댓글)·서브이슈 #56(OpenRouter PKCE v1, 계약+수락 기준 포함).
 - 인터뷰 D1–D9: 서버 커스터디 키·이중 게이트·모델 셀렉트 포함·우산 유지. Seed seed_8e464381dc64.


### PR DESCRIPTION
Closes #60

PR #59 머지 후 소유자 Chrome 실계정 QA 결과 기록 (상태 동기화 전용, 코드 무접촉).

- 인가 → `keySource: env→session` 전환 → 카탈로그 403종 → 모델 명시 선택 → 실제 AI 편집(제안→적용→undo) → disconnect 후 env 복귀
- `GET /api/hwp-edit` → `provider:openrouter · model:anthropic/claude-haiku-4.5 · keySource:session` 확증
- 게이트: 비루프백 Host → 404, `code_challenge_method=S256`, 오리진 기반 callback_url, 키 유출 0건

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PZY1SXKjyETaguz3JYfoq9