### PR TITLE
fix: make local models builds fail closed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ apps/hwp-lab/public/fonts/
 apps/hwp-lab/public/samples/
 apps/hwp-lab/public/docs-assets/
 apps/hwp-lab/.demo-api-hold/
+apps/hwp-lab/.demo-models-hold/
 apps/hwp-lab/.turbo/
 apps/hwp-lab/tsconfig.tsbuildinfo
 apps/hwp-lab/next-env.d.ts

--- a/apps/hwp-lab/next.config.mjs
+++ b/apps/hwp-lab/next.config.mjs
@@ -18,9 +18,9 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
  *    끌어넣지 않도록 한다.
  */
 // 정적 데모 빌드 (OSS): DEMO_STATIC=1 이면 서버 없는 `output:"export"` 로 GitHub Pages 등에
-// 배포 가능한 정적 사이트를 만든다. AI 프록시(/api/hwp-edit)는 라우트 핸들러라 export 와 공존할
-// 수 없으므로 scripts/build-demo.mjs 가 빌드 동안 api/ 를 임시로 치워둔다(클라이언트는
-// NEXT_PUBLIC_DEMO=1 을 보고 프록시 프로브를 건너뛰고 "정적 데모" 모드로 동작).
+// 배포 가능한 정적 사이트를 만든다. AI 프록시(/api/hwp-edit)와 요청 헤더를 읽는 로컬 /models는
+// export 와 공존할 수 없으므로 scripts/build-demo.mjs 가 빌드 동안 api/ 와 models/ 를 임시로
+// 치워둔다(클라이언트는 NEXT_PUBLIC_DEMO=1 을 보고 프록시 프로브를 건너뛰고 "정적 데모" 모드로 동작).
 // DEMO_BASE_PATH 는 프로젝트 페이지(/auto-hwp) 배포용 — 코드의 절대경로 fetch(/hwp, /fonts,
 // /samples)는 NEXT_PUBLIC_BASE_PATH 를 접두해 같은 경로 체계를 유지한다.
 const isDemo = process.env.DEMO_STATIC === "1";

--- a/apps/hwp-lab/scripts/build-demo.mjs
+++ b/apps/hwp-lab/scripts/build-demo.mjs
@@ -1,7 +1,9 @@
 // build-demo.mjs — 서버 없는 정적 데모 빌드 (OSS: GitHub Pages 등).
 //
-// Next `output:"export"` 는 동적 라우트 핸들러(POST /api/hwp-edit — AI BYOK 프록시)와 공존할 수
-// 없으므로, 빌드 동안 src/app/api 를 임시로 치워두고(.demo-api-hold) 끝나면 반드시 복원한다.
+// Next `output:"export"` 는 동적 라우트 핸들러(POST /api/hwp-edit — AI BYOK 프록시) 및 요청
+// 헤더를 읽는 로컬 전용 /models 페이지와 공존할 수 없으므로, 빌드 동안 두 라우트를 app tree 밖으로
+// 임시 격리하고 끝나면 반드시 복원한다. /models 를 정적으로 바꾸면 Next 15 segment config 계약을
+// 어기거나 로컬 전용 화면을 정적 산출물에 노출할 수 있으므로 라우트 제외가 의도된 경계다.
 // 클라이언트는 NEXT_PUBLIC_DEMO=1 을 보고 프록시 프로브를 건너뛰고 "정적 데모" 모드로 동작한다
 // (LabWorkspace.tsx — AI 편집은 로컬 실행 안내, 뷰/수동편집/export 는 전부 브라우저에서 동작).
 //
@@ -14,26 +16,115 @@ import { fileURLToPath } from "node:url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const appRoot = path.join(__dirname, "..");
-const apiDir = path.join(appRoot, "src", "app", "api");
-const holdDir = path.join(appRoot, ".demo-api-hold");
 
-const run = (cmd) => execSync(cmd, { cwd: appRoot, stdio: "inherit", env: { ...process.env, DEMO_STATIC: "1" } });
-
-// 이전 실행이 죽어 hold 가 남아 있으면 먼저 복원(멱등).
-if (existsSync(holdDir) && !existsSync(apiDir)) renameSync(holdDir, apiDir);
-
-if (!existsSync(apiDir)) {
-  console.error("[build-demo] src/app/api 가 없습니다 — 레포 상태를 확인하세요.");
-  process.exit(1);
+export function demoRouteHolds(root = appRoot) {
+  return [
+    {
+      label: "src/app/api",
+      source: path.join(root, "src", "app", "api"),
+      hold: path.join(root, ".demo-api-hold"),
+    },
+    {
+      label: "src/app/models",
+      source: path.join(root, "src", "app", "models"),
+      hold: path.join(root, ".demo-models-hold"),
+    },
+  ];
 }
 
-renameSync(apiDir, holdDir);
-try {
-  rmSync(path.join(appRoot, ".next"), { recursive: true, force: true }); // 서버 빌드 캐시와 절대 섞지 않는다
-  run("npm run build"); // prebuild 훅(build:deps + copy-wasm/fonts/samples)까지 그대로 수행
-  console.log("\n[build-demo] 완료 → apps/hwp-lab/out/ (정적 사이트)");
-  console.log("[build-demo] 로컬 확인: npx serve apps/hwp-lab/out");
-} finally {
-  renameSync(holdDir, apiDir); // 실패해도 api/ 는 반드시 제자리로
-  rmSync(path.join(appRoot, ".next"), { recursive: true, force: true }); // export 캐시도 다음 dev 와 섞지 않는다
+function restoreMovedRoutes(routes) {
+  let restoreError;
+
+  for (const route of [...routes].reverse()) {
+    const holdExists = existsSync(route.hold);
+    const sourceExists = existsSync(route.source);
+    if (!holdExists && !sourceExists) {
+      restoreError ??= new Error(
+        `[build-demo] ${route.label} 복원 실패: 원본과 임시 보관 경로가 모두 없습니다.`,
+      );
+      continue;
+    }
+    if (!holdExists) continue;
+    if (sourceExists) {
+      restoreError ??= new Error(
+        `[build-demo] ${route.label} 복원 충돌: 원본과 임시 보관 경로가 모두 존재합니다.`,
+      );
+      continue;
+    }
+
+    try {
+      renameSync(route.hold, route.source);
+    } catch (error) {
+      restoreError ??= error;
+    }
+  }
+
+  if (restoreError) throw restoreError;
 }
+
+// 빌드 실패에도 원본 라우트가 돌아온다는 계약을 테스트에서 직접 주입·검증할 수 있게 경계를 분리한다.
+export function withDemoRoutesHeld(root, build) {
+  const routes = demoRouteHolds(root);
+
+  // 이전 실행이 비정상 종료돼 hold 만 남았다면 먼저 복원한다. 둘 다 존재하면 어느 쪽도 덮지 않고
+  // fail-closed 한다. 사용자 파일을 추측으로 선택하거나 삭제하지 않는다.
+  for (const route of routes) {
+    if (existsSync(route.hold) && existsSync(route.source)) {
+      throw new Error(`[build-demo] ${route.label} 충돌: 원본과 임시 보관 경로가 모두 존재합니다.`);
+    }
+  }
+  for (const route of routes) {
+    if (existsSync(route.hold)) renameSync(route.hold, route.source);
+  }
+  for (const route of routes) {
+    if (!existsSync(route.source)) {
+      throw new Error(`[build-demo] ${route.label} 가 없습니다 — 레포 상태를 확인하세요.`);
+    }
+  }
+
+  const moved = [];
+  try {
+    for (const route of routes) {
+      renameSync(route.source, route.hold);
+      moved.push(route);
+    }
+    return build();
+  } finally {
+    restoreMovedRoutes(moved);
+  }
+}
+
+/**
+ * @param {{
+ *   root?: string,
+ *   execute?: (command: string, options: import("node:child_process").ExecSyncOptions) => unknown,
+ *   logger?: Pick<Console, "log">
+ * }} [options]
+ */
+export function buildDemo({ root = appRoot, execute = execSync, logger = console } = {}) {
+  const nextDir = path.join(root, ".next");
+  const outDir = path.join(root, "out");
+
+  try {
+    const result = withDemoRoutesHeld(root, () => {
+      rmSync(nextDir, { recursive: true, force: true }); // 서버 빌드 캐시와 절대 섞지 않는다
+      rmSync(outDir, { recursive: true, force: true }); // 이전 export 의 /models 잔재도 허용하지 않는다
+      execute("npm run build", {
+        cwd: root,
+        stdio: "inherit",
+        env: { ...process.env, DEMO_STATIC: "1" },
+      }); // prebuild 훅(build:deps + copy-wasm/fonts/samples)까지 그대로 수행
+    });
+    logger.log("\n[build-demo] 완료 → apps/hwp-lab/out/ (정적 사이트)");
+    logger.log("[build-demo] 로컬 확인: npx serve apps/hwp-lab/out");
+    return result;
+  } catch (error) {
+    rmSync(outDir, { recursive: true, force: true }); // 실패한 export 일부를 다음 배포가 집지 못하게 한다
+    throw error;
+  } finally {
+    rmSync(nextDir, { recursive: true, force: true }); // export 캐시도 다음 dev 와 섞지 않는다
+  }
+}
+
+const isMain = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isMain) buildDemo();

--- a/apps/hwp-lab/src/app/models/page.tsx
+++ b/apps/hwp-lab/src/app/models/page.tsx
@@ -3,13 +3,14 @@ import { headers } from "next/headers";
 import { notFound } from "next/navigation";
 import { SiteFooter } from "@/components/site/SiteFooter";
 import { SiteHeader } from "@/components/site/SiteHeader";
-import { localModelsDeniedReason } from "@/lib/openrouter/gating";
+import { localModelsDeniedReason, localModelsPageRequest } from "@/lib/openrouter/gating";
 import { ModelsPanel } from "./ModelsPanel";
 import styles from "./models.module.css";
 
-const STATIC_DEMO = process.env.DEMO_STATIC === "1";
-
-export const dynamic = STATIC_DEMO ? "force-static" : "force-dynamic";
+// Next 15 requires route-segment config to be statically analyzable. The page reads request
+// headers and must therefore stay dynamic in every server build. `build-demo.mjs` removes this
+// local-only route from the app tree while producing the serverless static demo.
+export const dynamic = "force-dynamic";
 
 export const metadata: Metadata = {
   title: "Models",
@@ -18,17 +19,9 @@ export const metadata: Metadata = {
 };
 
 export default async function ModelsPage() {
-  if (STATIC_DEMO) notFound();
   const h = await headers();
-  const host = h.get("x-forwarded-host") || h.get("host") || "localhost";
-  const proto = h.get("x-forwarded-proto") || "http";
-  const req = new Request(`${proto}://${host}/models`, {
-    headers: {
-      host,
-      ...(h.get("x-forwarded-host") ? { "x-forwarded-host": h.get("x-forwarded-host")! } : {}),
-    },
-  });
-  if (localModelsDeniedReason(req)) notFound();
+  const req = localModelsPageRequest(h.get("host"), h.get("x-forwarded-host"));
+  if (!req || localModelsDeniedReason(req)) notFound();
 
   return (
     <div className={styles.page}>

--- a/apps/hwp-lab/src/lib/buildDemoContract.test.ts
+++ b/apps/hwp-lab/src/lib/buildDemoContract.test.ts
@@ -1,0 +1,123 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { buildDemo, demoRouteHolds } from "../../scripts/build-demo.mjs";
+
+const PAGE = fileURLToPath(new URL("../app/models/page.tsx", import.meta.url));
+const roots: string[] = [];
+
+function fixtureRoot(): string {
+  const root = mkdtempSync(path.join(tmpdir(), "auto-hwp-build-demo-"));
+  for (const route of ["api", "models"]) {
+    const dir = path.join(root, "src", "app", route);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(path.join(dir, ".sentinel"), route);
+  }
+  mkdirSync(path.join(root, ".next"), { recursive: true });
+  mkdirSync(path.join(root, "out", "models"), { recursive: true });
+  writeFileSync(path.join(root, "out", "models", "index.html"), "stale local-only route");
+  roots.push(root);
+  return root;
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("static demo route contract", () => {
+  it("keeps the Next 15 segment config literal and server-dynamic", () => {
+    const source = readFileSync(PAGE, "utf8");
+    const assignment = source.match(/export const dynamic\s*=\s*([^;]+);/);
+
+    expect(assignment?.[1].trim()).toBe('"force-dynamic"');
+    expect(source).not.toMatch(/const\s+STATIC_DEMO|dynamic\s*=\s*[^;]*\?/);
+    expect(source).toContain("localModelsDeniedReason(req)");
+  });
+
+  it("excludes api and local-only models, removes stale output, then restores both", () => {
+    const root = fixtureRoot();
+    const routes = demoRouteHolds(root);
+    const execute = vi.fn((command: string, options: { env?: NodeJS.ProcessEnv }) => {
+      expect(command).toBe("npm run build");
+      expect(options.env?.DEMO_STATIC).toBe("1");
+      for (const route of routes) {
+        expect(existsSync(route.source)).toBe(false);
+        expect(existsSync(route.hold)).toBe(true);
+      }
+      expect(existsSync(path.join(root, "out", "models", "index.html"))).toBe(false);
+    });
+
+    buildDemo({ root, execute, logger: { log: vi.fn() } });
+
+    expect(execute).toHaveBeenCalledOnce();
+    for (const route of routes) {
+      expect(existsSync(route.source)).toBe(true);
+      expect(existsSync(route.hold)).toBe(false);
+    }
+  });
+
+  it("restores every route when the build fails", () => {
+    const root = fixtureRoot();
+    const routes = demoRouteHolds(root);
+
+    expect(() =>
+      buildDemo({
+        root,
+        execute: () => {
+          throw new Error("synthetic build failure");
+        },
+        logger: { log: vi.fn() },
+      }),
+    ).toThrow("synthetic build failure");
+
+    for (const route of routes) {
+      expect(existsSync(route.source)).toBe(true);
+      expect(existsSync(route.hold)).toBe(false);
+    }
+    expect(existsSync(path.join(root, "out"))).toBe(false);
+  });
+
+  it("fails closed and discards partial output when a held route disappears", () => {
+    const root = fixtureRoot();
+    const routes = demoRouteHolds(root);
+    const logger = { log: vi.fn() };
+
+    expect(() =>
+      buildDemo({
+        root,
+        execute: () => {
+          mkdirSync(path.join(root, "out"), { recursive: true });
+          writeFileSync(path.join(root, "out", "partial.html"), "partial");
+          rmSync(routes[1].hold, { recursive: true, force: true });
+        },
+        logger,
+      }),
+    ).toThrow("복원 실패");
+
+    expect(logger.log).not.toHaveBeenCalled();
+    expect(existsSync(path.join(root, "out"))).toBe(false);
+    expect(existsSync(routes[0].source)).toBe(true);
+    expect(existsSync(routes[0].hold)).toBe(false);
+    expect(existsSync(routes[1].source)).toBe(false);
+    expect(existsSync(routes[1].hold)).toBe(false);
+  });
+
+  it("recovers a stale hold, but fails closed instead of overwriting a conflict", () => {
+    const root = fixtureRoot();
+    const [api, models] = demoRouteHolds(root);
+    renameSync(api.source, api.hold);
+
+    buildDemo({ root, execute: vi.fn(), logger: { log: vi.fn() } });
+    expect(existsSync(api.source)).toBe(true);
+    expect(existsSync(api.hold)).toBe(false);
+
+    mkdirSync(models.hold, { recursive: true });
+    expect(() => buildDemo({ root, execute: vi.fn(), logger: { log: vi.fn() } })).toThrow(
+      "원본과 임시 보관 경로가 모두 존재합니다",
+    );
+    expect(readFileSync(path.join(models.source, ".sentinel"), "utf8")).toBe("models");
+    expect(existsSync(models.hold)).toBe(true);
+  });
+});

--- a/apps/hwp-lab/src/lib/buildDemoContract.test.ts
+++ b/apps/hwp-lab/src/lib/buildDemoContract.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildDemo, demoRouteHolds } from "../../scripts/build-demo.mjs";
 
 const PAGE = fileURLToPath(new URL("../app/models/page.tsx", import.meta.url));
+const ROOT_GITIGNORE = fileURLToPath(new URL("../../../../.gitignore", import.meta.url));
 const roots: string[] = [];
 
 function fixtureRoot(): string {
@@ -27,6 +28,13 @@ afterEach(() => {
 });
 
 describe("static demo route contract", () => {
+  it("ignores both crash-recovery hold directories", () => {
+    const ignore = readFileSync(ROOT_GITIGNORE, "utf8");
+
+    expect(ignore).toMatch(/^apps\/hwp-lab\/\.demo-api-hold\/$/m);
+    expect(ignore).toMatch(/^apps\/hwp-lab\/\.demo-models-hold\/$/m);
+  });
+
   it("keeps the Next 15 segment config literal and server-dynamic", () => {
     const source = readFileSync(PAGE, "utf8");
     const assignment = source.match(/export const dynamic\s*=\s*([^;]+);/);

--- a/apps/hwp-lab/src/lib/openrouter/gating.ts
+++ b/apps/hwp-lab/src/lib/openrouter/gating.ts
@@ -59,6 +59,29 @@ export function localModelsDeniedReason(req: Request): LocalModelsDenyReason | n
   return null;
 }
 
+/**
+ * Rebuild the page request without letting a proxy header replace the actual Host.
+ * Missing or syntactically invalid Host values fail closed by returning null.
+ */
+export function localModelsPageRequest(
+  host: string | null | undefined,
+  forwardedHost: string | null | undefined,
+): Request | null {
+  const actualHost = host?.trim();
+  if (!actualHost) return null;
+
+  try {
+    return new Request(`http://${actualHost}/models`, {
+      headers: {
+        host: actualHost,
+        ...(forwardedHost ? { "x-forwarded-host": forwardedHost } : {}),
+      },
+    });
+  } catch {
+    return null;
+  }
+}
+
 /** Callback / connect URL origin from the request itself — no hardcoded 3000/3100/3110. */
 export function requestOrigin(req: Request): string {
   const url = new URL(req.url);

--- a/apps/hwp-lab/src/lib/openrouter/models-gating.test.ts
+++ b/apps/hwp-lab/src/lib/openrouter/models-gating.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   isLoopbackRequest,
   localModelsDeniedReason,
+  localModelsPageRequest,
   requestOrigin,
 } from "./gating";
 
@@ -60,6 +61,20 @@ describe("models-gating", () => {
         }),
       ),
     ).toBe("non-loopback");
+  });
+
+  it("keeps the actual page Host authoritative against inverse forwarded-host spoofing", () => {
+    process.env.AUTO_HWP_LOCAL_MODELS = "1";
+
+    const publicHost = localModelsPageRequest("autohwp.com", "localhost:3000");
+    expect(publicHost).not.toBeNull();
+    expect(localModelsDeniedReason(publicHost!)).toBe("non-loopback");
+
+    const loopback = localModelsPageRequest("127.0.0.1:3000", null);
+    expect(loopback).not.toBeNull();
+    expect(localModelsDeniedReason(loopback!)).toBeNull();
+
+    expect(localModelsPageRequest(null, "localhost:3000")).toBeNull();
   });
 
   it("denies the static demo build (DEMO_STATIC=1)", () => {


### PR DESCRIPTION
Closes #117

## Outcome

- Keep the Next 15 route segment config as the literal `force-dynamic` for server builds.
- Exclude both `src/app/api` and the local-only `src/app/models` route while producing the static demo.
- Restore held routes fail-closed, reject source/hold conflicts, and delete partial output after any failure.
- Keep the actual Host authoritative so `X-Forwarded-Host` cannot promote a public request to loopback access.
- Add regression contracts for literal config, static route exclusion, stale-hold recovery, restore failure, partial-output cleanup, and inverse host spoofing.

## Verification

- Focused contract and gating tests: 15 passed.
- Full app Vitest: 246 passed; editor-core 269, ai-protocol 64, React 425.
- Normal Next production build: passed; `/models` stayed dynamic.
- Static demo build: passed; `/models` and `/api` absent from output.
- Full Rust workspace, rhwp feature, license, wasm, layout gates, committed 82-document oracle contract, and JS builds: passed.
- Playwright rerun with local port permission: 85 passed, 3 intentional skips.
- Browser and HTTP QA: loopback `/models` allowed only with the local flag; disabled/public/forwarded-host spoof requests returned 404; static demo navigation and output exposed no `/models` route.
- Independent review: PASS.

No provider credentials, proposal semantics, or production enablement policy changed.