### PR TITLE
test: add bounded report-only PDF visual oracle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,8 @@ jobs:
             benchmarks/benchmark1.hwp \
             benchmarks/benchmark2.hwp \
             | node scripts/canonical-layout-gate.mjs
+      - name: PDF visual oracle foundation (issue 121)
+        run: python3 -m unittest discover -s scripts/tests -p 'test_pdf_visual_check.py'
       - name: desktop adapter contract (vitest)
         working-directory: packages/react
         run: npm ci && npx vitest run src/__tests__/desktopParity.contract.test.ts

--- a/docs/PDF-VISUAL-ORACLE.md
+++ b/docs/PDF-VISUAL-ORACLE.md
@@ -1,0 +1,390 @@
+# PDF visual oracle (report-only V0/V1)
+
+This document describes the bounded report-only foundation in GitHub issue #121, under the broader
+#93 visual-oracle track. It compares a PDF already exported by auto-hwp's own engine with an
+explicitly classified PDF reference. It does **not** render HWP/HWPX itself, infer that a nearby PDF
+is ground truth, or decide pass/fail.
+Current reports use `schema_version: 3`; non-finite values are rejected rather than emitted as
+non-standard JSON `NaN`/`Infinity` tokens.
+
+The existing stored-lineseg `layout-check` remains the fast layout regression gate. This visual report
+is additive and does not replace or relax it.
+
+## Scope
+
+`scripts/pdf-visual-check.py` currently provides:
+
+- required T0/T1/T2/T3 reference classification;
+- SHA-256 identity for the candidate and reference in every JSON and HTML report;
+- a structural stage for page count, per-page MediaBox size, valid CropBox coordinates/size,
+  rotation, and CropBox orientation;
+- 144 DPI Poppler rasterization on white after the structural stage succeeds;
+- page-by-page rasterization with input/page/pixel/PNG/metric-work/report/timeout limits;
+- deterministic integer translation alignment bounded to ±3 px;
+- complementary global, local, foreground, ink, edge, bounding-box, and tile metrics;
+- local side-by-side, overlay, and heatmap diagnostics;
+- explicit JSON `null` plus reasons when a metric is unscorable;
+- no absolute thresholds and no pass/fail field.
+
+The candidate must be the actual own-engine PDF. Do not pass output from the legacy rhwp `render`
+command and describe it as the candidate.
+
+## Reference tiers
+
+The caller must supply `--reference-tier`; the script never guesses it from a filename or directory.
+
+| Tier | Intended authority |
+|---|---|
+| T0 | Licensed Hancom Windows/WebHWP rendering with product/build/font provenance |
+| T1 | Official PDF confirmed to represent the same published document |
+| T2 | HWP/HWPX plus stored-lineseg three-way diagnostic; useful but not absolute visual truth |
+| T3 | rhwp, LibreOffice, or another debugging aid; never ground truth |
+
+Classification is an assertion by the operator, not something this program can authenticate. T0 and
+T1 require nonempty renderer/product, build, OS, font fingerprint, and provenance note fields; the
+command fails closed when any is absent. A populated record is labelled `self_attested`, never
+“complete” or authenticated. The report and HTML preserve these values alongside both file hashes.
+T2/T3 may omit unavailable fields but remain explicitly lower-authority references.
+
+References containing private, licensed, or user content must stay on an authorized private runner.
+Only self-created or appropriately redistributable fixtures belong in public CI.
+
+## Dependencies
+
+Python dependencies are deliberately limited to the standard library. Runtime comparison needs
+Poppler commands on `PATH`:
+
+```bash
+pdfinfo -v
+pdftoppm -v
+```
+
+On macOS, install them with `brew install poppler`. Poppler command versions are recorded in the
+report because raster output can change across versions.
+
+## Usage
+
+First export the candidate with our PDF path. Binary `.hwp` additionally needs the `rhwp` parser
+feature; this does not make rhwp the renderer.
+
+```bash
+cargo run -p auto-hwp-cli --features pdf,shaper,rhwp -- \
+  export-pdf benchmarks/benchmark.hwp -o /tmp/benchmark-own.pdf
+```
+
+Then compare that explicit candidate with a reference. The output directory must not already exist.
+The report is built in a sibling staging directory and renamed into place only after JSON, HTML, and
+all assets succeed, so a failed run does not leave a partial report that blocks retry.
+
+```bash
+python3 scripts/pdf-visual-check.py /tmp/benchmark-own.pdf \
+  --reference benchmarks/benchmark.pdf \
+  --reference-tier T1 \
+  --reference-product "official publication PDF" \
+  --reference-build "recorded by fixture manifest" \
+  --reference-os "recorded by fixture manifest" \
+  --font-fingerprint "sha256:..." \
+  --candidate-font-fingerprint "sha256:..." \
+  --reference-note "Pair identity verified by document owner" \
+  --output-dir /tmp/benchmark-visual-report
+```
+
+Open `/tmp/benchmark-visual-report/index.html` locally. Machine-readable results are in
+`report.json`; stable PNG assets are under `assets/`.
+
+Input paths are redacted to their basenames by default so private directory names do not leak into a
+shared report. `--include-input-paths` is an explicit local-only override; SHA-256 remains the stable
+identity in either mode.
+
+Inputs are opened as regular file descriptors with `O_NOFOLLOW` where the platform provides it, then
+copied into a private snapshot. Staging, final report, and `assets/` directories are forcibly mode
+`0700`; JSON, HTML, and every source/copied/generated PNG are forcibly mode `0600`, independent of a
+caller umask such as `000` or `022`.
+
+The process exits nonzero only for tool/input/report-generation errors. A structural mismatch or bad
+visual score still exits successfully in this report-only phase and is represented in the report
+status. Consumers must not reinterpret exit zero as a fidelity pass.
+
+## Structural stage
+
+`pdfinfo` is run before either PDF is rasterized. The report compares:
+
+1. page count;
+2. MediaBox physical width and height for each page;
+3. a positive CropBox contained in MediaBox;
+4. CropBox offset coordinates and physical width/height;
+5. normalized page rotation;
+6. effective CropBox portrait/landscape/square orientation.
+
+Physical width and height may differ by at most 1.0 pt. This admits normal A4 writer rounding such as
+`595×841 pt` versus `595.28×841.88 pt`, while a larger size difference, page-count change, rotation,
+or orientation change remains a structural mismatch. Full MediaBox coordinates are retained in JSON
+for diagnosis; the hard comparison concerns physical page size.
+
+CropBox offset and size use the same 1.0 pt writer-rounding tolerance. A changed crop origin, visible
+extent, invalid/non-positive CropBox, or CropBox outside MediaBox is a structural mismatch. Both
+`pdfinfo` inspection and `pdftoppm -cropbox` therefore describe and render the same visible page box.
+
+If any structural item differs, root `status` is `structural_mismatch`,
+`pixel_comparison_attempted` is false, and no SSIM-like score is produced. The program does not hide a
+page-size error by stretching, rotating, or cropping either page.
+
+At 144 DPI, an accepted 1 pt page-size rounding can produce a one- or two-pixel raster difference.
+The smaller raster is therefore padded only on its right/bottom with white to a shared canvas. The
+maximum permitted padding is 3 px: 2 px for 1 pt at 144 DPI plus one pixel for independent boundary
+rounding. A larger raster difference makes that page `unscorable`. Neither case resizes content.
+
+## Raster and alignment contract
+
+- `pdftoppm` renders at exactly 144 DPI with its white page background.
+- every Poppler call renders one exact page with `-cropbox -singlefile`; all page/resource checks
+  derivable from PDF metadata finish before the first raster command, while actual PNG byte and pixel
+  totals are rechecked after each page;
+- PNG alpha, if present, is flattened onto white by the decoder.
+- each input is copied once into a unique temporary directory before hashing, inspection, and raster;
+- rendered pages are selected by exact numeric page number, not a broad stale glob;
+- candidate and reference retain their original pixels and scale; only the smaller accepted A4 page
+  receives recorded white right/bottom padding to a shared canvas;
+- no scaling, fractional resampling, rotation, crop, or content-aware mask is allowed;
+- only a whole-page integer translation is searched, within ±3 px in each axis;
+- the chosen `dx`/`dy`, search objective, scale `1.0`, rotation `0`, and `crop=false` are reported.
+
+`candidate_translation_px` describes the translation applied to candidate content. For example,
+`dx=-2, dy=1` means move candidate ink two pixels left and one pixel down to align with the reference.
+Pixels shifted outside the unchanged page canvas become white and are still penalized by ink loss.
+The report records clipped candidate ink/edge counts, and precision/F1/IoU/ink-ratio denominators use
+the pre-translation candidate count, so moving candidate-only ink off-canvas cannot improve a score.
+
+Alignment chooses the translation with the greatest exact binary-ink intersection. Deterministic
+tie-breaking favors the smallest movement. Alignment is diagnostic; raw candidate PNGs remain in the
+report so the offset cannot conceal the original rendering.
+
+## Resource limits
+
+The defaults are soft operational limits. Every CLI override is revalidated by `ResourceLimits`
+against a non-bypassable hard ceiling; constructing `ResourceLimits` directly does not evade it.
+An A4 page at 144 DPI is about 2.0 million pixels, so the page default is intentionally close to real
+work rather than the former unsafe 25 million-pixel allowance.
+
+| Option | Default | Hard ceiling | Scope |
+|---|---:|---:|---|
+| `--max-input-bytes` | 100 MiB | 1 GiB | each input snapshot |
+| `--max-pages` | 200 | 1,000 | each PDF, checked before detailed `pdfinfo` |
+| `--max-page-pixels` | 4,500,000 | 8,000,000 | each 144 DPI raster |
+| `--max-total-pixels` | 250,000,000 | 1,000,000,000 | estimated and actual pixels across both PDFs |
+| `--max-raster-bytes` | 64 MiB | 256 MiB | each Poppler PNG |
+| `--max-total-raster-bytes` | 512 MiB | 2 GiB | all Poppler PNGs across both PDFs |
+| `--max-png-decompressed-bytes` | 128 MiB | 512 MiB | one PNG's decoded scanlines |
+| `--max-ink-pixels` | 600,000 | 1,000,000 | foreground pixels in each page image before Python set allocation |
+| `--max-alignment-work` | 30,000,000 | 50,000,000 | candidate ink pixels × translation candidates per page |
+| `--max-edge-work` | 16,000,000 | 30,000,000 | foreground upper bound, then exact visible edge pixels × 13 probes per page |
+| `--max-report-asset-bytes` | 64 MiB | 128 MiB | each final raw/aligned/overlay/heatmap PNG |
+| `--max-report-bytes` | 512 MiB | 2 GiB | final JSON + HTML + all PNG assets |
+| `--max-subprocess-output-bytes` | 1 MiB | 4 MiB | combined stdout/stderr for each Poppler command |
+| `--subprocess-timeout-seconds` | 60 | 300 | each `pdfinfo` or page `pdftoppm` process |
+
+Input copying is streaming and stops after the configured byte ceiling. CropBox dimensions provide a
+pixel preflight before rasterization; actual PNG dimensions and cumulative counts are checked again.
+The PNG decoder checks compressed file bytes, declared pixel count, expected scanline bytes, and uses
+bounded zlib output rather than unbounded `decompress`. A limit or timeout is a tool error, not a zero
+fidelity score, and atomic report staging leaves no partial output.
+
+Before metrics allocate `set[int]`, the implementation counts reference and candidate ink using a
+constant-memory byte scan. It rejects either excessive ink or `candidate ink × (2d+1)²` alignment
+work before the up-to-49-offset search begins. This fail-closed boundary protects the two raw ink
+sets and up-to-49-offset search without attempting a high-risk bitmap rewrite. Before those sets are
+allocated, it also rejects the conservative `(reference ink + candidate ink) × 13` edge-work upper
+bound. Every edge is a subset of foreground ink, so this bounds derived edge work without allocating a
+potentially 13-times-larger dilation. Matching then probes the fixed radius-2 neighborhood directly and
+rechecks its exact visible-edge probe count against `--max-edge-work`.
+
+On POSIX, each `pdftoppm` child receives `RLIMIT_FSIZE` equal to the configured per-raster byte limit,
+then the completed file is checked again. Platforms without `RLIMIT_FSIZE` explicitly report
+`post_write_stat_only_platform_fallback` in the environment fingerprint. Raw copies and every derived
+asset are checked immediately after generation and again after private staging copy; JSON and HTML
+are included in the final report byte budget. `MemoryError` and `OverflowError` become explicit tool
+errors instead of uncaught tracebacks or fidelity scores. Each Poppler process is drained concurrently
+through bounded stdout/stderr readers; crossing their combined byte limit kills the child and fails the
+comparison without retaining the excess output.
+
+## Metrics
+
+All metrics are reported per page. They are rounded to six decimal places in JSON for stable review.
+There is intentionally no aggregate score that can compensate for a lost object on one page.
+
+### SSIM-like measures
+
+Raw and translated-only `global` values use the luminance/contrast/structure formula over the whole
+grayscale page. Raw and aligned `local` values apply the same formula to fixed 64×64 px windows and
+report the mean and worst window. Partial edge windows are weighted by their actual pixel count, so a
+one-pixel-wide final window cannot count as much as a full 64×64 window. These are called
+**SSIM-like**, not standards-certified SSIM: the implementation is small, deterministic, and
+dependency-free rather than a replacement for a calibrated image-science library.
+
+### Union-foreground MAE
+
+Foreground means grayscale `<245`. The union-foreground MAE averages normalized absolute grayscale
+difference only where the reference or candidate contains foreground. It avoids dilution by a large
+white margin. When both pages are blank, the value is unscorable (`null`), not zero.
+
+### Ink precision, recall, F1, IoU, and ratio
+
+Binary ink metrics use the same `<245` threshold after translation:
+
+- precision asks how much candidate ink coincides with reference ink;
+- recall asks how much reference ink survives in the candidate;
+- F1 balances those directions;
+- IoU measures intersection over union;
+- ink ratio is candidate ink count divided by reference ink count.
+
+A missing candidate object therefore lowers recall even if whole-page SSIM-like remains high. If a
+denominator does not exist, the corresponding metric is JSON `null` and its reason appears under
+`unscorable_metrics`. A nonblank reference with a blank candidate has recall/F1/IoU `0`, because that
+is measurable loss; precision remains unscorable because the candidate has no predicted ink.
+
+### Edge F1
+
+Edges are the four-neighbor boundary of binary ink. Precision and recall permit a Euclidean tolerance
+of at most 2 px to avoid turning rasterizer anti-aliasing into false object loss. The tolerance is
+fixed and recorded. It is not a whole-object shift allowance; the preceding translation remains
+bounded to ±3 px.
+
+### Content bounding box
+
+The report records both raw and aligned candidate/reference ink bounding boxes plus
+left/top/right/bottom, width, and height deltas. Raw SSIM-like/bbox values prevent a translation that
+clips candidate-only edge content from looking perfect; aligned ink denominators also retain clipped
+candidate ink. If either side has no ink, bounding-box comparison is unscorable.
+
+### Worst-tile recall
+
+The page is partitioned into fixed 128×128 px tiles. Every tile containing reference ink receives an
+exact ink-recall value, and the worst tile is reported with its coordinates and ink counts. This is
+the first report-only local-region alarm: a tiny missing equation or chart cannot disappear inside an
+otherwise white, globally similar page.
+
+Future slices may add semantic text/table/image/equation/chart regions from `PageLayerTree`; these
+fixed tiles do not claim to identify object types.
+
+## Visual report
+
+For every dimension-compatible page, `index.html` shows:
+
+- reference raster;
+- raw candidate raster;
+- translated-only candidate raster;
+- overlay, with reference-only ink red and candidate-only ink blue;
+- absolute grayscale-difference heatmap;
+- a metric table and the complete page JSON.
+
+The summary lists up to five lowest-ink-F1 pages and five lowest-recall worst tiles. These are
+diagnostic rankings only, not acceptance decisions. HTML has no remote scripts, fonts, or network
+dependencies.
+
+## Determinism and identity
+
+The report records:
+
+- candidate and reference SHA-256;
+- explicit tier and required-but-self-attested T0/T1 provenance fields;
+- fixed DPI, ink threshold, edge tolerance, local-window size, and tile size;
+- Poppler tool versions;
+- OS, machine, Python, candidate/reference font identifiers, and a canonical environment SHA-256;
+- all configured limits and actual/estimated resource usage;
+- the exact alignment policy and selected offsets.
+
+Inputs are first copied into an immutable per-run snapshot. SHA-256, `pdfinfo`, and `pdftoppm` all read
+that snapshot, so a source path replaced during the run cannot make a hash describe different rendered
+bytes. Final output is staged and renamed as one directory.
+
+No wall-clock timestamp, random identifier, temporary path, or default output location is written to
+the output. Repeating a comparison with identical file bytes, command arguments, Poppler version,
+and OS/font environment should therefore produce identical report bytes and asset PNGs even when the
+input parents and output directories differ.
+
+The current CLI computes hashes but does not yet consume a signed fixture manifest. Issue #101 owns
+the ≥20-pair T0/T1 calibration and reviewed-manifest work: source/reference hash, Hancom
+product/build, OS, export method, font-file hashes, and redistribution authority. A sibling `.pdf`
+alone must never be promoted to T0 or T1.
+
+## Report-only interpretation
+
+This slice intentionally defines no universal green/yellow/red bands. Font differences and reference
+authority must be measured across representative T0/T1 samples before thresholds are adopted.
+
+Recommended rollout remains:
+
+1. collect report-only distributions with stable reference and font fingerprints;
+2. inspect worst pages/tiles and correct sink loss;
+3. introduce per-fixture regression-only baselines after repeatability is established;
+4. separately decide absolute fidelity targets from T0/T1 evidence;
+5. never allow aggregate improvement to erase a failing page or object region.
+
+`policy.pass` is therefore always JSON `null`. `status` distinguishes `structural_mismatch`,
+`partially_unscorable`, and `scored_report`; none means “passed.”
+
+### First T1 calibration (2026-08-22)
+
+The first live pass used five same-post HWPX/PDF attachment pairs from the official
+[MOHW publication](https://www.mohw.go.kr/board.es?act=view&bid=0027&list_no=1490937&mid=a10503010100).
+Source binaries and full reports remained under ignored/private paths; no document was added to Git.
+
+| Pair | Own → official pages | Status | Mean global SSIM-like | Mean ink F1 | Finding |
+|---|---:|---|---:|---:|---|
+| 01 | 4 → 4 | `scored_report` | 0.150700 | 0.318802 | typography/table geometry drift |
+| 02 | 4 → 4 | `scored_report` | 0.123952 | 0.173607 | typography/table geometry drift |
+| 03 | 4 → 6 | `structural_mismatch` | — | — | table/cell flow collapse; #95 |
+| 04 | 3 → 3 | `structural_mismatch` | — | — | final page portrait vs official landscape; #96 |
+| 05 | 9 → 9 | `scored_report` | 0.074480 | 0.257094 | page count alone hides large visual drift |
+
+All three scored documents had worst-tile recall `0.0`. This run proves that the structure-first
+stage and local-region alarm expose failures that a page-count or white-background-dominated score
+would miss. It does **not** provide enough samples to define an acceptance threshold.
+
+## Tests
+
+Run the dependency-free synthetic metric and PNG codec suite with:
+
+```bash
+python3 scripts/tests/test_pdf_visual_check.py -v
+```
+
+The suite covers exact identity, bounded translation, clipped-ink penalties, translation overflow,
+missing small foreground, blank/unscorable semantics, missing-all-ink loss, 2 px edge tolerance,
+white padding without resampling, PNG round-trips, A4 tolerance, and structural mismatches. It also
+exercises valid/different CropBoxes, `-cropbox` page rendering, input/page/pixel/raster/decompression,
+ink/alignment/edge-work, derived-asset, and report-total limits; subprocess output caps, timeouts,
+and POSIX file-size caps;
+T0/T1 provenance, path redaction, forced `0700`/`0600` modes under umask `000` and `022`, secure
+symlink rejection, finite box/rotation validation, resource-exhaustion conversion,
+structural-before-raster orchestration, complete unscorable HTML/JSON output, and atomic failure.
+When Poppler and
+`benchmarks/benchmark.pdf` are present, it rasterizes the first page and performs an exact
+self-compare; otherwise that integration case is skipped.
+
+The standard-library suite is wired into `scripts/verify-local.sh` and the required GitHub
+`build-test` job through `unittest discover`. It includes a two-run whole-report determinism check
+covering the raw byte-identical `report.json`, HTML, and every raw/derived PNG asset without deleting,
+normalizing, or ignoring any clock or path field.
+Synthetic/structural/resource tests need no third-party Python dependency; the one Poppler
+self-compare remains automatically skipped when Poppler or the benchmark fixture is unavailable.
+
+## Known first-slice limits
+
+- Inputs are PDF files; reference manifests are not yet parsed.
+- Provenance is required and labelled `self_attested`, but no signed manifest authenticates it yet.
+- The script assumes the caller already produced the candidate through `export-pdf`.
+- It does not yet compare own SVG against own PDF from the same `PageLayerTree`.
+- It cannot yet count text/table/image/equation/chart objects or PDF replay/stub events; issue #102
+  owns object accounting and SVG/PDF replay/sink parity.
+- It does not mask dynamic regions; broad automatic masking would make missing content easier to hide.
+- It does not address the known PDF `PaintOp::Image.svg` equation/chart stub. Instead, the current
+  image/tile diagnostics make that loss visible while the renderer fix proceeds separately.
+- Poppler version and platform are recorded but not enforced by a baseline manifest yet.
+- A non-POSIX platform cannot stop `pdftoppm` while it is writing an oversized file; it falls back to
+  the documented post-write stat check.
+- The output parent is checked before final rename but is not held by a directory file descriptor for
+  the entire run; use a trusted local parent until that remaining TOCTOU hardening is implemented.
+
+Those limits are reasons to keep this phase report-only, not reasons to weaken the existing layout
+oracle.

--- a/scripts/pdf-visual-check.py
+++ b/scripts/pdf-visual-check.py
@@ -1,0 +1,2696 @@
+#!/usr/bin/env python3
+"""Report-only visual comparison for a candidate PDF and an explicit reference.
+
+This is intentionally independent from hwp-fidelity.  The candidate is expected
+to be a PDF already exported by auto-hwp's own engine.  This script never
+renders HWP/HWPX itself, never assigns a pass/fail verdict, and never promotes a
+reference to ground truth without the caller supplying a T0/T1/T2/T3 tier.
+
+Only Python's standard library and Poppler's ``pdfinfo``/``pdftoppm`` are used.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import html
+import json
+import math
+import os
+import platform
+import re
+import signal
+import shutil
+import stat
+import struct
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import zlib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Set, Tuple
+
+try:
+    import resource as posix_resource
+except ImportError:  # pragma: no cover - exercised only on non-POSIX Python.
+    posix_resource = None  # type: ignore[assignment]
+
+
+SCHEMA_VERSION = 3
+DPI = 144
+MAX_TRANSLATION_PX = 3
+INK_THRESHOLD = 245
+EDGE_TOLERANCE_PX = 2
+LOCAL_SSIM_WINDOW_PX = 64
+TILE_SIZE_PX = 128
+PAGE_SIZE_TOLERANCE_PT = 1.0
+# One point is two pixels at 144 DPI. The extra pixel covers independent
+# rasterizer rounding at the page boundary; accepted pages are never scaled.
+MAX_RASTER_PADDING_PX = math.ceil(PAGE_SIZE_TOLERANCE_PT * DPI / 72.0) + 1
+PDF_BOX_VALIDATION_TOLERANCE_PT = 0.01
+
+MIB = 1024 * 1024
+GIB = 1024 * MIB
+
+DEFAULT_MAX_INPUT_BYTES = 100 * MIB
+DEFAULT_MAX_PAGES = 200
+DEFAULT_MAX_PAGE_PIXELS = 4_500_000
+DEFAULT_MAX_TOTAL_PIXELS = 250_000_000
+DEFAULT_MAX_RASTER_BYTES = 64 * MIB
+DEFAULT_MAX_TOTAL_RASTER_BYTES = 512 * MIB
+DEFAULT_MAX_PNG_DECOMPRESSED_BYTES = 128 * MIB
+DEFAULT_MAX_INK_PIXELS = 600_000
+DEFAULT_MAX_ALIGNMENT_WORK = 30_000_000
+DEFAULT_MAX_EDGE_WORK = 16_000_000
+DEFAULT_MAX_REPORT_ASSET_BYTES = 64 * MIB
+DEFAULT_MAX_REPORT_BYTES = 512 * MIB
+DEFAULT_MAX_SUBPROCESS_OUTPUT_BYTES = MIB
+DEFAULT_SUBPROCESS_TIMEOUT_SECONDS = 60.0
+
+HARD_MAX_INPUT_BYTES = GIB
+HARD_MAX_PAGES = 1_000
+HARD_MAX_PAGE_PIXELS = 8_000_000
+HARD_MAX_TOTAL_PIXELS = 1_000_000_000
+HARD_MAX_RASTER_BYTES = 256 * MIB
+HARD_MAX_TOTAL_RASTER_BYTES = 2 * GIB
+HARD_MAX_PNG_DECOMPRESSED_BYTES = 512 * MIB
+HARD_MAX_INK_PIXELS = 1_000_000
+HARD_MAX_ALIGNMENT_WORK = 50_000_000
+HARD_MAX_EDGE_WORK = 30_000_000
+HARD_MAX_REPORT_ASSET_BYTES = 128 * MIB
+HARD_MAX_REPORT_BYTES = 2 * GIB
+HARD_MAX_SUBPROCESS_OUTPUT_BYTES = 4 * MIB
+HARD_SUBPROCESS_TIMEOUT_SECONDS = 300.0
+
+REFERENCE_TIERS: Mapping[str, str] = {
+    "T0": "Licensed Hancom Windows/WebHWP rendering with product, build, and font provenance.",
+    "T1": "Official PDF confirmed to represent the same published document.",
+    "T2": "HWP/HWPX pair plus stored-lineseg three-way diagnostic; not absolute visual truth.",
+    "T3": "rhwp/LibreOffice or another debugging aid; never treated as ground truth.",
+}
+
+
+class VisualCheckError(RuntimeError):
+    """Expected input, dependency, or report-generation failure."""
+
+
+@dataclass(frozen=True)
+class ResourceLimits:
+    max_input_bytes: int
+    max_pages: int
+    max_page_pixels: int
+    max_total_pixels: int
+    max_raster_bytes: int
+    max_total_raster_bytes: int
+    max_png_decompressed_bytes: int
+    max_ink_pixels: int
+    max_alignment_work: int
+    max_edge_work: int
+    max_report_asset_bytes: int
+    max_report_bytes: int
+    max_subprocess_output_bytes: int
+    subprocess_timeout_seconds: float
+
+    def __post_init__(self) -> None:
+        integer_limits = {
+            "max_input_bytes": (self.max_input_bytes, HARD_MAX_INPUT_BYTES),
+            "max_pages": (self.max_pages, HARD_MAX_PAGES),
+            "max_page_pixels": (self.max_page_pixels, HARD_MAX_PAGE_PIXELS),
+            "max_total_pixels": (self.max_total_pixels, HARD_MAX_TOTAL_PIXELS),
+            "max_raster_bytes": (self.max_raster_bytes, HARD_MAX_RASTER_BYTES),
+            "max_total_raster_bytes": (
+                self.max_total_raster_bytes,
+                HARD_MAX_TOTAL_RASTER_BYTES,
+            ),
+            "max_png_decompressed_bytes": (
+                self.max_png_decompressed_bytes,
+                HARD_MAX_PNG_DECOMPRESSED_BYTES,
+            ),
+            "max_ink_pixels": (self.max_ink_pixels, HARD_MAX_INK_PIXELS),
+            "max_alignment_work": (
+                self.max_alignment_work,
+                HARD_MAX_ALIGNMENT_WORK,
+            ),
+            "max_edge_work": (self.max_edge_work, HARD_MAX_EDGE_WORK),
+            "max_report_asset_bytes": (
+                self.max_report_asset_bytes,
+                HARD_MAX_REPORT_ASSET_BYTES,
+            ),
+            "max_report_bytes": (self.max_report_bytes, HARD_MAX_REPORT_BYTES),
+            "max_subprocess_output_bytes": (
+                self.max_subprocess_output_bytes,
+                HARD_MAX_SUBPROCESS_OUTPUT_BYTES,
+            ),
+        }
+        for name, (value, hard_ceiling) in integer_limits.items():
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise ValueError(f"{name} must be a positive integer")
+            if value > hard_ceiling:
+                raise ValueError(
+                    f"{name} {value} exceeds hard ceiling {hard_ceiling}"
+                )
+        timeout = self.subprocess_timeout_seconds
+        if (
+            isinstance(timeout, bool)
+            or not isinstance(timeout, (int, float))
+            or not math.isfinite(timeout)
+            or timeout <= 0
+        ):
+            raise ValueError("subprocess_timeout_seconds must be positive and finite")
+        if timeout > HARD_SUBPROCESS_TIMEOUT_SECONDS:
+            raise ValueError(
+                "subprocess_timeout_seconds "
+                f"{timeout:g} exceeds hard ceiling {HARD_SUBPROCESS_TIMEOUT_SECONDS:g}"
+            )
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "max_input_bytes_per_pdf": self.max_input_bytes,
+            "max_pages_per_pdf": self.max_pages,
+            "max_pixels_per_page": self.max_page_pixels,
+            "max_total_pixels_both_pdfs": self.max_total_pixels,
+            "max_raster_bytes_per_page": self.max_raster_bytes,
+            "max_total_raster_bytes_both_pdfs": self.max_total_raster_bytes,
+            "max_png_decompressed_bytes_per_page": self.max_png_decompressed_bytes,
+            "max_ink_pixels_per_image": self.max_ink_pixels,
+            "max_alignment_work_per_page": self.max_alignment_work,
+            "max_edge_work_per_page": self.max_edge_work,
+            "max_report_asset_bytes": self.max_report_asset_bytes,
+            "max_report_bytes": self.max_report_bytes,
+            "max_subprocess_output_bytes_per_command": (
+                self.max_subprocess_output_bytes
+            ),
+            "subprocess_timeout_seconds": self.subprocess_timeout_seconds,
+            "hard_ceilings": {
+                "max_input_bytes_per_pdf": HARD_MAX_INPUT_BYTES,
+                "max_pages_per_pdf": HARD_MAX_PAGES,
+                "max_pixels_per_page": HARD_MAX_PAGE_PIXELS,
+                "max_total_pixels_both_pdfs": HARD_MAX_TOTAL_PIXELS,
+                "max_raster_bytes_per_page": HARD_MAX_RASTER_BYTES,
+                "max_total_raster_bytes_both_pdfs": HARD_MAX_TOTAL_RASTER_BYTES,
+                "max_png_decompressed_bytes_per_page": HARD_MAX_PNG_DECOMPRESSED_BYTES,
+                "max_ink_pixels_per_image": HARD_MAX_INK_PIXELS,
+                "max_alignment_work_per_page": HARD_MAX_ALIGNMENT_WORK,
+                "max_edge_work_per_page": HARD_MAX_EDGE_WORK,
+                "max_report_asset_bytes": HARD_MAX_REPORT_ASSET_BYTES,
+                "max_report_bytes": HARD_MAX_REPORT_BYTES,
+                "max_subprocess_output_bytes_per_command": (
+                    HARD_MAX_SUBPROCESS_OUTPUT_BYTES
+                ),
+                "subprocess_timeout_seconds": HARD_SUBPROCESS_TIMEOUT_SECONDS,
+            },
+        }
+
+
+@dataclass(frozen=True)
+class GrayImage:
+    width: int
+    height: int
+    pixels: bytes
+
+    def __post_init__(self) -> None:
+        if self.width <= 0 or self.height <= 0:
+            raise ValueError("image dimensions must be positive")
+        if len(self.pixels) != self.width * self.height:
+            raise ValueError("pixel byte count does not match image dimensions")
+
+
+@dataclass(frozen=True)
+class PdfPageInfo:
+    page: int
+    media_box: Tuple[float, float, float, float]
+    rotation: int
+    crop_box: Optional[Tuple[float, float, float, float]] = None
+
+    @property
+    def effective_crop_box(self) -> Tuple[float, float, float, float]:
+        return self.media_box if self.crop_box is None else self.crop_box
+
+    @property
+    def width_pt(self) -> float:
+        return abs(self.media_box[2] - self.media_box[0])
+
+    @property
+    def height_pt(self) -> float:
+        return abs(self.media_box[3] - self.media_box[1])
+
+    @property
+    def crop_width_pt(self) -> float:
+        crop = self.effective_crop_box
+        return abs(crop[2] - crop[0])
+
+    @property
+    def crop_height_pt(self) -> float:
+        crop = self.effective_crop_box
+        return abs(crop[3] - crop[1])
+
+    @property
+    def crop_offset_pt(self) -> Tuple[float, float]:
+        crop = self.effective_crop_box
+        return (crop[0] - self.media_box[0], crop[1] - self.media_box[1])
+
+    @property
+    def orientation(self) -> str:
+        width = self.crop_width_pt
+        height = self.crop_height_pt
+        if self.rotation % 180:
+            width, height = height, width
+        if math.isclose(width, height, abs_tol=PAGE_SIZE_TOLERANCE_PT):
+            return "square"
+        return "landscape" if width > height else "portrait"
+
+    def validation_errors(self) -> List[str]:
+        errors: List[str] = []
+        media = self.media_box
+        crop = self.effective_crop_box
+        coordinates = media + crop
+        if not all(math.isfinite(value) for value in coordinates):
+            errors.append("MediaBox and CropBox coordinates must be finite")
+            return errors
+        if (
+            isinstance(self.rotation, bool)
+            or not isinstance(self.rotation, int)
+            or self.rotation < 0
+            or self.rotation >= 360
+            or self.rotation % 90 != 0
+        ):
+            errors.append("page rotation must be a finite 0/90/180/270 degree integer")
+        if media[2] <= media[0] or media[3] <= media[1]:
+            errors.append("MediaBox must have positive width and height")
+        if crop[2] <= crop[0] or crop[3] <= crop[1]:
+            errors.append("CropBox must have positive width and height")
+        tolerance = PDF_BOX_VALIDATION_TOLERANCE_PT
+        if (
+            crop[0] < media[0] - tolerance
+            or crop[1] < media[1] - tolerance
+            or crop[2] > media[2] + tolerance
+            or crop[3] > media[3] + tolerance
+        ):
+            errors.append("CropBox must be contained within MediaBox")
+        return errors
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "page": self.page,
+            "media_box_pt": list(self.media_box),
+            "width_pt": self.width_pt,
+            "height_pt": self.height_pt,
+            "crop_box_pt": list(self.effective_crop_box),
+            "crop_width_pt": self.crop_width_pt,
+            "crop_height_pt": self.crop_height_pt,
+            "crop_offset_pt": list(self.crop_offset_pt),
+            "rotation_degrees": self.rotation,
+            "orientation": self.orientation,
+            "validation_errors": self.validation_errors(),
+        }
+
+
+@dataclass(frozen=True)
+class PdfInfo:
+    page_count: int
+    pages: Tuple[PdfPageInfo, ...]
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "page_count": self.page_count,
+            "pages": [page.as_dict() for page in self.pages],
+        }
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _snapshot_file(source: Path, destination: Path, max_bytes: int) -> int:
+    """Securely copy one regular file, bounded even if the input grows."""
+    total = 0
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        input_fd = os.open(source, flags)
+    except OSError as error:
+        raise VisualCheckError(
+            f"could not securely open input as a non-symlink regular file: {source.name}"
+        ) from error
+    try:
+        source_stat = os.fstat(input_fd)
+        if not stat.S_ISREG(source_stat.st_mode):
+            raise VisualCheckError(f"input is not a regular file: {source.name}")
+        output_fd = os.open(
+            destination,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+            0o600,
+        )
+        try:
+            with (
+                os.fdopen(input_fd, "rb", closefd=False) as input_stream,
+                os.fdopen(output_fd, "wb", closefd=False) as output_stream,
+            ):
+                while True:
+                    chunk = input_stream.read(min(MIB, max_bytes - total + 1))
+                    if not chunk:
+                        break
+                    total += len(chunk)
+                    if total > max_bytes:
+                        raise VisualCheckError(
+                            "input exceeds --max-input-bytes "
+                            f"({max_bytes} bytes): {source.name}"
+                        )
+                    output_stream.write(chunk)
+            os.chmod(destination, 0o600)
+        finally:
+            os.close(output_fd)
+    finally:
+        os.close(input_fd)
+    return total
+
+
+def _command_env() -> Dict[str, str]:
+    env = os.environ.copy()
+    env["LC_ALL"] = "C"
+    env["LANG"] = "C"
+    return env
+
+
+def _file_size_limit_preexec(max_bytes: int) -> Optional[Any]:
+    if posix_resource is None or not hasattr(posix_resource, "RLIMIT_FSIZE"):
+        return None
+    try:
+        _, current_hard = posix_resource.getrlimit(posix_resource.RLIMIT_FSIZE)
+    except (OSError, ValueError):
+        return None
+    infinity = posix_resource.RLIM_INFINITY
+    effective_limit = (
+        max_bytes
+        if current_hard == infinity
+        else min(max_bytes, int(current_hard))
+    )
+
+    def apply_limit() -> None:
+        assert posix_resource is not None
+        posix_resource.setrlimit(
+            posix_resource.RLIMIT_FSIZE,
+            (effective_limit, effective_limit),
+        )
+
+    return apply_limit
+
+
+def _raster_file_size_cap_mode() -> str:
+    return (
+        "posix_rlimit_fsize_plus_post_write_stat"
+        if _file_size_limit_preexec(DEFAULT_MAX_RASTER_BYTES) is not None
+        else "post_write_stat_only_platform_fallback"
+    )
+
+
+@dataclass(frozen=True)
+class _CommandCapture:
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+def _capture_command(
+    command: Sequence[str],
+    timeout_seconds: float,
+    output_limit_bytes: int,
+    file_size_limit_bytes: Optional[int] = None,
+) -> _CommandCapture:
+    if (
+        isinstance(output_limit_bytes, bool)
+        or not isinstance(output_limit_bytes, int)
+        or output_limit_bytes <= 0
+    ):
+        raise ValueError("subprocess output byte limit must be a positive integer")
+    if output_limit_bytes > HARD_MAX_SUBPROCESS_OUTPUT_BYTES:
+        raise ValueError(
+            "subprocess output byte limit "
+            f"{output_limit_bytes} exceeds hard ceiling "
+            f"{HARD_MAX_SUBPROCESS_OUTPUT_BYTES}"
+        )
+    popen_options: Dict[str, Any] = {
+        "stdout": subprocess.PIPE,
+        "stderr": subprocess.PIPE,
+        "env": _command_env(),
+        "text": False,
+    }
+    file_size_preexec = (
+        None
+        if file_size_limit_bytes is None
+        else _file_size_limit_preexec(file_size_limit_bytes)
+    )
+    if file_size_preexec is not None:
+        popen_options["preexec_fn"] = file_size_preexec
+    try:
+        process = subprocess.Popen(list(command), **popen_options)
+    except subprocess.SubprocessError as error:
+        raise VisualCheckError(
+            f"could not start command with configured process limits: {command[0]}"
+        ) from error
+
+    if process.stdout is None or process.stderr is None:  # pragma: no cover
+        process.kill()
+        process.wait()
+        raise VisualCheckError(f"could not capture command output: {command[0]}")
+
+    buffers = {"stdout": bytearray(), "stderr": bytearray()}
+    byte_count = 0
+    lock = threading.Lock()
+    output_limit_exceeded = threading.Event()
+    read_failures: List[OSError] = []
+
+    def drain(stream: Any, destination: bytearray) -> None:
+        nonlocal byte_count
+        read_chunk = getattr(stream, "read1", stream.read)
+        try:
+            while not output_limit_exceeded.is_set():
+                chunk = read_chunk(64 * 1024)
+                if not chunk:
+                    return
+                with lock:
+                    remaining = output_limit_bytes - byte_count
+                    if len(chunk) > remaining:
+                        if remaining > 0:
+                            destination.extend(chunk[:remaining])
+                            byte_count += remaining
+                        output_limit_exceeded.set()
+                        return
+                    destination.extend(chunk)
+                    byte_count += len(chunk)
+        except OSError as error:
+            with lock:
+                read_failures.append(error)
+        finally:
+            stream.close()
+
+    readers = [
+        threading.Thread(
+            target=drain,
+            args=(process.stdout, buffers["stdout"]),
+            name=f"{command[0]}-stdout",
+            daemon=True,
+        ),
+        threading.Thread(
+            target=drain,
+            args=(process.stderr, buffers["stderr"]),
+            name=f"{command[0]}-stderr",
+            daemon=True,
+        ),
+    ]
+    for reader in readers:
+        reader.start()
+
+    deadline = time.monotonic() + timeout_seconds
+    timed_out = False
+    while process.poll() is None:
+        remaining_seconds = deadline - time.monotonic()
+        if remaining_seconds <= 0:
+            timed_out = True
+            break
+        if output_limit_exceeded.wait(timeout=min(0.05, remaining_seconds)):
+            break
+
+    if timed_out or output_limit_exceeded.is_set():
+        try:
+            process.kill()
+        except OSError:
+            pass
+    try:
+        returncode = process.wait(timeout=5.0)
+    except subprocess.TimeoutExpired as error:  # pragma: no cover - kill should win.
+        try:
+            process.kill()
+        except OSError:
+            pass
+        raise VisualCheckError(f"could not terminate command: {command[0]}") from error
+
+    for reader in readers:
+        reader.join(timeout=5.0)
+    if any(reader.is_alive() for reader in readers):  # pragma: no cover
+        raise VisualCheckError(f"could not finish reading command output: {command[0]}")
+    if timed_out:
+        raise VisualCheckError(
+            f"command timed out after {timeout_seconds:g}s: {command[0]}"
+        )
+    if output_limit_exceeded.is_set():
+        raise VisualCheckError(
+            "command stdout/stderr exceeded --max-subprocess-output-bytes "
+            f"{output_limit_bytes}: {command[0]}"
+        )
+    if read_failures:
+        raise VisualCheckError(f"could not read command output: {command[0]}")
+    return _CommandCapture(
+        returncode=returncode,
+        stdout=bytes(buffers["stdout"]).decode("utf-8", errors="replace"),
+        stderr=bytes(buffers["stderr"]).decode("utf-8", errors="replace"),
+    )
+
+
+def _run_command(
+    command: Sequence[str],
+    timeout_seconds: float,
+    file_size_limit_bytes: Optional[int] = None,
+    output_limit_bytes: int = DEFAULT_MAX_SUBPROCESS_OUTPUT_BYTES,
+) -> str:
+    result = _capture_command(
+        command,
+        timeout_seconds,
+        output_limit_bytes,
+        file_size_limit_bytes=file_size_limit_bytes,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or "no diagnostic output"
+        size_signal = getattr(signal, "SIGXFSZ", None)
+        if file_size_limit_bytes is not None and (
+            (size_signal is not None and result.returncode == -size_signal)
+            or "file size limit" in detail.lower()
+        ):
+            raise VisualCheckError(
+                f"command exceeded runtime file-size cap {file_size_limit_bytes}: "
+                f"{command[0]}"
+            )
+        raise VisualCheckError(f"command failed ({result.returncode}): {' '.join(command)}\n{detail}")
+    return result.stdout
+
+
+def _tool_version(
+    command: str,
+    timeout_seconds: float,
+    output_limit_bytes: int = DEFAULT_MAX_SUBPROCESS_OUTPUT_BYTES,
+) -> str:
+    result = _capture_command(
+        [command, "-v"], timeout_seconds, output_limit_bytes
+    )
+    output = (result.stdout + "\n" + result.stderr).strip()
+    first_line = output.splitlines()[0] if output else "unknown"
+    return first_line.strip()
+
+
+_NUMBER = r"[-+]?(?:\d+(?:\.\d*)?|\.\d+)"
+
+
+def _inspect_pdf(path: Path, limits: ResourceLimits) -> PdfInfo:
+    summary = _run_command(
+        ["pdfinfo", str(path)],
+        limits.subprocess_timeout_seconds,
+        output_limit_bytes=limits.max_subprocess_output_bytes,
+    )
+    match = re.search(r"^Pages:\s+(\d+)\s*$", summary, re.MULTILINE)
+    if not match:
+        raise VisualCheckError(f"pdfinfo did not report a page count for {path}")
+    page_count = int(match.group(1))
+    if page_count <= 0:
+        raise VisualCheckError(f"PDF has no pages: {path}")
+    if page_count > limits.max_pages:
+        raise VisualCheckError(
+            f"PDF page count {page_count} exceeds --max-pages {limits.max_pages}: {path.name}"
+        )
+
+    details = _run_command(
+        ["pdfinfo", "-f", "1", "-l", str(page_count), "-box", str(path)],
+        limits.subprocess_timeout_seconds,
+        output_limit_bytes=limits.max_subprocess_output_bytes,
+    )
+    media_boxes: Dict[int, Tuple[float, float, float, float]] = {}
+    crop_boxes: Dict[int, Tuple[float, float, float, float]] = {}
+    rotations: Dict[int, int] = {}
+
+    box_pattern = re.compile(
+        rf"^Page\s+(\d+)\s+MediaBox:\s+({_NUMBER})\s+({_NUMBER})\s+({_NUMBER})\s+({_NUMBER})\s*$",
+        re.MULTILINE,
+    )
+    rotation_pattern = re.compile(
+        r"^Page\s+(\d+)\s+rot:\s+(-?\d+)\s*$", re.MULTILINE
+    )
+    crop_pattern = re.compile(
+        rf"^Page\s+(\d+)\s+CropBox:\s+({_NUMBER})\s+({_NUMBER})\s+({_NUMBER})\s+({_NUMBER})\s*$",
+        re.MULTILINE,
+    )
+    for box_match in box_pattern.finditer(details):
+        page = int(box_match.group(1))
+        media_boxes[page] = tuple(float(box_match.group(index)) for index in range(2, 6))  # type: ignore[assignment]
+    for crop_match in crop_pattern.finditer(details):
+        page = int(crop_match.group(1))
+        crop_boxes[page] = tuple(float(crop_match.group(index)) for index in range(2, 6))  # type: ignore[assignment]
+    for rotation_match in rotation_pattern.finditer(details):
+        page = int(rotation_match.group(1))
+        rotations[page] = int(rotation_match.group(2)) % 360
+
+    pages: List[PdfPageInfo] = []
+    for page in range(1, page_count + 1):
+        if page not in media_boxes:
+            raise VisualCheckError(f"pdfinfo did not report page {page} MediaBox for {path}")
+        if page not in rotations:
+            raise VisualCheckError(f"pdfinfo did not report page {page} rotation for {path}")
+        if page not in crop_boxes:
+            raise VisualCheckError(f"pdfinfo did not report page {page} CropBox for {path}")
+        pages.append(
+            PdfPageInfo(page, media_boxes[page], rotations[page], crop_boxes[page])
+        )
+    return PdfInfo(page_count=page_count, pages=tuple(pages))
+
+
+def _compare_pdf_structure(candidate: PdfInfo, reference: PdfInfo) -> Dict[str, Any]:
+    mismatches: List[Dict[str, Any]] = []
+    if candidate.page_count != reference.page_count:
+        mismatches.append(
+            {
+                "kind": "page_count",
+                "candidate": candidate.page_count,
+                "reference": reference.page_count,
+            }
+        )
+
+    for candidate_page, reference_page in zip(candidate.pages, reference.pages):
+        candidate_validation = candidate_page.validation_errors()
+        reference_validation = reference_page.validation_errors()
+        if candidate_validation:
+            mismatches.append(
+                {
+                    "kind": "invalid_candidate_boxes",
+                    "page": candidate_page.page,
+                    "errors": candidate_validation,
+                    "media_box_pt": list(candidate_page.media_box),
+                    "crop_box_pt": list(candidate_page.effective_crop_box),
+                }
+            )
+        if reference_validation:
+            mismatches.append(
+                {
+                    "kind": "invalid_reference_boxes",
+                    "page": reference_page.page,
+                    "errors": reference_validation,
+                    "media_box_pt": list(reference_page.media_box),
+                    "crop_box_pt": list(reference_page.effective_crop_box),
+                }
+            )
+        size_matches = (
+            math.isclose(
+                candidate_page.width_pt,
+                reference_page.width_pt,
+                rel_tol=0.0,
+                abs_tol=PAGE_SIZE_TOLERANCE_PT,
+            )
+            and math.isclose(
+                candidate_page.height_pt,
+                reference_page.height_pt,
+                rel_tol=0.0,
+                abs_tol=PAGE_SIZE_TOLERANCE_PT,
+            )
+        )
+        if not size_matches:
+            mismatches.append(
+                {
+                    "kind": "media_box_size",
+                    "page": candidate_page.page,
+                    "candidate_pt": list(candidate_page.media_box),
+                    "reference_pt": list(reference_page.media_box),
+                    "candidate_size_pt": [
+                        candidate_page.width_pt,
+                        candidate_page.height_pt,
+                    ],
+                    "reference_size_pt": [
+                        reference_page.width_pt,
+                        reference_page.height_pt,
+                    ],
+                    "comparison_tolerance_pt": PAGE_SIZE_TOLERANCE_PT,
+                }
+            )
+        crop_values_candidate = (
+            candidate_page.crop_offset_pt[0],
+            candidate_page.crop_offset_pt[1],
+            candidate_page.crop_width_pt,
+            candidate_page.crop_height_pt,
+        )
+        crop_values_reference = (
+            reference_page.crop_offset_pt[0],
+            reference_page.crop_offset_pt[1],
+            reference_page.crop_width_pt,
+            reference_page.crop_height_pt,
+        )
+        crop_matches = all(
+            math.isclose(
+                candidate_value,
+                reference_value,
+                rel_tol=0.0,
+                abs_tol=PAGE_SIZE_TOLERANCE_PT,
+            )
+            for candidate_value, reference_value in zip(
+                crop_values_candidate, crop_values_reference
+            )
+        )
+        if not crop_matches:
+            mismatches.append(
+                {
+                    "kind": "crop_box",
+                    "page": candidate_page.page,
+                    "candidate_pt": list(candidate_page.effective_crop_box),
+                    "reference_pt": list(reference_page.effective_crop_box),
+                    "candidate_offset_and_size_pt": list(crop_values_candidate),
+                    "reference_offset_and_size_pt": list(crop_values_reference),
+                    "comparison_tolerance_pt": PAGE_SIZE_TOLERANCE_PT,
+                }
+            )
+        if candidate_page.rotation != reference_page.rotation:
+            mismatches.append(
+                {
+                    "kind": "rotation",
+                    "page": candidate_page.page,
+                    "candidate_degrees": candidate_page.rotation,
+                    "reference_degrees": reference_page.rotation,
+                }
+            )
+        if candidate_page.orientation != reference_page.orientation:
+            mismatches.append(
+                {
+                    "kind": "orientation",
+                    "page": candidate_page.page,
+                    "candidate": candidate_page.orientation,
+                    "reference": reference_page.orientation,
+                }
+            )
+
+    return {
+        "status": "match" if not mismatches else "mismatch",
+        "mismatches": mismatches,
+        "candidate": candidate.as_dict(),
+        "reference": reference.as_dict(),
+    }
+
+
+def _estimated_raster_dimensions(page: PdfPageInfo) -> Tuple[int, int]:
+    width = max(1, math.floor(page.crop_width_pt * DPI / 72.0 + 0.5))
+    height = max(1, math.floor(page.crop_height_pt * DPI / 72.0 + 0.5))
+    if page.rotation % 180:
+        width, height = height, width
+    return width, height
+
+
+def _preflight_pixels(
+    candidate: PdfInfo, reference: PdfInfo, limits: ResourceLimits
+) -> Dict[str, Any]:
+    per_page: List[Dict[str, Any]] = []
+    total_pixels = 0
+    for side, info in (("candidate", candidate), ("reference", reference)):
+        for page in info.pages:
+            width, height = _estimated_raster_dimensions(page)
+            pixels = width * height
+            if pixels > limits.max_page_pixels:
+                raise VisualCheckError(
+                    f"estimated {side} page {page.page} pixels {pixels} exceed "
+                    f"--max-page-pixels {limits.max_page_pixels}"
+                )
+            total_pixels += pixels
+            if total_pixels > limits.max_total_pixels:
+                raise VisualCheckError(
+                    f"estimated total pixels {total_pixels} exceed "
+                    f"--max-total-pixels {limits.max_total_pixels}"
+                )
+            per_page.append(
+                {
+                    "side": side,
+                    "page": page.page,
+                    "estimated_width": width,
+                    "estimated_height": height,
+                    "estimated_pixels": pixels,
+                }
+            )
+    return {"estimated_total_pixels": total_pixels, "pages": per_page}
+
+
+def _png_chunk(kind: bytes, payload: bytes) -> bytes:
+    checksum = zlib.crc32(kind)
+    checksum = zlib.crc32(payload, checksum) & 0xFFFFFFFF
+    return struct.pack(">I", len(payload)) + kind + payload + struct.pack(">I", checksum)
+
+
+def _paeth_predictor(left: int, above: int, upper_left: int) -> int:
+    estimate = left + above - upper_left
+    left_distance = abs(estimate - left)
+    above_distance = abs(estimate - above)
+    upper_left_distance = abs(estimate - upper_left)
+    if left_distance <= above_distance and left_distance <= upper_left_distance:
+        return left
+    if above_distance <= upper_left_distance:
+        return above
+    return upper_left
+
+
+def _read_png_gray(
+    path: Path,
+    max_file_bytes: int = DEFAULT_MAX_RASTER_BYTES,
+    max_pixels: int = DEFAULT_MAX_PAGE_PIXELS,
+    max_decompressed_bytes: int = DEFAULT_MAX_PNG_DECOMPRESSED_BYTES,
+) -> GrayImage:
+    file_size = path.stat().st_size
+    if file_size > max_file_bytes:
+        raise VisualCheckError(
+            f"PNG size {file_size} exceeds limit {max_file_bytes}: {path.name}"
+        )
+    data = path.read_bytes()
+    if len(data) > max_file_bytes:
+        raise VisualCheckError(
+            f"PNG size {len(data)} exceeds limit {max_file_bytes}: {path.name}"
+        )
+    if data[:8] != b"\x89PNG\r\n\x1a\n":
+        raise VisualCheckError(f"not a PNG file: {path}")
+
+    position = 8
+    width = height = bit_depth = color_type = interlace = None
+    compressed = bytearray()
+    while position < len(data):
+        if position + 12 > len(data):
+            raise VisualCheckError(f"truncated PNG chunk in {path}")
+        length = struct.unpack(">I", data[position : position + 4])[0]
+        kind = data[position + 4 : position + 8]
+        payload_start = position + 8
+        payload_end = payload_start + length
+        crc_end = payload_end + 4
+        if crc_end > len(data):
+            raise VisualCheckError(f"truncated PNG payload in {path}")
+        payload = data[payload_start:payload_end]
+        expected_crc = struct.unpack(">I", data[payload_end:crc_end])[0]
+        actual_crc = zlib.crc32(kind)
+        actual_crc = zlib.crc32(payload, actual_crc) & 0xFFFFFFFF
+        if actual_crc != expected_crc:
+            raise VisualCheckError(f"PNG CRC mismatch in {path}")
+        position = crc_end
+
+        if kind == b"IHDR":
+            if len(payload) != 13:
+                raise VisualCheckError(f"invalid PNG IHDR in {path}")
+            width, height, bit_depth, color_type, compression, filtering, interlace = struct.unpack(
+                ">IIBBBBB", payload
+            )
+            if compression != 0 or filtering != 0:
+                raise VisualCheckError(f"unsupported PNG compression/filter method in {path}")
+        elif kind == b"IDAT":
+            compressed.extend(payload)
+        elif kind == b"IEND":
+            break
+
+    if None in (width, height, bit_depth, color_type, interlace):
+        raise VisualCheckError(f"PNG is missing IHDR: {path}")
+    assert width is not None and height is not None
+    assert bit_depth is not None and color_type is not None and interlace is not None
+    if bit_depth != 8 or interlace != 0:
+        raise VisualCheckError(
+            f"unsupported PNG format in {path}: bit_depth={bit_depth}, interlace={interlace}"
+        )
+    bytes_per_pixel = {0: 1, 2: 3, 4: 2, 6: 4}.get(color_type)
+    if bytes_per_pixel is None:
+        raise VisualCheckError(f"unsupported PNG color type {color_type} in {path}")
+
+    pixel_count = width * height
+    if pixel_count > max_pixels:
+        raise VisualCheckError(
+            f"PNG pixel count {pixel_count} exceeds limit {max_pixels}: {path.name}"
+        )
+    row_bytes = width * bytes_per_pixel
+    expected_size = height * (row_bytes + 1)
+    if expected_size > max_decompressed_bytes:
+        raise VisualCheckError(
+            "PNG decompressed scanlines exceed limit "
+            f"{max_decompressed_bytes}: {expected_size} bytes in {path.name}"
+        )
+    try:
+        decompressor = zlib.decompressobj()
+        filtered = decompressor.decompress(bytes(compressed), expected_size + 1)
+    except zlib.error as error:
+        raise VisualCheckError(f"could not decompress PNG {path}: {error}") from error
+    if decompressor.unconsumed_tail or not decompressor.eof:
+        raise VisualCheckError(
+            f"PNG decompressed data exceeds its declared bounded size or is truncated: {path.name}"
+        )
+    if decompressor.unused_data:
+        raise VisualCheckError(f"PNG has trailing compressed data: {path.name}")
+    if len(filtered) != expected_size:
+        raise VisualCheckError(
+            f"unexpected PNG data length in {path}: {len(filtered)} != {expected_size}"
+        )
+
+    decoded = bytearray()
+    previous = bytearray(row_bytes)
+    cursor = 0
+    for _ in range(height):
+        filter_type = filtered[cursor]
+        cursor += 1
+        row = bytearray(filtered[cursor : cursor + row_bytes])
+        cursor += row_bytes
+        if filter_type not in (0, 1, 2, 3, 4):
+            raise VisualCheckError(f"unsupported PNG row filter {filter_type} in {path}")
+        for index in range(row_bytes):
+            left = row[index - bytes_per_pixel] if index >= bytes_per_pixel else 0
+            above = previous[index]
+            upper_left = previous[index - bytes_per_pixel] if index >= bytes_per_pixel else 0
+            if filter_type == 1:
+                predictor = left
+            elif filter_type == 2:
+                predictor = above
+            elif filter_type == 3:
+                predictor = (left + above) // 2
+            elif filter_type == 4:
+                predictor = _paeth_predictor(left, above, upper_left)
+            else:
+                predictor = 0
+            row[index] = (row[index] + predictor) & 0xFF
+        decoded.extend(row)
+        previous = row
+
+    grayscale = bytearray(width * height)
+    if color_type == 0:
+        grayscale[:] = decoded
+    elif color_type == 2:
+        for pixel in range(width * height):
+            offset = pixel * 3
+            red, green, blue = decoded[offset : offset + 3]
+            grayscale[pixel] = (77 * red + 150 * green + 29 * blue + 128) >> 8
+    elif color_type == 4:
+        for pixel in range(width * height):
+            offset = pixel * 2
+            gray, alpha = decoded[offset : offset + 2]
+            grayscale[pixel] = (gray * alpha + 255 * (255 - alpha) + 127) // 255
+    else:  # RGBA
+        for pixel in range(width * height):
+            offset = pixel * 4
+            red, green, blue, alpha = decoded[offset : offset + 4]
+            gray = (77 * red + 150 * green + 29 * blue + 128) >> 8
+            grayscale[pixel] = (gray * alpha + 255 * (255 - alpha) + 127) // 255
+    return GrayImage(width=width, height=height, pixels=bytes(grayscale))
+
+
+def _write_png(path: Path, width: int, height: int, pixels: bytes, color_type: int) -> None:
+    bytes_per_pixel = {0: 1, 2: 3}.get(color_type)
+    if bytes_per_pixel is None:
+        raise ValueError("writer supports grayscale or RGB only")
+    expected = width * height * bytes_per_pixel
+    if len(pixels) != expected:
+        raise ValueError(f"pixel byte count {len(pixels)} does not match expected {expected}")
+    row_bytes = width * bytes_per_pixel
+    filtered = bytearray()
+    for row in range(height):
+        filtered.append(0)
+        start = row * row_bytes
+        filtered.extend(pixels[start : start + row_bytes])
+    header = struct.pack(">IIBBBBB", width, height, 8, color_type, 0, 0, 0)
+    payload = (
+        b"\x89PNG\r\n\x1a\n"
+        + _png_chunk(b"IHDR", header)
+        + _png_chunk(b"IDAT", zlib.compress(bytes(filtered), level=9))
+        + _png_chunk(b"IEND", b"")
+    )
+    path.write_bytes(payload)
+    _force_private_regular_file(path)
+
+
+def _write_gray_png(path: Path, image: GrayImage) -> None:
+    _write_png(path, image.width, image.height, image.pixels, color_type=0)
+
+
+def _write_rgb_png(path: Path, width: int, height: int, pixels: bytes) -> None:
+    _write_png(path, width, height, pixels, color_type=2)
+
+
+def _force_private_regular_file(path: Path) -> int:
+    file_status = path.lstat()
+    if stat.S_ISLNK(file_status.st_mode) or not stat.S_ISREG(file_status.st_mode):
+        raise VisualCheckError(f"expected a regular output file: {path.name}")
+    os.chmod(path, 0o600)
+    return path.stat().st_size
+
+
+def _make_private_directory(
+    path: Path, *, parents: bool = False, exist_ok: bool = False
+) -> None:
+    path.mkdir(mode=0o700, parents=parents, exist_ok=exist_ok)
+    directory_status = path.lstat()
+    if stat.S_ISLNK(directory_status.st_mode) or not stat.S_ISDIR(
+        directory_status.st_mode
+    ):
+        raise VisualCheckError(f"expected a private output directory: {path}")
+    os.chmod(path, 0o700)
+
+
+def _copy_private_regular_file(source: Path, destination: Path) -> int:
+    shutil.copyfile(source, destination)
+    return _force_private_regular_file(destination)
+
+
+def _write_private_text(path: Path, value: str) -> int:
+    path.write_text(value, encoding="utf-8")
+    return _force_private_regular_file(path)
+
+
+def _rasterize_pdf_page(
+    pdf_path: Path,
+    destination: Path,
+    label: str,
+    page: int,
+    limits: ResourceLimits,
+) -> Tuple[Path, int]:
+    _make_private_directory(destination, parents=True, exist_ok=True)
+    prefix = destination / f"{label}-page-{page:04d}"
+    command = [
+        "pdftoppm",
+        "-png",
+        "-r",
+        str(DPI),
+        "-f",
+        str(page),
+        "-l",
+        str(page),
+        "-singlefile",
+        "-cropbox",
+        "-aa",
+        "yes",
+        "-aaVector",
+        "yes",
+        "-q",
+        str(pdf_path),
+        str(prefix),
+    ]
+    _run_command(
+        command,
+        limits.subprocess_timeout_seconds,
+        file_size_limit_bytes=limits.max_raster_bytes,
+        output_limit_bytes=limits.max_subprocess_output_bytes,
+    )
+
+    output = prefix.with_suffix(".png")
+    if not output.is_file():
+        raise VisualCheckError(
+            f"pdftoppm produced no PNG for page {page}: {pdf_path.name}"
+        )
+    output_bytes = _force_private_regular_file(output)
+    if output_bytes > limits.max_raster_bytes:
+        raise VisualCheckError(
+            f"raster page {page} is {output_bytes} bytes; limit is {limits.max_raster_bytes}"
+        )
+    return output, output_bytes
+
+
+def _ink_set(image: GrayImage) -> Set[int]:
+    return {index for index, value in enumerate(image.pixels) if value < INK_THRESHOLD}
+
+
+def _translation_order(max_translation: int) -> Iterable[Tuple[int, int]]:
+    offsets = [
+        (dx, dy)
+        for dy in range(-max_translation, max_translation + 1)
+        for dx in range(-max_translation, max_translation + 1)
+    ]
+    return sorted(
+        offsets,
+        key=lambda offset: (
+            abs(offset[0]) + abs(offset[1]),
+            abs(offset[1]),
+            abs(offset[0]),
+            offset[1],
+            offset[0],
+        ),
+    )
+
+
+def _shift_set(mask: Set[int], width: int, height: int, dx: int, dy: int) -> Set[int]:
+    shifted: Set[int] = set()
+    for index in mask:
+        y, x = divmod(index, width)
+        new_x = x + dx
+        new_y = y + dy
+        if 0 <= new_x < width and 0 <= new_y < height:
+            shifted.add(new_y * width + new_x)
+    return shifted
+
+
+def _estimate_translation(
+    reference_ink: Set[int],
+    candidate_ink: Set[int],
+    width: int,
+    height: int,
+    max_translation: int = MAX_TRANSLATION_PX,
+) -> Tuple[int, int, Optional[float]]:
+    if not reference_ink and not candidate_ink:
+        return 0, 0, None
+    if reference_ink == candidate_ink:
+        return 0, 0, 1.0
+    denominator = len(reference_ink) + len(candidate_ink)
+    best_dx = best_dy = 0
+    best_intersection = -1
+    for dx, dy in _translation_order(max_translation):
+        intersection = 0
+        for index in candidate_ink:
+            y, x = divmod(index, width)
+            new_x = x + dx
+            new_y = y + dy
+            if (
+                0 <= new_x < width
+                and 0 <= new_y < height
+                and new_y * width + new_x in reference_ink
+            ):
+                intersection += 1
+        if intersection > best_intersection:
+            best_dx, best_dy = dx, dy
+            best_intersection = intersection
+    score = (2.0 * best_intersection / denominator) if denominator else None
+    return best_dx, best_dy, score
+
+
+def _shift_image(image: GrayImage, dx: int, dy: int) -> GrayImage:
+    output = bytearray([255]) * (image.width * image.height)
+    source_x = max(0, -dx)
+    destination_x = max(0, dx)
+    copy_width = image.width - abs(dx)
+    source_y = max(0, -dy)
+    destination_y = max(0, dy)
+    copy_height = image.height - abs(dy)
+    if copy_width <= 0 or copy_height <= 0:
+        return GrayImage(image.width, image.height, bytes(output))
+    for row in range(copy_height):
+        source_start = (source_y + row) * image.width + source_x
+        destination_start = (destination_y + row) * image.width + destination_x
+        output[destination_start : destination_start + copy_width] = image.pixels[
+            source_start : source_start + copy_width
+        ]
+    return GrayImage(image.width, image.height, bytes(output))
+
+
+def _pad_image(image: GrayImage, width: int, height: int) -> GrayImage:
+    """Pad the right/bottom edges with white without resampling or cropping."""
+    if width < image.width or height < image.height:
+        raise ValueError("padding canvas cannot be smaller than the image")
+    if width == image.width and height == image.height:
+        return image
+    output = bytearray([255]) * (width * height)
+    for row in range(image.height):
+        source_start = row * image.width
+        destination_start = row * width
+        output[destination_start : destination_start + image.width] = image.pixels[
+            source_start : source_start + image.width
+        ]
+    return GrayImage(width, height, bytes(output))
+
+
+def _ssim_from_sums(
+    count: int,
+    sum_reference: int,
+    sum_candidate: int,
+    sum_reference_squared: int,
+    sum_candidate_squared: int,
+    sum_cross: int,
+) -> float:
+    if count <= 0:
+        raise ValueError("SSIM-like statistics require at least one pixel")
+    reference_mean = sum_reference / count
+    candidate_mean = sum_candidate / count
+    reference_variance = max(0.0, sum_reference_squared / count - reference_mean**2)
+    candidate_variance = max(0.0, sum_candidate_squared / count - candidate_mean**2)
+    covariance = sum_cross / count - reference_mean * candidate_mean
+    c1 = (0.01 * 255) ** 2
+    c2 = (0.03 * 255) ** 2
+    numerator = (2 * reference_mean * candidate_mean + c1) * (2 * covariance + c2)
+    denominator = (
+        reference_mean**2 + candidate_mean**2 + c1
+    ) * (reference_variance + candidate_variance + c2)
+    if denominator == 0:
+        return 1.0 if numerator == 0 else 0.0
+    return max(-1.0, min(1.0, numerator / denominator))
+
+
+def _global_ssim_like(reference: GrayImage, candidate: GrayImage) -> float:
+    count = len(reference.pixels)
+    sum_reference = sum(reference.pixels)
+    sum_candidate = sum(candidate.pixels)
+    sum_reference_squared = sum(value * value for value in reference.pixels)
+    sum_candidate_squared = sum(value * value for value in candidate.pixels)
+    sum_cross = sum(
+        reference_value * candidate_value
+        for reference_value, candidate_value in zip(reference.pixels, candidate.pixels)
+    )
+    return _ssim_from_sums(
+        count,
+        sum_reference,
+        sum_candidate,
+        sum_reference_squared,
+        sum_candidate_squared,
+        sum_cross,
+    )
+
+
+def _local_ssim_like(reference: GrayImage, candidate: GrayImage) -> Dict[str, Any]:
+    values: List[float] = []
+    weighted_sum = 0.0
+    total_pixels = 0
+    for top in range(0, reference.height, LOCAL_SSIM_WINDOW_PX):
+        bottom = min(reference.height, top + LOCAL_SSIM_WINDOW_PX)
+        for left in range(0, reference.width, LOCAL_SSIM_WINDOW_PX):
+            right = min(reference.width, left + LOCAL_SSIM_WINDOW_PX)
+            count = 0
+            sum_reference = sum_candidate = 0
+            sum_reference_squared = sum_candidate_squared = sum_cross = 0
+            for y in range(top, bottom):
+                start = y * reference.width + left
+                end = y * reference.width + right
+                for reference_value, candidate_value in zip(
+                    reference.pixels[start:end], candidate.pixels[start:end]
+                ):
+                    count += 1
+                    sum_reference += reference_value
+                    sum_candidate += candidate_value
+                    sum_reference_squared += reference_value * reference_value
+                    sum_candidate_squared += candidate_value * candidate_value
+                    sum_cross += reference_value * candidate_value
+            value = _ssim_from_sums(
+                count,
+                sum_reference,
+                sum_candidate,
+                sum_reference_squared,
+                sum_candidate_squared,
+                sum_cross,
+            )
+            values.append(value)
+            weighted_sum += value * count
+            total_pixels += count
+    return {
+        "window_px": LOCAL_SSIM_WINDOW_PX,
+        "mean": weighted_sum / total_pixels,
+        "worst": min(values),
+        "window_count": len(values),
+        "mean_weighting": "window_pixel_count",
+        "total_pixels": total_pixels,
+    }
+
+
+def _edge_set(mask: Set[int], width: int, height: int) -> Set[int]:
+    edges: Set[int] = set()
+    for index in mask:
+        y, x = divmod(index, width)
+        if (
+            x == 0
+            or x == width - 1
+            or y == 0
+            or y == height - 1
+            or index - 1 not in mask
+            or index + 1 not in mask
+            or index - width not in mask
+            or index + width not in mask
+        ):
+            edges.add(index)
+    return edges
+
+
+def _disk_offsets(radius: int) -> Tuple[Tuple[int, int], ...]:
+    if radius < 0:
+        raise ValueError("dilation radius cannot be negative")
+    return tuple(
+        (dx, dy)
+        for dy in range(-radius, radius + 1)
+        for dx in range(-radius, radius + 1)
+        if dx * dx + dy * dy <= radius * radius
+    )
+
+
+def _edge_match_counts(
+    reference_edges: Set[int],
+    candidate_edges: Set[int],
+    width: int,
+    height: int,
+    radius: int,
+    max_edge_work: int,
+) -> Tuple[int, int, int, int]:
+    if (
+        isinstance(max_edge_work, bool)
+        or not isinstance(max_edge_work, int)
+        or max_edge_work <= 0
+    ):
+        raise ValueError("edge work limit must be a positive integer")
+    if max_edge_work > HARD_MAX_EDGE_WORK:
+        raise ValueError(
+            f"edge work limit {max_edge_work} exceeds hard ceiling "
+            f"{HARD_MAX_EDGE_WORK}"
+        )
+    offsets = _disk_offsets(radius)
+    work_units = (len(reference_edges) + len(candidate_edges)) * len(offsets)
+    if work_units > max_edge_work:
+        raise VisualCheckError(
+            f"edge match work {work_units} exceeds --max-edge-work "
+            f"{max_edge_work}"
+        )
+
+    def count_matches(probes: Set[int], targets: Set[int]) -> int:
+        matches = 0
+        for index in probes:
+            y, x = divmod(index, width)
+            for dx, dy in offsets:
+                new_x = x + dx
+                new_y = y + dy
+                if (
+                    0 <= new_x < width
+                    and 0 <= new_y < height
+                    and new_y * width + new_x in targets
+                ):
+                    matches += 1
+                    break
+        return matches
+
+    candidate_matches = count_matches(candidate_edges, reference_edges)
+    reference_matches = count_matches(reference_edges, candidate_edges)
+    return candidate_matches, reference_matches, work_units, len(offsets)
+
+
+def _bbox(mask: Set[int], width: int) -> Optional[Dict[str, int]]:
+    if not mask:
+        return None
+    coordinates = [divmod(index, width) for index in mask]
+    top = min(y for y, _ in coordinates)
+    bottom = max(y for y, _ in coordinates)
+    left = min(x for _, x in coordinates)
+    right = max(x for _, x in coordinates)
+    return {
+        "left": left,
+        "top": top,
+        "right": right,
+        "bottom": bottom,
+        "width": right - left + 1,
+        "height": bottom - top + 1,
+    }
+
+
+def _bbox_comparison(
+    reference_ink: Set[int], candidate_ink: Set[int], width: int
+) -> Optional[Dict[str, Any]]:
+    reference_bbox = _bbox(reference_ink, width)
+    candidate_bbox = _bbox(candidate_ink, width)
+    if reference_bbox is None or candidate_bbox is None:
+        return None
+    delta = {
+        key: candidate_bbox[key] - reference_bbox[key]
+        for key in ("left", "top", "right", "bottom", "width", "height")
+    }
+    return {
+        "reference": reference_bbox,
+        "candidate": candidate_bbox,
+        "delta_px": delta,
+        "max_abs_edge_delta_px": max(
+            abs(delta[key]) for key in ("left", "top", "right", "bottom")
+        ),
+    }
+
+
+def _worst_tile_recall(
+    reference_ink: Set[int],
+    candidate_ink: Set[int],
+    width: int,
+    height: int,
+) -> Optional[Dict[str, Any]]:
+    if not reference_ink:
+        return None
+    reference_counts: Dict[Tuple[int, int], int] = {}
+    matched_counts: Dict[Tuple[int, int], int] = {}
+    for index in reference_ink:
+        y, x = divmod(index, width)
+        tile = (x // TILE_SIZE_PX, y // TILE_SIZE_PX)
+        reference_counts[tile] = reference_counts.get(tile, 0) + 1
+        if index in candidate_ink:
+            matched_counts[tile] = matched_counts.get(tile, 0) + 1
+    worst_tile = min(
+        reference_counts,
+        key=lambda tile: (
+            matched_counts.get(tile, 0) / reference_counts[tile],
+            tile[1],
+            tile[0],
+        ),
+    )
+    tile_x, tile_y = worst_tile
+    reference_count = reference_counts[worst_tile]
+    matched_count = matched_counts.get(worst_tile, 0)
+    return {
+        "recall": matched_count / reference_count,
+        "tile_size_px": TILE_SIZE_PX,
+        "tile": {
+            "left": tile_x * TILE_SIZE_PX,
+            "top": tile_y * TILE_SIZE_PX,
+            "width": min(TILE_SIZE_PX, width - tile_x * TILE_SIZE_PX),
+            "height": min(TILE_SIZE_PX, height - tile_y * TILE_SIZE_PX),
+            "reference_ink_pixels": reference_count,
+            "matched_ink_pixels": matched_count,
+        },
+    }
+
+
+def _round_numbers(value: Any) -> Any:
+    if isinstance(value, float):
+        return round(value, 6)
+    if isinstance(value, list):
+        return [_round_numbers(item) for item in value]
+    if isinstance(value, tuple):
+        return [_round_numbers(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _round_numbers(item) for key, item in value.items()}
+    return value
+
+
+def _preflight_metric_work(
+    reference: GrayImage,
+    candidate: GrayImage,
+    max_translation: int,
+    limits: ResourceLimits,
+) -> Dict[str, int]:
+    if reference.width != candidate.width or reference.height != candidate.height:
+        raise VisualCheckError("metric preflight requires equal raster dimensions")
+    if max_translation < 0 or max_translation > MAX_TRANSLATION_PX:
+        raise VisualCheckError(
+            f"translation bound must be between 0 and {MAX_TRANSLATION_PX}px"
+        )
+    reference_ink_pixels = sum(
+        1 for value in reference.pixels if value < INK_THRESHOLD
+    )
+    candidate_ink_pixels = sum(
+        1 for value in candidate.pixels if value < INK_THRESHOLD
+    )
+    for side, ink_pixels in (
+        ("reference", reference_ink_pixels),
+        ("candidate", candidate_ink_pixels),
+    ):
+        if ink_pixels > limits.max_ink_pixels:
+            raise VisualCheckError(
+                f"{side} ink pixels {ink_pixels} exceed "
+                f"--max-ink-pixels {limits.max_ink_pixels} before set allocation"
+            )
+    alignment_candidates = (2 * max_translation + 1) ** 2
+    alignment_work = candidate_ink_pixels * alignment_candidates
+    if alignment_work > limits.max_alignment_work:
+        raise VisualCheckError(
+            f"alignment work {alignment_work} exceeds "
+            f"--max-alignment-work {limits.max_alignment_work}"
+        )
+    edge_neighbor_probes = len(_disk_offsets(EDGE_TOLERANCE_PX))
+    edge_work_upper_bound = (
+        reference_ink_pixels + candidate_ink_pixels
+    ) * edge_neighbor_probes
+    if edge_work_upper_bound > limits.max_edge_work:
+        raise VisualCheckError(
+            f"edge work upper bound {edge_work_upper_bound} exceeds "
+            f"--max-edge-work {limits.max_edge_work} before set allocation"
+        )
+    return {
+        "reference_ink_pixels": reference_ink_pixels,
+        "candidate_ink_pixels": candidate_ink_pixels,
+        "alignment_candidate_offsets": alignment_candidates,
+        "alignment_work_units": alignment_work,
+        "edge_neighbor_probes": edge_neighbor_probes,
+        "edge_work_upper_bound": edge_work_upper_bound,
+    }
+
+
+def _compare_images(
+    reference: GrayImage,
+    candidate: GrayImage,
+    max_translation: int = MAX_TRANSLATION_PX,
+    max_edge_work: int = DEFAULT_MAX_EDGE_WORK,
+) -> Tuple[GrayImage, Dict[str, Any]]:
+    if reference.width != candidate.width or reference.height != candidate.height:
+        raise ValueError("raster dimensions differ; resizing is forbidden")
+    if max_translation < 0 or max_translation > MAX_TRANSLATION_PX:
+        raise ValueError(f"translation bound must be between 0 and {MAX_TRANSLATION_PX}px")
+
+    reference_ink = _ink_set(reference)
+    raw_candidate_ink = _ink_set(candidate)
+    raw_ssim_global = _global_ssim_like(reference, candidate)
+    raw_ssim_local = _local_ssim_like(reference, candidate)
+    raw_content_bbox = _bbox_comparison(
+        reference_ink, raw_candidate_ink, reference.width
+    )
+    dx, dy, search_score = _estimate_translation(
+        reference_ink,
+        raw_candidate_ink,
+        reference.width,
+        reference.height,
+        max_translation=max_translation,
+    )
+    aligned_candidate = _shift_image(candidate, dx, dy)
+    candidate_ink = _shift_set(
+        raw_candidate_ink, reference.width, reference.height, dx, dy
+    )
+    clipped_candidate_ink: Set[int] = set()
+    for index in raw_candidate_ink:
+        y, x = divmod(index, reference.width)
+        if not (0 <= x + dx < reference.width and 0 <= y + dy < reference.height):
+            clipped_candidate_ink.add(index)
+
+    intersection = reference_ink & candidate_ink
+    union = reference_ink | candidate_ink
+    reference_count = len(reference_ink)
+    # Alignment is registration, not cropping. Candidate ink translated outside
+    # the fixed canvas remains in all metric denominators as unmatched ink.
+    candidate_count = len(raw_candidate_ink)
+    visible_candidate_count = len(candidate_ink)
+    clipped_candidate_count = len(clipped_candidate_ink)
+    true_positive_count = len(intersection)
+
+    ink_precision = true_positive_count / candidate_count if candidate_count else None
+    ink_recall = true_positive_count / reference_count if reference_count else None
+    ink_f1 = (
+        2.0 * true_positive_count / (candidate_count + reference_count)
+        if candidate_count + reference_count
+        else None
+    )
+    logical_union_count = len(union) + clipped_candidate_count
+    ink_iou = true_positive_count / logical_union_count if logical_union_count else None
+    ink_ratio = candidate_count / reference_count if reference_count else None
+
+    union_foreground_mae = None
+    if logical_union_count:
+        visible_error = sum(
+            abs(reference.pixels[index] - aligned_candidate.pixels[index])
+            for index in union
+        )
+        clipped_error = sum(
+            255 - candidate.pixels[index] for index in clipped_candidate_ink
+        )
+        union_foreground_mae = (visible_error + clipped_error) / (
+            255.0 * logical_union_count
+        )
+
+    reference_edges = _edge_set(reference_ink, reference.width, reference.height)
+    raw_candidate_edges = _edge_set(
+        raw_candidate_ink, reference.width, reference.height
+    )
+    candidate_edges = _shift_set(
+        raw_candidate_edges, reference.width, reference.height, dx, dy
+    )
+    clipped_candidate_edge_count = len(raw_candidate_edges) - len(candidate_edges)
+    (
+        candidate_edge_matches,
+        reference_edge_matches,
+        edge_work_units,
+        edge_neighbor_probes,
+    ) = _edge_match_counts(
+        reference_edges,
+        candidate_edges,
+        reference.width,
+        reference.height,
+        EDGE_TOLERANCE_PX,
+        max_edge_work,
+    )
+    edge_precision = (
+        candidate_edge_matches / len(raw_candidate_edges)
+        if raw_candidate_edges
+        else None
+    )
+    edge_recall = (
+        reference_edge_matches / len(reference_edges)
+        if reference_edges
+        else None
+    )
+    if not reference_edges and not raw_candidate_edges:
+        edge_f1 = None
+    elif edge_precision is None or edge_recall is None:
+        edge_f1 = 0.0
+    elif edge_precision + edge_recall == 0:
+        edge_f1 = 0.0
+    else:
+        edge_f1 = 2 * edge_precision * edge_recall / (edge_precision + edge_recall)
+
+    unscorable: Dict[str, str] = {}
+    if not logical_union_count:
+        unscorable["union_foreground_mae"] = "both rasters contain no foreground ink"
+        unscorable["ink_iou"] = "both rasters contain no foreground ink"
+        unscorable["ink_f1"] = "both rasters contain no foreground ink"
+    if candidate_count == 0:
+        unscorable["ink_precision"] = "candidate contains no foreground ink"
+    if reference_count == 0:
+        unscorable["ink_recall"] = "reference contains no foreground ink"
+        unscorable["ink_ratio"] = "reference contains no foreground ink"
+        unscorable["worst_tile_recall"] = "reference contains no foreground ink"
+    if not reference_edges:
+        unscorable["edge_recall"] = "reference contains no foreground edges"
+    if not raw_candidate_edges:
+        unscorable["edge_precision"] = "candidate contains no foreground edges"
+    if not reference_edges and not raw_candidate_edges:
+        unscorable["edge_f1"] = "both rasters contain no foreground edges"
+    if not reference_ink or not candidate_ink:
+        unscorable["content_bbox_delta"] = "one or both rasters contain no foreground ink"
+
+    metrics = {
+        "status": "partially_unscorable" if unscorable else "scored",
+        "dimensions_px": {"width": reference.width, "height": reference.height},
+        "blankness": {
+            "reference_blank": reference_count == 0,
+            "candidate_blank": candidate_count == 0,
+            "matches": (reference_count == 0) == (candidate_count == 0),
+        },
+        "alignment": {
+            "method": "bounded_integer_translation",
+            "candidate_translation_px": {"dx": dx, "dy": dy},
+            "max_abs_translation_px": max_translation,
+            "search_objective": "exact_binary_ink_f1",
+            "search_score": search_score,
+            "scale": 1.0,
+            "rotation_degrees": 0,
+            "crop": False,
+            "clipped_candidate_ink_pixels": clipped_candidate_count,
+            "clipped_candidate_edge_pixels": clipped_candidate_edge_count,
+        },
+        "ssim_like": {
+            "raw_global": raw_ssim_global,
+            "raw_local": raw_ssim_local,
+            "global": _global_ssim_like(reference, aligned_candidate),
+            "local": _local_ssim_like(reference, aligned_candidate),
+            "aligned_fields": ["global", "local"],
+        },
+        "union_foreground_mae": union_foreground_mae,
+        "ink": {
+            "threshold_gray_lt": INK_THRESHOLD,
+            "reference_pixels": reference_count,
+            "candidate_pixels": candidate_count,
+            "candidate_visible_pixels_after_translation": visible_candidate_count,
+            "candidate_clipped_pixels": clipped_candidate_count,
+            "matched_pixels": true_positive_count,
+            "precision": ink_precision,
+            "recall": ink_recall,
+            "f1": ink_f1,
+            "iou": ink_iou,
+            "candidate_to_reference_ratio": ink_ratio,
+        },
+        "edge": {
+            "tolerance_px": EDGE_TOLERANCE_PX,
+            "neighbor_probes_per_edge": edge_neighbor_probes,
+            "match_work_units": edge_work_units,
+            "reference_pixels": len(reference_edges),
+            "candidate_pixels": len(raw_candidate_edges),
+            "candidate_visible_pixels_after_translation": len(candidate_edges),
+            "candidate_clipped_pixels": clipped_candidate_edge_count,
+            "precision": edge_precision,
+            "recall": edge_recall,
+            "f1": edge_f1,
+        },
+        "content_bbox": _bbox_comparison(reference_ink, candidate_ink, reference.width),
+        "raw_content_bbox": raw_content_bbox,
+        "worst_tile_recall": _worst_tile_recall(
+            reference_ink,
+            candidate_ink,
+            reference.width,
+            reference.height,
+        ),
+        "unscorable_metrics": unscorable,
+    }
+    return aligned_candidate, _round_numbers(metrics)
+
+
+def _overlay_pixels(reference: GrayImage, candidate: GrayImage) -> bytes:
+    output = bytearray(reference.width * reference.height * 3)
+    for index, (reference_gray, candidate_gray) in enumerate(
+        zip(reference.pixels, candidate.pixels)
+    ):
+        reference_ink = 255 - reference_gray
+        candidate_ink = 255 - candidate_gray
+        offset = index * 3
+        # Reference-only differences are red; candidate-only differences are blue;
+        # matching dark content remains neutral/black.
+        output[offset] = 255 - candidate_ink
+        output[offset + 1] = 255 - max(reference_ink, candidate_ink)
+        output[offset + 2] = 255 - reference_ink
+    return bytes(output)
+
+
+def _heatmap_pixels(reference: GrayImage, candidate: GrayImage) -> bytes:
+    output = bytearray(reference.width * reference.height * 3)
+    for index, (reference_gray, candidate_gray) in enumerate(
+        zip(reference.pixels, candidate.pixels)
+    ):
+        difference = abs(reference_gray - candidate_gray)
+        offset = index * 3
+        output[offset] = 255
+        output[offset + 1] = 255 - difference
+        output[offset + 2] = 255 - difference
+    return bytes(output)
+
+
+def _format_metric(value: Any) -> str:
+    if value is None:
+        return "unscorable"
+    if isinstance(value, float):
+        return f"{value:.6f}"
+    return html.escape(str(value))
+
+
+def _render_html(report: Mapping[str, Any]) -> str:
+    candidate = report["inputs"]["candidate"]
+    reference = report["inputs"]["reference"]
+    structural = report["structural"]
+    page_sections: List[str] = []
+    for page in report.get("pages", []):
+        metrics = page.get("metrics")
+        if metrics is None:
+            metric_rows = (
+                f"<p class=warning>Pixel metrics are unscorable: "
+                f"{html.escape(page.get('reason', 'unknown reason'))}</p>"
+            )
+        else:
+            worst_tile = metrics.get("worst_tile_recall")
+            raw_bbox = metrics.get("raw_content_bbox")
+            aligned_bbox = metrics.get("content_bbox")
+            metric_rows = f"""
+            <table>
+              <tr><th>Metric</th><th>Value</th></tr>
+              <tr><td>Raw / aligned global SSIM-like</td><td>{_format_metric(metrics['ssim_like']['raw_global'])} / {_format_metric(metrics['ssim_like']['global'])}</td></tr>
+              <tr><td>Raw local mean / worst</td><td>{_format_metric(metrics['ssim_like']['raw_local']['mean'])} / {_format_metric(metrics['ssim_like']['raw_local']['worst'])}</td></tr>
+              <tr><td>Aligned local mean / worst</td><td>{_format_metric(metrics['ssim_like']['local']['mean'])} / {_format_metric(metrics['ssim_like']['local']['worst'])}</td></tr>
+              <tr><td>Union-foreground MAE</td><td>{_format_metric(metrics['union_foreground_mae'])}</td></tr>
+              <tr><td>Ink precision / recall / F1 / IoU</td><td>{_format_metric(metrics['ink']['precision'])} / {_format_metric(metrics['ink']['recall'])} / {_format_metric(metrics['ink']['f1'])} / {_format_metric(metrics['ink']['iou'])}</td></tr>
+              <tr><td>Edge F1 (≤ {metrics['edge']['tolerance_px']} px)</td><td>{_format_metric(metrics['edge']['f1'])}</td></tr>
+              <tr><td>Ink ratio</td><td>{_format_metric(metrics['ink']['candidate_to_reference_ratio'])}</td></tr>
+              <tr><td>Raw / aligned bbox max edge delta</td><td>{_format_metric(None if raw_bbox is None else raw_bbox['max_abs_edge_delta_px'])} / {_format_metric(None if aligned_bbox is None else aligned_bbox['max_abs_edge_delta_px'])}</td></tr>
+              <tr><td>Worst-tile recall</td><td>{_format_metric(None if worst_tile is None else worst_tile['recall'])}</td></tr>
+            </table>
+            """
+        artifacts = page.get("artifacts", {})
+        image_cards: List[str] = []
+        for key, label in (
+            ("reference", "Reference"),
+            ("candidate_raw", "Candidate (raw)"),
+            ("candidate_aligned", "Candidate (translated only)"),
+            ("overlay", "Overlay: reference red, candidate blue"),
+            ("heatmap", "Absolute-difference heatmap"),
+        ):
+            if key in artifacts:
+                image_cards.append(
+                    f'<figure><figcaption>{html.escape(label)}</figcaption>'
+                    f'<img src="{html.escape(artifacts[key])}" alt="{html.escape(label)} page {page["page"]}"></figure>'
+                )
+        offset = (page.get("alignment") or {}).get("candidate_translation_px")
+        offset_text = (
+            f"Candidate translation: dx={offset['dx']} px, dy={offset['dy']} px. "
+            "Scale=1, rotation=0, crop=false."
+            if offset
+            else "No alignment was scored."
+        )
+        page_sections.append(
+            f"""
+            <section>
+              <h2>Page {page['page']} - {html.escape(page['status'])}</h2>
+              <p>{html.escape(offset_text)}</p>
+              {metric_rows}
+              <div class=images>{''.join(image_cards)}</div>
+              <details><summary>Page JSON</summary><pre>{html.escape(json.dumps(page, ensure_ascii=False, indent=2, sort_keys=True))}</pre></details>
+            </section>
+            """
+        )
+
+    mismatch_items = "".join(
+        f"<li><code>{html.escape(json.dumps(item, ensure_ascii=False, sort_keys=True))}</code></li>"
+        for item in structural["mismatches"]
+    )
+    if mismatch_items:
+        structure_notice = (
+            "<p class=warning>Structural mismatch: pixel comparison was not attempted.</p>"
+            f"<ul>{mismatch_items}</ul>"
+        )
+    else:
+        structure_notice = (
+            "<p class=ok>Page count, physical MediaBox size, CropBox coordinates/size "
+            "(within 1 pt), rotation, and CropBox orientation match.</p>"
+        )
+
+    worst_pages = report.get("summary", {}).get("worst_pages", [])
+    worst_tiles = report.get("summary", {}).get("worst_tiles", [])
+    return f"""<!doctype html>
+<html lang=en>
+<head>
+  <meta charset=utf-8>
+  <meta name=viewport content="width=device-width, initial-scale=1">
+  <title>auto-hwp PDF visual check</title>
+  <style>
+    :root {{ color-scheme: light; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }}
+    body {{ margin: 0 auto; max-width: 1500px; padding: 24px; color: #172033; background: #f5f7fb; }}
+    header, section {{ background: white; border: 1px solid #d8deea; border-radius: 10px; padding: 20px; margin-bottom: 20px; }}
+    h1, h2 {{ margin-top: 0; }}
+    code, pre {{ font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }}
+    pre {{ white-space: pre-wrap; overflow-wrap: anywhere; }}
+    table {{ border-collapse: collapse; width: 100%; margin: 12px 0; }}
+    th, td {{ border: 1px solid #d8deea; padding: 7px 9px; text-align: left; }}
+    th {{ background: #eef2f8; }}
+    .images {{ display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 16px; }}
+    figure {{ margin: 0; min-width: 0; }}
+    figcaption {{ font-weight: 600; margin-bottom: 5px; }}
+    img {{ display: block; width: 100%; height: auto; border: 1px solid #cbd3e1; background: white; }}
+    .warning {{ color: #8a2c0d; font-weight: 700; }}
+    .ok {{ color: #17643a; font-weight: 700; }}
+    .muted {{ color: #5c667a; }}
+    @media (max-width: 800px) {{ .images {{ grid-template-columns: 1fr; }} }}
+  </style>
+</head>
+<body>
+  <header>
+    <h1>auto-hwp PDF visual check</h1>
+    <p class=warning>Report-only. This report intentionally contains no pass/fail verdict.</p>
+    <table>
+      <tr><th>Candidate</th><td>{html.escape(candidate['path'])}<br><code>{candidate['sha256']}</code></td></tr>
+      <tr><th>Reference</th><td>{html.escape(reference['path'])}<br><code>{reference['sha256']}</code></td></tr>
+      <tr><th>Reference tier</th><td>{reference['tier']}: {html.escape(reference['tier_description'])}</td></tr>
+      <tr><th>Reference product/build</th><td>{html.escape(str(reference.get('product')))} / {html.escape(str(reference.get('build')))}</td></tr>
+      <tr><th>Reference OS/font</th><td>{html.escape(str(reference.get('os')))} / {html.escape(str(reference.get('font_fingerprint')))}</td></tr>
+      <tr><th>Reference provenance</th><td>{html.escape(str(reference.get('provenance_validation', {}).get('status')))} - {html.escape(str(reference.get('note')))}</td></tr>
+      <tr><th>Environment fingerprint</th><td><code>{report['environment']['fingerprint_sha256']}</code></td></tr>
+      <tr><th>DPI</th><td>{report['environment']['dpi']}</td></tr>
+      <tr><th>Overall status</th><td>{html.escape(report['status'])}</td></tr>
+    </table>
+    <p class=muted>Full machine-readable data: <a href="report.json">report.json</a></p>
+  </header>
+  <section>
+    <h2>Structural stage</h2>
+    {structure_notice}
+  </section>
+  <section>
+    <h2>Worst-page diagnostics</h2>
+    <p>Worst pages: <code>{html.escape(json.dumps(worst_pages, ensure_ascii=False, sort_keys=True))}</code></p>
+    <p>Worst tiles: <code>{html.escape(json.dumps(worst_tiles, ensure_ascii=False, sort_keys=True))}</code></p>
+  </section>
+  {''.join(page_sections)}
+</body>
+</html>
+"""
+
+
+def _summarize_pages(pages: Sequence[Mapping[str, Any]]) -> Dict[str, Any]:
+    scored = [page for page in pages if page.get("metrics") is not None]
+    unscorable = [page for page in pages if page.get("metrics") is None]
+    partially_unscorable = [
+        page
+        for page in scored
+        if page["metrics"].get("status") == "partially_unscorable"
+    ]
+
+    def page_key(page: Mapping[str, Any]) -> Tuple[float, float, int]:
+        metrics = page["metrics"]
+        ink_f1 = metrics["ink"]["f1"]
+        local_mean = metrics["ssim_like"]["local"]["mean"]
+        return (
+            float("inf") if ink_f1 is None else ink_f1,
+            float("inf") if local_mean is None else local_mean,
+            page["page"],
+        )
+
+    worst_pages = []
+    for page in sorted(scored, key=page_key)[:5]:
+        metrics = page["metrics"]
+        worst_tile = metrics["worst_tile_recall"]
+        worst_pages.append(
+            {
+                "page": page["page"],
+                "ink_f1": metrics["ink"]["f1"],
+                "local_ssim_like_mean": metrics["ssim_like"]["local"]["mean"],
+                "worst_tile_recall": None if worst_tile is None else worst_tile["recall"],
+            }
+        )
+
+    tile_entries = []
+    for page in scored:
+        worst_tile = page["metrics"]["worst_tile_recall"]
+        if worst_tile is not None:
+            tile_entries.append(
+                {
+                    "page": page["page"],
+                    "recall": worst_tile["recall"],
+                    "tile": worst_tile["tile"],
+                }
+            )
+    tile_entries.sort(key=lambda item: (item["recall"], item["page"]))
+
+    return {
+        "total_pages": len(pages),
+        "scored_pages": len(scored),
+        "unscorable_pages": len(unscorable),
+        "partially_unscorable_pages": len(partially_unscorable),
+        "worst_pages": worst_pages,
+        "worst_tiles": tile_entries[:5],
+    }
+
+
+def _ensure_output_target(output_dir: Path) -> None:
+    if output_dir.exists() or output_dir.is_symlink():
+        raise VisualCheckError(f"output path already exists; choose a new directory: {output_dir}")
+    output_dir.parent.mkdir(parents=True, exist_ok=True)
+
+
+def _register_report_asset(
+    generated_assets: Dict[str, Path],
+    relative_name: str,
+    source: Path,
+    limits: ResourceLimits,
+    current_asset_bytes: int,
+) -> int:
+    if Path(relative_name).name != relative_name or not relative_name.endswith(".png"):
+        raise VisualCheckError(f"invalid generated PNG asset name: {relative_name}")
+    asset_bytes = _force_private_regular_file(source)
+    if asset_bytes > limits.max_report_asset_bytes:
+        raise VisualCheckError(
+            f"report asset {relative_name} is {asset_bytes} bytes; "
+            f"limit is {limits.max_report_asset_bytes}"
+        )
+    next_total = current_asset_bytes + asset_bytes
+    if next_total > limits.max_report_bytes:
+        raise VisualCheckError(
+            f"report assets total {next_total} bytes exceeds "
+            f"--max-report-bytes {limits.max_report_bytes}"
+        )
+    generated_assets[relative_name] = source
+    return next_total
+
+
+def _write_report(
+    output_dir: Path,
+    report: Dict[str, Any],
+    generated_assets: Mapping[str, Path],
+    limits: ResourceLimits,
+) -> None:
+    normalized_report = _round_numbers(report)
+    try:
+        report_json = json.dumps(
+            normalized_report,
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+            allow_nan=False,
+        ) + "\n"
+    except ValueError as error:
+        raise VisualCheckError(
+            "report contains a non-finite or otherwise invalid JSON value"
+        ) from error
+    # Render first, then stage every output beside the final directory. A
+    # rendering/copy failure leaves no partial report that blocks a retry.
+    report_html = _render_html(normalized_report)
+    report_json_bytes = len(report_json.encode("utf-8"))
+    report_html_bytes = len(report_html.encode("utf-8"))
+    source_asset_bytes = 0
+    for relative_name, source in sorted(generated_assets.items()):
+        if Path(relative_name).name != relative_name or not relative_name.endswith(".png"):
+            raise VisualCheckError(f"invalid generated PNG asset name: {relative_name}")
+        asset_bytes = _force_private_regular_file(source)
+        if asset_bytes > limits.max_report_asset_bytes:
+            raise VisualCheckError(
+                f"report asset {relative_name} is {asset_bytes} bytes; "
+                f"limit is {limits.max_report_asset_bytes}"
+            )
+        source_asset_bytes += asset_bytes
+    projected_total = report_json_bytes + report_html_bytes + source_asset_bytes
+    if projected_total > limits.max_report_bytes:
+        raise VisualCheckError(
+            f"final report would be {projected_total} bytes; "
+            f"limit is {limits.max_report_bytes}"
+        )
+
+    with tempfile.TemporaryDirectory(
+        prefix=".auto-hwp-pdf-report-", dir=str(output_dir.parent)
+    ) as staging_parent:
+        _make_private_directory(Path(staging_parent), exist_ok=True)
+        staging_dir = Path(staging_parent) / "report"
+        _make_private_directory(staging_dir)
+        assets_dir = staging_dir / "assets"
+        _make_private_directory(assets_dir)
+        copied_total = 0
+        for relative_name, source in sorted(generated_assets.items()):
+            copied_bytes = _copy_private_regular_file(
+                source, assets_dir / relative_name
+            )
+            if copied_bytes > limits.max_report_asset_bytes:
+                raise VisualCheckError(
+                    f"copied report asset {relative_name} is {copied_bytes} bytes; "
+                    f"limit is {limits.max_report_asset_bytes}"
+                )
+            copied_total += copied_bytes
+            if copied_total > limits.max_report_bytes:
+                raise VisualCheckError(
+                    f"copied report assets total {copied_total} bytes exceeds "
+                    f"--max-report-bytes {limits.max_report_bytes}"
+                )
+        written_total = copied_total
+        written_total += _write_private_text(staging_dir / "report.json", report_json)
+        if written_total > limits.max_report_bytes:
+            raise VisualCheckError(
+                f"staged report exceeds --max-report-bytes {limits.max_report_bytes}"
+            )
+        written_total += _write_private_text(staging_dir / "index.html", report_html)
+        if written_total > limits.max_report_bytes:
+            raise VisualCheckError(
+                f"staged report exceeds --max-report-bytes {limits.max_report_bytes}"
+            )
+        if output_dir.exists() or output_dir.is_symlink():
+            raise VisualCheckError(
+                f"output path appeared during report generation: {output_dir}"
+            )
+        os.chmod(staging_dir, 0o700)
+        os.chmod(assets_dir, 0o700)
+        staging_dir.rename(output_dir)
+        os.chmod(output_dir, 0o700)
+
+
+def _limits_from_args(args: argparse.Namespace) -> ResourceLimits:
+    return ResourceLimits(
+        max_input_bytes=args.max_input_bytes,
+        max_pages=args.max_pages,
+        max_page_pixels=args.max_page_pixels,
+        max_total_pixels=args.max_total_pixels,
+        max_raster_bytes=args.max_raster_bytes,
+        max_total_raster_bytes=args.max_total_raster_bytes,
+        max_png_decompressed_bytes=args.max_png_decompressed_bytes,
+        max_ink_pixels=args.max_ink_pixels,
+        max_alignment_work=args.max_alignment_work,
+        max_edge_work=args.max_edge_work,
+        max_report_asset_bytes=args.max_report_asset_bytes,
+        max_report_bytes=args.max_report_bytes,
+        max_subprocess_output_bytes=args.max_subprocess_output_bytes,
+        subprocess_timeout_seconds=args.subprocess_timeout_seconds,
+    )
+
+
+def _provenance_validation(args: argparse.Namespace) -> Dict[str, Any]:
+    fields = {
+        "product": args.reference_product,
+        "build": args.reference_build,
+        "os": args.reference_os,
+        "font_fingerprint": args.font_fingerprint,
+        "note": args.reference_note,
+    }
+    required = list(fields) if args.reference_tier in ("T0", "T1") else []
+    missing = [
+        name
+        for name in required
+        if not isinstance(fields[name], str) or not fields[name].strip()
+    ]
+    if missing:
+        status = "incomplete"
+    elif required:
+        status = "self_attested"
+    else:
+        status = "optional_unverified"
+    return {
+        "status": status,
+        "required_fields": required,
+        "missing_fields": missing,
+        "authentication": "caller_assertion_not_cryptographically_verified",
+    }
+
+
+def _environment_details(args: argparse.Namespace, limits: ResourceLimits) -> Dict[str, Any]:
+    details = {
+        "dpi": DPI,
+        "background": "white",
+        "input_snapshotting": "copy_before_hash_inspect_and_raster",
+        "pdfinfo": _tool_version(
+            "pdfinfo",
+            limits.subprocess_timeout_seconds,
+            limits.max_subprocess_output_bytes,
+        ),
+        "pdftoppm": _tool_version(
+            "pdftoppm",
+            limits.subprocess_timeout_seconds,
+            limits.max_subprocess_output_bytes,
+        ),
+        "platform_system": platform.system(),
+        "platform_release": platform.release(),
+        "platform_machine": platform.machine(),
+        "python_implementation": platform.python_implementation(),
+        "python_version": platform.python_version(),
+        "candidate_font_fingerprint": args.candidate_font_fingerprint,
+        "reference_font_fingerprint": args.font_fingerprint,
+        "ink_threshold_gray_lt": INK_THRESHOLD,
+        "edge_tolerance_px": EDGE_TOLERANCE_PX,
+        "local_ssim_window_px": LOCAL_SSIM_WINDOW_PX,
+        "worst_tile_size_px": TILE_SIZE_PX,
+        "crop_policy": "pdfinfo CropBox contract plus pdftoppm -cropbox",
+        "raster_output_file_size_cap": _raster_file_size_cap_mode(),
+        "input_open_policy": (
+            "regular_file_descriptor_with_o_nofollow"
+            if hasattr(os, "O_NOFOLLOW")
+            else "regular_file_descriptor_without_platform_o_nofollow"
+        ),
+        "report_permissions": "directories_0700_files_0600",
+    }
+    canonical = json.dumps(details, ensure_ascii=False, sort_keys=True).encode("utf-8")
+    details["fingerprint_sha256"] = hashlib.sha256(canonical).hexdigest()
+    return details
+
+
+def _reported_path(path_value: str, include_input_paths: bool) -> str:
+    path = Path(path_value)
+    return str(path) if include_input_paths else path.name
+
+
+def _base_report(
+    args: argparse.Namespace,
+    candidate_sha: str,
+    reference_sha: str,
+    candidate_bytes: int,
+    reference_bytes: int,
+    limits: ResourceLimits,
+) -> Dict[str, Any]:
+    provenance = _provenance_validation(args)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_only": True,
+        "policy": {
+            "mode": "report-only",
+            "pass": None,
+            "note": "No absolute or regression threshold is applied in this slice.",
+        },
+        "inputs": {
+            "candidate": {
+                "path": _reported_path(args.candidate, args.include_input_paths),
+                "path_redacted": not args.include_input_paths,
+                "sha256": candidate_sha,
+                "bytes": candidate_bytes,
+            },
+            "reference": {
+                "path": _reported_path(args.reference, args.include_input_paths),
+                "path_redacted": not args.include_input_paths,
+                "sha256": reference_sha,
+                "bytes": reference_bytes,
+                "tier": args.reference_tier,
+                "tier_description": REFERENCE_TIERS[args.reference_tier],
+                "product": args.reference_product,
+                "build": args.reference_build,
+                "os": args.reference_os,
+                "font_fingerprint": args.font_fingerprint,
+                "note": args.reference_note,
+                "provenance_validation": provenance,
+            },
+        },
+        "environment": _environment_details(args, limits),
+        "resource_limits": limits.as_dict(),
+        "alignment_policy": {
+            "page_size_tolerance_pt": PAGE_SIZE_TOLERANCE_PT,
+            "raster_canvas": "white_pad_right_and_bottom_only",
+            "max_raster_padding_px": MAX_RASTER_PADDING_PX,
+            "translation_only": True,
+            "max_abs_translation_px": args.max_translation_px,
+            "scale": 1.0,
+            "rotation_degrees": 0,
+            "crop": False,
+            "resize": False,
+        },
+    }
+
+
+def _run_visual_check(args: argparse.Namespace) -> Dict[str, Any]:
+    try:
+        return _run_visual_check_impl(args)
+    except (MemoryError, OverflowError) as error:
+        raise VisualCheckError(
+            "resource exhaustion while inspecting, rasterizing, or scoring PDFs"
+        ) from error
+
+
+def _run_visual_check_impl(args: argparse.Namespace) -> Dict[str, Any]:
+    candidate_path = Path(args.candidate)
+    reference_path = Path(args.reference)
+    output_dir = Path(args.output_dir)
+    limits = _limits_from_args(args)
+    provenance = _provenance_validation(args)
+    if provenance["missing_fields"]:
+        raise VisualCheckError(
+            f"{args.reference_tier} reference requires provenance fields: "
+            + ", ".join(provenance["missing_fields"])
+        )
+    for dependency in ("pdfinfo", "pdftoppm"):
+        if shutil.which(dependency) is None:
+            raise VisualCheckError(f"required Poppler command is unavailable: {dependency}")
+    for label, path in (("candidate", candidate_path), ("reference", reference_path)):
+        if not path.is_file():
+            raise VisualCheckError(f"{label} PDF does not exist: {path}")
+    _ensure_output_target(output_dir)
+
+    # Snapshot each input once. Hashing, pdfinfo, and rasterization all consume
+    # these exact bytes, so a concurrently replaced source path cannot make the
+    # report hash describe different content from the rendered pages.
+    with tempfile.TemporaryDirectory(prefix="auto-hwp-pdf-visual-") as temporary:
+        temporary_path = Path(temporary)
+        candidate_snapshot = temporary_path / "candidate.pdf"
+        reference_snapshot = temporary_path / "reference.pdf"
+        candidate_bytes = _snapshot_file(
+            candidate_path, candidate_snapshot, limits.max_input_bytes
+        )
+        reference_bytes = _snapshot_file(
+            reference_path, reference_snapshot, limits.max_input_bytes
+        )
+        return _run_visual_check_from_snapshots(
+            args,
+            candidate_snapshot,
+            reference_snapshot,
+            output_dir,
+            temporary_path,
+            candidate_bytes,
+            reference_bytes,
+            limits,
+        )
+
+
+def _run_visual_check_from_snapshots(
+    args: argparse.Namespace,
+    candidate_snapshot: Path,
+    reference_snapshot: Path,
+    output_dir: Path,
+    temporary_path: Path,
+    candidate_bytes: int,
+    reference_bytes: int,
+    limits: ResourceLimits,
+) -> Dict[str, Any]:
+    candidate_sha = _sha256(candidate_snapshot)
+    reference_sha = _sha256(reference_snapshot)
+    report = _base_report(
+        args,
+        candidate_sha,
+        reference_sha,
+        candidate_bytes,
+        reference_bytes,
+        limits,
+    )
+    candidate_info = _inspect_pdf(candidate_snapshot, limits)
+    reference_info = _inspect_pdf(reference_snapshot, limits)
+    structural = _compare_pdf_structure(candidate_info, reference_info)
+    report["structural"] = structural
+    report["pages"] = []
+
+    if structural["status"] != "match":
+        report["status"] = "structural_mismatch"
+        report["resource_usage"] = {
+            "raster_mode": "not_started_due_to_structural_mismatch",
+            "actual_total_pixels": 0,
+            "actual_total_raster_bytes": 0,
+        }
+        report["summary"] = {
+            "total_pages": 0,
+            "scored_pages": 0,
+            "unscorable_pages": 0,
+            "partially_unscorable_pages": 0,
+            "worst_pages": [],
+            "worst_tiles": [],
+            "pixel_comparison_attempted": False,
+        }
+        _write_report(output_dir, report, {}, limits)
+        return report
+
+    generated_assets: Dict[str, Path] = {}
+    report_asset_bytes = 0
+    preflight = _preflight_pixels(candidate_info, reference_info, limits)
+    total_raster_bytes = 0
+    total_actual_pixels = 0
+    report["resource_usage"] = {
+        "raster_mode": "page_by_page",
+        "preflight": preflight,
+        "actual_total_pixels": 0,
+        "actual_total_raster_bytes": 0,
+        "generated_asset_bytes": 0,
+    }
+
+    for page_number in range(1, candidate_info.page_count + 1):
+        candidate_raster, candidate_raster_bytes = _rasterize_pdf_page(
+            candidate_snapshot,
+            temporary_path,
+            "candidate",
+            page_number,
+            limits,
+        )
+        total_raster_bytes += candidate_raster_bytes
+        if total_raster_bytes > limits.max_total_raster_bytes:
+            raise VisualCheckError(
+                f"total raster bytes {total_raster_bytes} exceed "
+                f"--max-total-raster-bytes {limits.max_total_raster_bytes}"
+            )
+        reference_raster, reference_raster_bytes = _rasterize_pdf_page(
+            reference_snapshot,
+            temporary_path,
+            "reference",
+            page_number,
+            limits,
+        )
+        total_raster_bytes += reference_raster_bytes
+        if total_raster_bytes > limits.max_total_raster_bytes:
+            raise VisualCheckError(
+                f"total raster bytes {total_raster_bytes} exceed "
+                f"--max-total-raster-bytes {limits.max_total_raster_bytes}"
+            )
+        candidate_raw_image = _read_png_gray(
+            candidate_raster,
+            max_file_bytes=limits.max_raster_bytes,
+            max_pixels=limits.max_page_pixels,
+            max_decompressed_bytes=limits.max_png_decompressed_bytes,
+        )
+        reference_raw_image = _read_png_gray(
+            reference_raster,
+            max_file_bytes=limits.max_raster_bytes,
+            max_pixels=limits.max_page_pixels,
+            max_decompressed_bytes=limits.max_png_decompressed_bytes,
+        )
+        page_actual_pixels = (
+            candidate_raw_image.width * candidate_raw_image.height
+            + reference_raw_image.width * reference_raw_image.height
+        )
+        total_actual_pixels += page_actual_pixels
+        if total_actual_pixels > limits.max_total_pixels:
+            raise VisualCheckError(
+                f"actual total pixels {total_actual_pixels} exceed "
+                f"--max-total-pixels {limits.max_total_pixels}"
+            )
+        report["resource_usage"]["actual_total_pixels"] = total_actual_pixels
+        report["resource_usage"]["actual_total_raster_bytes"] = total_raster_bytes
+        prefix = f"page-{page_number:04d}"
+        reference_name = f"{prefix}-reference.png"
+        candidate_raw_name = f"{prefix}-candidate-raw.png"
+        reference_asset = temporary_path / reference_name
+        candidate_raw_asset = temporary_path / candidate_raw_name
+        _copy_private_regular_file(reference_raster, reference_asset)
+        report_asset_bytes = _register_report_asset(
+            generated_assets,
+            reference_name,
+            reference_asset,
+            limits,
+            report_asset_bytes,
+        )
+        _copy_private_regular_file(candidate_raster, candidate_raw_asset)
+        report_asset_bytes = _register_report_asset(
+            generated_assets,
+            candidate_raw_name,
+            candidate_raw_asset,
+            limits,
+            report_asset_bytes,
+        )
+        report["resource_usage"]["generated_asset_bytes"] = report_asset_bytes
+        artifacts = {
+            "reference": f"assets/{reference_name}",
+            "candidate_raw": f"assets/{candidate_raw_name}",
+        }
+
+        width_delta = abs(candidate_raw_image.width - reference_raw_image.width)
+        height_delta = abs(candidate_raw_image.height - reference_raw_image.height)
+        if width_delta > MAX_RASTER_PADDING_PX or height_delta > MAX_RASTER_PADDING_PX:
+            report["pages"].append(
+                {
+                    "page": page_number,
+                    "status": "unscorable",
+                    "reason": (
+                        "raster dimensions differ beyond the A4 rounding padding bound; "
+                        "resize/rotate/crop is forbidden"
+                    ),
+                    "reference_dimensions_px": {
+                        "width": reference_raw_image.width,
+                        "height": reference_raw_image.height,
+                    },
+                    "candidate_dimensions_px": {
+                        "width": candidate_raw_image.width,
+                        "height": candidate_raw_image.height,
+                    },
+                    "max_padding_px": MAX_RASTER_PADDING_PX,
+                    "resource_usage": {
+                        "candidate_raster_bytes": candidate_raster_bytes,
+                        "reference_raster_bytes": reference_raster_bytes,
+                        "combined_pixels": page_actual_pixels,
+                    },
+                    "alignment": None,
+                    "metrics": None,
+                    "artifacts": artifacts,
+                }
+            )
+            continue
+
+        canvas_width = max(candidate_raw_image.width, reference_raw_image.width)
+        canvas_height = max(candidate_raw_image.height, reference_raw_image.height)
+        candidate_image = _pad_image(
+            candidate_raw_image, canvas_width, canvas_height
+        )
+        reference_image = _pad_image(
+            reference_raw_image, canvas_width, canvas_height
+        )
+        raster_canvas = {
+            "policy": "white_pad_right_and_bottom_only",
+            "canvas_dimensions_px": {
+                "width": canvas_width,
+                "height": canvas_height,
+            },
+            "candidate_original_dimensions_px": {
+                "width": candidate_raw_image.width,
+                "height": candidate_raw_image.height,
+            },
+            "reference_original_dimensions_px": {
+                "width": reference_raw_image.width,
+                "height": reference_raw_image.height,
+            },
+            "candidate_padding_px": {
+                "right": canvas_width - candidate_raw_image.width,
+                "bottom": canvas_height - candidate_raw_image.height,
+            },
+            "reference_padding_px": {
+                "right": canvas_width - reference_raw_image.width,
+                "bottom": canvas_height - reference_raw_image.height,
+            },
+            "resize": False,
+            "rotation_degrees": 0,
+            "crop": False,
+        }
+
+        metric_preflight = _preflight_metric_work(
+            reference_image,
+            candidate_image,
+            args.max_translation_px,
+            limits,
+        )
+        aligned_candidate, metrics = _compare_images(
+            reference_image,
+            candidate_image,
+            max_translation=args.max_translation_px,
+            max_edge_work=limits.max_edge_work,
+        )
+        aligned_name = f"{prefix}-candidate-aligned.png"
+        overlay_name = f"{prefix}-overlay.png"
+        heatmap_name = f"{prefix}-heatmap.png"
+        _write_gray_png(temporary_path / aligned_name, aligned_candidate)
+        _write_rgb_png(
+            temporary_path / overlay_name,
+            reference_image.width,
+            reference_image.height,
+            _overlay_pixels(reference_image, aligned_candidate),
+        )
+        _write_rgb_png(
+            temporary_path / heatmap_name,
+            reference_image.width,
+            reference_image.height,
+            _heatmap_pixels(reference_image, aligned_candidate),
+        )
+        for name in (aligned_name, overlay_name, heatmap_name):
+            report_asset_bytes = _register_report_asset(
+                generated_assets,
+                name,
+                temporary_path / name,
+                limits,
+                report_asset_bytes,
+            )
+        report["resource_usage"]["generated_asset_bytes"] = report_asset_bytes
+        artifacts.update(
+            {
+                "candidate_aligned": f"assets/{aligned_name}",
+                "overlay": f"assets/{overlay_name}",
+                "heatmap": f"assets/{heatmap_name}",
+            }
+        )
+        report["pages"].append(
+            {
+                "page": page_number,
+                "status": metrics["status"],
+                "resource_usage": {
+                    "candidate_raster_bytes": candidate_raster_bytes,
+                    "reference_raster_bytes": reference_raster_bytes,
+                    "combined_pixels": page_actual_pixels,
+                    "metric_preflight": metric_preflight,
+                },
+                "raster_canvas": raster_canvas,
+                "alignment": metrics["alignment"],
+                "metrics": metrics,
+                "artifacts": artifacts,
+            }
+        )
+
+    report["summary"] = _summarize_pages(report["pages"])
+    report["summary"]["pixel_comparison_attempted"] = True
+    if report["summary"]["unscorable_pages"]:
+        report["status"] = "partially_unscorable"
+    elif report["summary"]["partially_unscorable_pages"]:
+        report["status"] = "partially_unscorable"
+    else:
+        report["status"] = "scored_report"
+    _write_report(output_dir, report, generated_assets, limits)
+    return report
+
+
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return parsed
+
+
+def _positive_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed) or parsed <= 0:
+        raise argparse.ArgumentTypeError("must be a positive finite number")
+    return parsed
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Create a report-only visual comparison of an own-engine candidate PDF "
+            "and an explicitly tiered PDF reference."
+        )
+    )
+    parser.add_argument("candidate", help="candidate PDF exported by auto-hwp")
+    parser.add_argument("--reference", required=True, help="reference PDF")
+    parser.add_argument(
+        "--reference-tier",
+        required=True,
+        choices=sorted(REFERENCE_TIERS),
+        help="explicit reference authority tier; the script never infers this",
+    )
+    parser.add_argument(
+        "--output-dir",
+        required=True,
+        help="new directory for report.json, index.html, and assets",
+    )
+    parser.add_argument("--reference-product", help="reference renderer/product name")
+    parser.add_argument("--reference-build", help="reference renderer/product build")
+    parser.add_argument("--reference-os", help="reference rendering OS")
+    parser.add_argument(
+        "--font-fingerprint",
+        help="font-set fingerprint or manifest identifier used for the reference",
+    )
+    parser.add_argument(
+        "--candidate-font-fingerprint",
+        help="font-set fingerprint used by the own-engine candidate export",
+    )
+    parser.add_argument("--reference-note", help="provenance note for the reference")
+    parser.add_argument(
+        "--include-input-paths",
+        action="store_true",
+        help="include full input paths in the report; default keeps only basenames",
+    )
+    parser.add_argument(
+        "--max-translation-px",
+        type=int,
+        default=MAX_TRANSLATION_PX,
+        choices=range(0, MAX_TRANSLATION_PX + 1),
+        metavar="0..3",
+        help="integer translation search bound; scaling/rotation/cropping stay forbidden",
+    )
+    parser.add_argument(
+        "--max-input-bytes",
+        type=_positive_int,
+        default=DEFAULT_MAX_INPUT_BYTES,
+        help="maximum bytes per candidate/reference PDF",
+    )
+    parser.add_argument(
+        "--max-pages",
+        type=_positive_int,
+        default=DEFAULT_MAX_PAGES,
+        help="maximum pages per PDF",
+    )
+    parser.add_argument(
+        "--max-page-pixels",
+        type=_positive_int,
+        default=DEFAULT_MAX_PAGE_PIXELS,
+        help="maximum pixels in one 144 DPI raster page",
+    )
+    parser.add_argument(
+        "--max-total-pixels",
+        type=_positive_int,
+        default=DEFAULT_MAX_TOTAL_PIXELS,
+        help="maximum estimated/actual raster pixels across both PDFs",
+    )
+    parser.add_argument(
+        "--max-raster-bytes",
+        type=_positive_int,
+        default=DEFAULT_MAX_RASTER_BYTES,
+        help="maximum compressed PNG bytes per Poppler page",
+    )
+    parser.add_argument(
+        "--max-total-raster-bytes",
+        type=_positive_int,
+        default=DEFAULT_MAX_TOTAL_RASTER_BYTES,
+        help="maximum Poppler PNG bytes across both PDFs",
+    )
+    parser.add_argument(
+        "--max-png-decompressed-bytes",
+        type=_positive_int,
+        default=DEFAULT_MAX_PNG_DECOMPRESSED_BYTES,
+        help="maximum decompressed PNG scanline bytes per page",
+    )
+    parser.add_argument(
+        "--max-ink-pixels",
+        type=_positive_int,
+        default=DEFAULT_MAX_INK_PIXELS,
+        help="maximum foreground ink pixels per candidate/reference page image",
+    )
+    parser.add_argument(
+        "--max-alignment-work",
+        type=_positive_int,
+        default=DEFAULT_MAX_ALIGNMENT_WORK,
+        help="maximum candidate ink pixels multiplied by translation offsets per page",
+    )
+    parser.add_argument(
+        "--max-edge-work",
+        type=_positive_int,
+        default=DEFAULT_MAX_EDGE_WORK,
+        help=(
+            "maximum conservative foreground/edge pixels multiplied by "
+            "tolerance-neighbor probes per page"
+        ),
+    )
+    parser.add_argument(
+        "--max-report-asset-bytes",
+        type=_positive_int,
+        default=DEFAULT_MAX_REPORT_ASSET_BYTES,
+        help="maximum bytes for one final report PNG asset",
+    )
+    parser.add_argument(
+        "--max-report-bytes",
+        type=_positive_int,
+        default=DEFAULT_MAX_REPORT_BYTES,
+        help="maximum combined bytes for final JSON, HTML, and PNG assets",
+    )
+    parser.add_argument(
+        "--max-subprocess-output-bytes",
+        type=_positive_int,
+        default=DEFAULT_MAX_SUBPROCESS_OUTPUT_BYTES,
+        help="maximum combined stdout/stderr bytes for each Poppler invocation",
+    )
+    parser.add_argument(
+        "--subprocess-timeout-seconds",
+        type=_positive_float,
+        default=DEFAULT_SUBPROCESS_TIMEOUT_SECONDS,
+        help="timeout for each pdfinfo/pdftoppm invocation",
+    )
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    try:
+        report = _run_visual_check(args)
+    except (OSError, ValueError, VisualCheckError) as error:
+        print(f"pdf-visual-check: error: {error}", file=sys.stderr)
+        return 2
+    output_dir = Path(args.output_dir)
+    print(f"status: {report['status']} (report-only; no pass/fail verdict)")
+    print(f"json: {output_dir / 'report.json'}")
+    print(f"html: {output_dir / 'index.html'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_pdf_visual_check.py
+++ b/scripts/tests/test_pdf_visual_check.py
@@ -1,0 +1,1362 @@
+#!/usr/bin/env python3
+"""Dependency-free tests for scripts/pdf-visual-check.py metrics.
+
+The Poppler self-compare is skipped when pdfinfo/pdftoppm or the repository
+benchmark fixture is unavailable.  All metric tests use synthetic byte arrays.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import shutil
+import stat
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "pdf-visual-check.py"
+SPEC = importlib.util.spec_from_file_location("pdf_visual_check", SCRIPT_PATH)
+if SPEC is None or SPEC.loader is None:  # pragma: no cover - import machinery failure
+    raise RuntimeError(f"could not import {SCRIPT_PATH}")
+pdf_visual_check = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = pdf_visual_check
+SPEC.loader.exec_module(pdf_visual_check)
+
+
+def gray_image(width: int, height: int, ink_points=()):
+    pixels = bytearray([255]) * (width * height)
+    for point in ink_points:
+        if len(point) == 2:
+            x, y = point
+            value = 0
+        else:
+            x, y, value = point
+        pixels[y * width + x] = value
+    return pdf_visual_check.GrayImage(width, height, bytes(pixels))
+
+
+def rectangle(left: int, top: int, right: int, bottom: int):
+    return [
+        (x, y)
+        for y in range(top, bottom + 1)
+        for x in range(left, right + 1)
+    ]
+
+
+def default_limits(**overrides):
+    values = {
+        "max_input_bytes": pdf_visual_check.DEFAULT_MAX_INPUT_BYTES,
+        "max_pages": pdf_visual_check.DEFAULT_MAX_PAGES,
+        "max_page_pixels": pdf_visual_check.DEFAULT_MAX_PAGE_PIXELS,
+        "max_total_pixels": pdf_visual_check.DEFAULT_MAX_TOTAL_PIXELS,
+        "max_raster_bytes": pdf_visual_check.DEFAULT_MAX_RASTER_BYTES,
+        "max_total_raster_bytes": pdf_visual_check.DEFAULT_MAX_TOTAL_RASTER_BYTES,
+        "max_png_decompressed_bytes": pdf_visual_check.DEFAULT_MAX_PNG_DECOMPRESSED_BYTES,
+        "max_ink_pixels": pdf_visual_check.DEFAULT_MAX_INK_PIXELS,
+        "max_alignment_work": pdf_visual_check.DEFAULT_MAX_ALIGNMENT_WORK,
+        "max_edge_work": pdf_visual_check.DEFAULT_MAX_EDGE_WORK,
+        "max_report_asset_bytes": pdf_visual_check.DEFAULT_MAX_REPORT_ASSET_BYTES,
+        "max_report_bytes": pdf_visual_check.DEFAULT_MAX_REPORT_BYTES,
+        "max_subprocess_output_bytes": (
+            pdf_visual_check.DEFAULT_MAX_SUBPROCESS_OUTPUT_BYTES
+        ),
+        "subprocess_timeout_seconds": pdf_visual_check.DEFAULT_SUBPROCESS_TIMEOUT_SECONDS,
+    }
+    values.update(overrides)
+    return pdf_visual_check.ResourceLimits(**values)
+
+
+class MetricTests(unittest.TestCase):
+    def test_identical_images_are_exact_without_translation(self):
+        image = gray_image(16, 16, rectangle(4, 4, 9, 9))
+
+        aligned, metrics = pdf_visual_check._compare_images(image, image)
+
+        self.assertEqual(aligned, image)
+        self.assertEqual(
+            metrics["alignment"]["candidate_translation_px"], {"dx": 0, "dy": 0}
+        )
+        self.assertEqual(metrics["ssim_like"]["global"], 1.0)
+        self.assertEqual(metrics["ssim_like"]["local"]["mean"], 1.0)
+        self.assertEqual(metrics["ssim_like"]["local"]["worst"], 1.0)
+        self.assertEqual(metrics["union_foreground_mae"], 0.0)
+        self.assertEqual(metrics["ink"]["precision"], 1.0)
+        self.assertEqual(metrics["ink"]["recall"], 1.0)
+        self.assertEqual(metrics["ink"]["f1"], 1.0)
+        self.assertEqual(metrics["ink"]["iou"], 1.0)
+        self.assertEqual(metrics["edge"]["f1"], 1.0)
+        self.assertEqual(metrics["ink"]["candidate_to_reference_ratio"], 1.0)
+        self.assertEqual(metrics["content_bbox"]["max_abs_edge_delta_px"], 0)
+        self.assertEqual(metrics["worst_tile_recall"]["recall"], 1.0)
+        self.assertEqual(metrics["unscorable_metrics"], {})
+
+    def test_bounded_translation_is_detected_and_reported(self):
+        reference = gray_image(16, 16, rectangle(2, 2, 5, 5))
+        candidate = gray_image(16, 16, rectangle(4, 3, 7, 6))
+
+        aligned, metrics = pdf_visual_check._compare_images(reference, candidate)
+
+        self.assertEqual(
+            metrics["alignment"]["candidate_translation_px"], {"dx": -2, "dy": -1}
+        )
+        self.assertEqual(metrics["alignment"]["scale"], 1.0)
+        self.assertEqual(metrics["alignment"]["rotation_degrees"], 0)
+        self.assertFalse(metrics["alignment"]["crop"])
+        self.assertEqual(aligned, reference)
+        self.assertEqual(metrics["ink"]["f1"], 1.0)
+
+    def test_translation_search_never_exceeds_three_pixels(self):
+        reference = gray_image(16, 16, rectangle(2, 2, 4, 4))
+        candidate = gray_image(16, 16, rectangle(7, 2, 9, 4))
+
+        _, metrics = pdf_visual_check._compare_images(reference, candidate)
+
+        offset = metrics["alignment"]["candidate_translation_px"]
+        self.assertLessEqual(abs(offset["dx"]), 3)
+        self.assertLessEqual(abs(offset["dy"]), 3)
+        self.assertLess(metrics["ink"]["f1"], 1.0)
+        with self.assertRaises(ValueError):
+            pdf_visual_check._compare_images(reference, candidate, max_translation=4)
+
+    def test_alignment_cannot_hide_candidate_ink_off_canvas(self):
+        reference = gray_image(5, 2, [(0, 0), (1, 0)])
+        candidate = gray_image(5, 2, [(0, 0), (2, 0), (3, 0)])
+
+        _, metrics = pdf_visual_check._compare_images(reference, candidate)
+
+        self.assertEqual(
+            metrics["alignment"]["candidate_translation_px"], {"dx": -2, "dy": 0}
+        )
+        self.assertEqual(metrics["alignment"]["clipped_candidate_ink_pixels"], 1)
+        self.assertEqual(metrics["ink"]["candidate_pixels"], 3)
+        self.assertEqual(metrics["ink"]["candidate_visible_pixels_after_translation"], 2)
+        self.assertEqual(metrics["ink"]["candidate_clipped_pixels"], 1)
+        self.assertAlmostEqual(metrics["ink"]["precision"], 2 / 3, places=6)
+        self.assertEqual(metrics["ink"]["recall"], 1.0)
+        self.assertEqual(metrics["ink"]["f1"], 0.8)
+        self.assertAlmostEqual(metrics["ink"]["iou"], 2 / 3, places=6)
+        self.assertEqual(metrics["ink"]["candidate_to_reference_ratio"], 1.5)
+        self.assertGreater(metrics["union_foreground_mae"], 0.0)
+        self.assertLess(metrics["ssim_like"]["raw_global"], 1.0)
+        self.assertEqual(metrics["ssim_like"]["global"], 1.0)
+        self.assertGreater(
+            metrics["raw_content_bbox"]["max_abs_edge_delta_px"], 0
+        )
+        self.assertEqual(metrics["content_bbox"]["max_abs_edge_delta_px"], 0)
+
+    def test_worst_tile_exposes_a_tiny_missing_object(self):
+        main_content = rectangle(10, 10, 19, 19)
+        tiny_object = [(200, 20)]
+        reference = gray_image(256, 64, main_content + tiny_object)
+        candidate = gray_image(256, 64, main_content)
+
+        _, metrics = pdf_visual_check._compare_images(
+            reference, candidate, max_translation=0
+        )
+
+        self.assertGreater(metrics["ssim_like"]["global"], 0.99)
+        self.assertGreater(metrics["ink"]["recall"], 0.98)
+        self.assertEqual(metrics["worst_tile_recall"]["recall"], 0.0)
+        self.assertEqual(metrics["worst_tile_recall"]["tile"]["left"], 128)
+        self.assertGreater(metrics["union_foreground_mae"], 0.0)
+
+    def test_blank_foreground_metrics_are_null_not_zero(self):
+        blank = gray_image(8, 8)
+
+        _, metrics = pdf_visual_check._compare_images(blank, blank)
+
+        self.assertEqual(metrics["status"], "partially_unscorable")
+        self.assertEqual(metrics["ssim_like"]["global"], 1.0)
+        self.assertIsNone(metrics["union_foreground_mae"])
+        self.assertIsNone(metrics["ink"]["precision"])
+        self.assertIsNone(metrics["ink"]["recall"])
+        self.assertIsNone(metrics["ink"]["f1"])
+        self.assertIsNone(metrics["ink"]["iou"])
+        self.assertIsNone(metrics["edge"]["f1"])
+        self.assertIsNone(metrics["content_bbox"])
+        self.assertIsNone(metrics["worst_tile_recall"])
+        self.assertIn("ink_f1", metrics["unscorable_metrics"])
+
+    def test_edge_f1_uses_two_pixel_tolerance(self):
+        reference = gray_image(12, 12, [(4, y) for y in range(2, 9)])
+        candidate = gray_image(12, 12, [(5, y) for y in range(2, 9)])
+
+        _, metrics = pdf_visual_check._compare_images(
+            reference, candidate, max_translation=0
+        )
+
+        self.assertEqual(metrics["ink"]["f1"], 0.0)
+        self.assertEqual(metrics["edge"]["tolerance_px"], 2)
+        self.assertEqual(metrics["edge"]["f1"], 1.0)
+        self.assertEqual(metrics["content_bbox"]["delta_px"]["left"], 1)
+
+    def test_candidate_missing_all_ink_is_scorable_as_loss(self):
+        reference = gray_image(8, 8, [(3, 3)])
+        candidate = gray_image(8, 8)
+
+        _, metrics = pdf_visual_check._compare_images(
+            reference, candidate, max_translation=0
+        )
+
+        self.assertEqual(metrics["ink"]["recall"], 0.0)
+        self.assertEqual(metrics["ink"]["f1"], 0.0)
+        self.assertEqual(metrics["ink"]["iou"], 0.0)
+        self.assertIsNone(metrics["ink"]["precision"])
+        self.assertEqual(metrics["worst_tile_recall"]["recall"], 0.0)
+
+    def test_dimension_mismatch_is_not_resized(self):
+        reference = gray_image(8, 8)
+        candidate = gray_image(9, 8)
+
+        with self.assertRaisesRegex(ValueError, "resizing is forbidden"):
+            pdf_visual_check._compare_images(reference, candidate)
+
+    def test_padding_adds_white_right_and_bottom_without_resampling(self):
+        image = gray_image(2, 2, [(0, 0), (1, 1, 128)])
+
+        padded = pdf_visual_check._pad_image(image, 3, 4)
+
+        self.assertEqual((padded.width, padded.height), (3, 4))
+        self.assertEqual(padded.pixels[0], 0)
+        self.assertEqual(padded.pixels[1], 255)
+        self.assertEqual(padded.pixels[3], 255)
+        self.assertEqual(padded.pixels[4], 128)
+        self.assertTrue(all(value == 255 for value in padded.pixels[6:]))
+        with self.assertRaises(ValueError):
+            pdf_visual_check._pad_image(image, 1, 2)
+
+    def test_partial_local_ssim_windows_are_weighted_by_pixel_count(self):
+        reference = gray_image(65, 64)
+        candidate = gray_image(65, 64, [(64, y) for y in range(64)])
+
+        result = pdf_visual_check._local_ssim_like(reference, candidate)
+
+        self.assertEqual(result["window_count"], 2)
+        self.assertEqual(result["mean_weighting"], "window_pixel_count")
+        self.assertEqual(result["total_pixels"], 65 * 64)
+        self.assertGreater(result["mean"], 0.95)
+        self.assertLess(result["worst"], 0.1)
+
+
+class PngCodecTests(unittest.TestCase):
+    def test_grayscale_png_round_trip_is_exact(self):
+        image = gray_image(
+            4,
+            3,
+            [(0, 0, 0), (1, 0, 64), (2, 1, 128), (3, 2, 240)],
+        )
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "gray.png"
+            pdf_visual_check._write_gray_png(path, image)
+            decoded = pdf_visual_check._read_png_gray(path)
+        self.assertEqual(decoded, image)
+
+    def test_rgb_png_is_flattened_to_deterministic_gray(self):
+        rgb = bytes(
+            [
+                0,
+                0,
+                0,
+                255,
+                255,
+                255,
+                255,
+                0,
+                0,
+            ]
+        )
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "rgb.png"
+            pdf_visual_check._write_rgb_png(path, 3, 1, rgb)
+            decoded = pdf_visual_check._read_png_gray(path)
+        self.assertEqual(decoded.pixels[0], 0)
+        self.assertEqual(decoded.pixels[1], 255)
+        self.assertEqual(decoded.pixels[2], 77)
+
+    def test_png_file_pixel_and_decompressed_limits_are_enforced(self):
+        image = gray_image(8, 8, [(1, 1)])
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "bounded.png"
+            pdf_visual_check._write_gray_png(path, image)
+            with self.assertRaisesRegex(
+                pdf_visual_check.VisualCheckError, "PNG size"
+            ):
+                pdf_visual_check._read_png_gray(
+                    path, max_file_bytes=path.stat().st_size - 1
+                )
+            with self.assertRaisesRegex(
+                pdf_visual_check.VisualCheckError, "pixel count"
+            ):
+                pdf_visual_check._read_png_gray(path, max_pixels=63)
+            with self.assertRaisesRegex(
+                pdf_visual_check.VisualCheckError, "decompressed scanlines"
+            ):
+                pdf_visual_check._read_png_gray(
+                    path, max_decompressed_bytes=8 * 9 - 1
+                )
+
+
+class StructuralTests(unittest.TestCase):
+    def page(
+        self,
+        number,
+        box=(0.0, 0.0, 595.0, 842.0),
+        rotation=0,
+        crop=None,
+    ):
+        return pdf_visual_check.PdfPageInfo(number, box, rotation, crop)
+
+    def test_matching_structure_is_explicit(self):
+        candidate = pdf_visual_check.PdfInfo(1, (self.page(1),))
+        reference = pdf_visual_check.PdfInfo(1, (self.page(1),))
+
+        result = pdf_visual_check._compare_pdf_structure(candidate, reference)
+
+        self.assertEqual(result["status"], "match")
+        self.assertEqual(result["mismatches"], [])
+
+    def test_page_count_media_box_and_orientation_mismatch_are_separate(self):
+        candidate = pdf_visual_check.PdfInfo(
+            2,
+            (
+                self.page(1, (0.0, 0.0, 842.0, 595.0)),
+                self.page(2),
+            ),
+        )
+        reference = pdf_visual_check.PdfInfo(1, (self.page(1),))
+
+        result = pdf_visual_check._compare_pdf_structure(candidate, reference)
+
+        self.assertEqual(result["status"], "mismatch")
+        kinds = [mismatch["kind"] for mismatch in result["mismatches"]]
+        self.assertIn("page_count", kinds)
+        self.assertIn("media_box_size", kinds)
+        self.assertIn("orientation", kinds)
+
+    def test_standard_a4_rounding_within_one_point_matches(self):
+        candidate = pdf_visual_check.PdfInfo(
+            1, (self.page(1, (0.0, 0.0, 595.28, 841.88)),)
+        )
+        reference = pdf_visual_check.PdfInfo(
+            1, (self.page(1, (0.0, 0.0, 595.0, 841.0)),)
+        )
+
+        result = pdf_visual_check._compare_pdf_structure(candidate, reference)
+
+        self.assertEqual(result["status"], "match")
+
+    def test_physical_page_difference_over_one_point_is_rejected(self):
+        candidate = pdf_visual_check.PdfInfo(
+            1, (self.page(1, (0.0, 0.0, 596.01, 842.0)),)
+        )
+        reference = pdf_visual_check.PdfInfo(1, (self.page(1),))
+
+        result = pdf_visual_check._compare_pdf_structure(candidate, reference)
+
+        kinds = [mismatch["kind"] for mismatch in result["mismatches"]]
+        self.assertIn("media_box_size", kinds)
+
+    def test_rotation_mismatch_is_not_auto_corrected(self):
+        candidate = pdf_visual_check.PdfInfo(1, (self.page(1, rotation=90),))
+        reference = pdf_visual_check.PdfInfo(1, (self.page(1, rotation=0),))
+
+        result = pdf_visual_check._compare_pdf_structure(candidate, reference)
+
+        kinds = [mismatch["kind"] for mismatch in result["mismatches"]]
+        self.assertIn("rotation", kinds)
+        self.assertIn("orientation", kinds)
+
+    def test_crop_box_offset_or_size_mismatch_is_structural(self):
+        candidate = pdf_visual_check.PdfInfo(
+            1, (self.page(1, crop=(10.0, 20.0, 585.0, 822.0)),)
+        )
+        reference = pdf_visual_check.PdfInfo(
+            1, (self.page(1, crop=(12.0, 20.0, 585.0, 822.0)),)
+        )
+
+        result = pdf_visual_check._compare_pdf_structure(candidate, reference)
+
+        kinds = [mismatch["kind"] for mismatch in result["mismatches"]]
+        self.assertIn("crop_box", kinds)
+        self.assertEqual(
+            result["candidate"]["pages"][0]["crop_box_pt"],
+            [10.0, 20.0, 585.0, 822.0],
+        )
+
+    def test_invalid_crop_box_is_rejected_before_pixels(self):
+        candidate = pdf_visual_check.PdfInfo(
+            1, (self.page(1, crop=(-2.0, 0.0, 595.0, 842.0)),)
+        )
+        reference = pdf_visual_check.PdfInfo(1, (self.page(1),))
+
+        result = pdf_visual_check._compare_pdf_structure(candidate, reference)
+
+        kinds = [mismatch["kind"] for mismatch in result["mismatches"]]
+        self.assertIn("invalid_candidate_boxes", kinds)
+
+    def test_crop_box_drives_orientation(self):
+        page = self.page(1, crop=(0.0, 0.0, 595.0, 300.0))
+
+        self.assertEqual(page.orientation, "landscape")
+
+
+class ReportOrchestrationTests(unittest.TestCase):
+    def parse_args(self, candidate: Path, reference: Path, output: Path, extra=()):
+        return pdf_visual_check._build_parser().parse_args(
+            [
+                str(candidate),
+                "--reference",
+                str(reference),
+                "--reference-tier",
+                "T3",
+                "--output-dir",
+                str(output),
+            ]
+            + list(extra)
+        )
+
+    def test_structure_mismatch_writes_report_without_rasterizing(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            candidate = root / "candidate.pdf"
+            reference = root / "reference.pdf"
+            candidate.write_bytes(b"candidate")
+            reference.write_bytes(b"reference")
+            output = root / "report"
+            args = self.parse_args(candidate, reference, output)
+            candidate_info = pdf_visual_check.PdfInfo(
+                2,
+                (
+                    pdf_visual_check.PdfPageInfo(1, (0.0, 0.0, 595.0, 842.0), 0),
+                    pdf_visual_check.PdfPageInfo(2, (0.0, 0.0, 595.0, 842.0), 0),
+                ),
+            )
+            reference_info = pdf_visual_check.PdfInfo(
+                1,
+                (pdf_visual_check.PdfPageInfo(1, (0.0, 0.0, 595.0, 842.0), 0),),
+            )
+            with (
+                mock.patch.object(pdf_visual_check.shutil, "which", return_value="/mock"),
+                mock.patch.object(pdf_visual_check, "_tool_version", return_value="mock 1"),
+                mock.patch.object(
+                    pdf_visual_check,
+                    "_inspect_pdf",
+                    side_effect=[candidate_info, reference_info],
+                ),
+                mock.patch.object(
+                    pdf_visual_check, "_rasterize_pdf_page"
+                ) as rasterize,
+            ):
+                report = pdf_visual_check._run_visual_check(args)
+
+            rasterize.assert_not_called()
+            self.assertEqual(report["status"], "structural_mismatch")
+            self.assertFalse(report["summary"]["pixel_comparison_attempted"])
+            self.assertIsNone(report["policy"]["pass"])
+            self.assertTrue((output / "report.json").is_file())
+            self.assertTrue((output / "index.html").is_file())
+            written = json.loads((output / "report.json").read_text())
+            self.assertEqual(
+                written["inputs"]["candidate"]["sha256"],
+                pdf_visual_check._sha256(candidate),
+            )
+            self.assertEqual(
+                written["inputs"]["reference"]["sha256"],
+                pdf_visual_check._sha256(reference),
+            )
+            self.assertEqual(written["inputs"]["candidate"]["path"], "candidate.pdf")
+            self.assertTrue(written["inputs"]["candidate"]["path_redacted"])
+            self.assertEqual(
+                written["resource_usage"]["raster_mode"],
+                "not_started_due_to_structural_mismatch",
+            )
+
+    def test_large_raster_dimension_mismatch_is_a_complete_unscorable_report(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            candidate = root / "candidate.pdf"
+            reference = root / "reference.pdf"
+            candidate.write_bytes(b"candidate")
+            reference.write_bytes(b"reference")
+            candidate_png = root / "candidate.png"
+            reference_png = root / "reference.png"
+            pdf_visual_check._write_gray_png(candidate_png, gray_image(12, 8, [(1, 1)]))
+            pdf_visual_check._write_gray_png(reference_png, gray_image(8, 8, [(1, 1)]))
+            output = root / "report"
+            args = self.parse_args(candidate, reference, output)
+            page_info = pdf_visual_check.PdfInfo(
+                1,
+                (pdf_visual_check.PdfPageInfo(1, (0.0, 0.0, 595.0, 842.0), 0),),
+            )
+            with (
+                mock.patch.object(pdf_visual_check.shutil, "which", return_value="/mock"),
+                mock.patch.object(pdf_visual_check, "_tool_version", return_value="mock 1"),
+                mock.patch.object(
+                    pdf_visual_check, "_inspect_pdf", side_effect=[page_info, page_info]
+                ),
+                mock.patch.object(
+                    pdf_visual_check,
+                    "_rasterize_pdf_page",
+                    side_effect=[
+                        (candidate_png, candidate_png.stat().st_size),
+                        (reference_png, reference_png.stat().st_size),
+                    ],
+                ),
+            ):
+                report = pdf_visual_check._run_visual_check(args)
+
+            self.assertEqual(report["status"], "partially_unscorable")
+            self.assertIsNone(report["pages"][0]["alignment"])
+            self.assertIsNone(report["pages"][0]["metrics"])
+            self.assertTrue((output / "report.json").is_file())
+            html_text = (output / "index.html").read_text()
+            self.assertIn("Pixel metrics are unscorable", html_text)
+
+    def test_crop_box_mismatch_never_calls_rasterizer(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            candidate = root / "candidate.pdf"
+            reference = root / "reference.pdf"
+            candidate.write_bytes(b"candidate")
+            reference.write_bytes(b"reference")
+            output = root / "report"
+            args = self.parse_args(candidate, reference, output)
+            candidate_info = pdf_visual_check.PdfInfo(
+                1,
+                (
+                    pdf_visual_check.PdfPageInfo(
+                        1,
+                        (0.0, 0.0, 595.0, 842.0),
+                        0,
+                        (10.0, 10.0, 585.0, 832.0),
+                    ),
+                ),
+            )
+            reference_info = pdf_visual_check.PdfInfo(
+                1,
+                (
+                    pdf_visual_check.PdfPageInfo(
+                        1,
+                        (0.0, 0.0, 595.0, 842.0),
+                        0,
+                        (12.0, 10.0, 585.0, 832.0),
+                    ),
+                ),
+            )
+            with (
+                mock.patch.object(pdf_visual_check.shutil, "which", return_value="/mock"),
+                mock.patch.object(pdf_visual_check, "_tool_version", return_value="mock 1"),
+                mock.patch.object(
+                    pdf_visual_check,
+                    "_inspect_pdf",
+                    side_effect=[candidate_info, reference_info],
+                ),
+                mock.patch.object(
+                    pdf_visual_check, "_rasterize_pdf_page"
+                ) as rasterize,
+            ):
+                report = pdf_visual_check._run_visual_check(args)
+
+            rasterize.assert_not_called()
+            self.assertEqual(report["status"], "structural_mismatch")
+            self.assertIn(
+                "crop_box",
+                [item["kind"] for item in report["structural"]["mismatches"]],
+            )
+
+    def test_small_raster_rounding_difference_is_white_padded_and_scored(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            candidate = root / "candidate.pdf"
+            reference = root / "reference.pdf"
+            candidate.write_bytes(b"candidate")
+            reference.write_bytes(b"reference")
+            candidate_png = root / "candidate.png"
+            reference_png = root / "reference.png"
+            pdf_visual_check._write_gray_png(candidate_png, gray_image(9, 10, [(1, 1)]))
+            pdf_visual_check._write_gray_png(reference_png, gray_image(8, 8, [(1, 1)]))
+            output = root / "report"
+            args = self.parse_args(candidate, reference, output)
+            page_info = pdf_visual_check.PdfInfo(
+                1,
+                (pdf_visual_check.PdfPageInfo(1, (0.0, 0.0, 595.0, 842.0), 0),),
+            )
+            with (
+                mock.patch.object(pdf_visual_check.shutil, "which", return_value="/mock"),
+                mock.patch.object(pdf_visual_check, "_tool_version", return_value="mock 1"),
+                mock.patch.object(
+                    pdf_visual_check, "_inspect_pdf", side_effect=[page_info, page_info]
+                ),
+                mock.patch.object(
+                    pdf_visual_check,
+                    "_rasterize_pdf_page",
+                    side_effect=[
+                        (candidate_png, candidate_png.stat().st_size),
+                        (reference_png, reference_png.stat().st_size),
+                    ],
+                ),
+            ):
+                report = pdf_visual_check._run_visual_check(args)
+
+            self.assertEqual(report["status"], "scored_report")
+            page = report["pages"][0]
+            self.assertEqual(
+                page["raster_canvas"]["canvas_dimensions_px"],
+                {"width": 9, "height": 10},
+            )
+            self.assertEqual(
+                page["raster_canvas"]["reference_padding_px"],
+                {"right": 1, "bottom": 2},
+            )
+            self.assertFalse(page["raster_canvas"]["resize"])
+            self.assertEqual(page["metrics"]["ink"]["f1"], 1.0)
+
+    def test_full_run_is_byte_deterministic_for_identical_inputs(self):
+        """The complete report tree is stable, not only its parsed metrics."""
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            raster_root = root / "rasters"
+            raster_root.mkdir()
+            candidate_raster = raster_root / "candidate.png"
+            reference_raster = raster_root / "reference.png"
+            pdf_visual_check._write_gray_png(
+                candidate_raster,
+                gray_image(32, 24, rectangle(5, 5, 13, 13) + [(25, 8)]),
+            )
+            pdf_visual_check._write_gray_png(
+                reference_raster,
+                gray_image(32, 24, rectangle(4, 5, 12, 13) + [(24, 8)]),
+            )
+            page_info = pdf_visual_check.PdfInfo(
+                1,
+                (
+                    pdf_visual_check.PdfPageInfo(
+                        1, (0.0, 0.0, 595.0, 842.0), 0
+                    ),
+                ),
+            )
+
+            args_by_run = []
+            for run_name in ("run-a", "run-b"):
+                input_root = root / run_name / "inputs"
+                input_root.mkdir(parents=True)
+                candidate = input_root / "candidate.pdf"
+                reference = input_root / "reference.pdf"
+                candidate.write_bytes(b"identical-candidate-pdf")
+                reference.write_bytes(b"identical-reference-pdf")
+                args_by_run.append(
+                    self.parse_args(
+                        candidate,
+                        reference,
+                        root / run_name / "report",
+                    )
+                )
+
+            def rasterize(_pdf, _destination, label, _page, _limits):
+                source = (
+                    candidate_raster if label == "candidate" else reference_raster
+                )
+                return source, source.stat().st_size
+
+            reports = []
+            with (
+                mock.patch.object(pdf_visual_check.shutil, "which", return_value="/mock"),
+                mock.patch.object(
+                    pdf_visual_check, "_tool_version", return_value="mock-poppler 1"
+                ),
+                mock.patch.object(
+                    pdf_visual_check, "_inspect_pdf", return_value=page_info
+                ),
+                mock.patch.object(
+                    pdf_visual_check,
+                    "_rasterize_pdf_page",
+                    side_effect=rasterize,
+                ),
+            ):
+                for args in args_by_run:
+                    reports.append(pdf_visual_check._run_visual_check(args))
+
+            def output_bytes(output: Path):
+                return {
+                    path.relative_to(output).as_posix(): path.read_bytes()
+                    for path in sorted(output.rglob("*"))
+                    if path.is_file()
+                }
+
+            first_output = Path(args_by_run[0].output_dir)
+            second_output = Path(args_by_run[1].output_dir)
+            first_bytes = output_bytes(first_output)
+            second_bytes = output_bytes(second_output)
+
+            # Default path redaction is part of the determinism contract. The
+            # product emits no clock-derived field, so no test-only normalization
+            # or ignored metadata is needed here.
+            self.assertEqual(reports[0], reports[1])
+            self.assertEqual(first_bytes, second_bytes)
+            self.assertEqual(
+                set(first_bytes),
+                {
+                    "assets/page-0001-candidate-aligned.png",
+                    "assets/page-0001-candidate-raw.png",
+                    "assets/page-0001-heatmap.png",
+                    "assets/page-0001-overlay.png",
+                    "assets/page-0001-reference.png",
+                    "index.html",
+                    "report.json",
+                },
+            )
+            self.assertEqual(
+                json.loads(first_bytes["report.json"]),
+                reports[0],
+            )
+
+    def test_failed_html_render_leaves_no_partial_output(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            output = Path(temporary) / "report"
+            with self.assertRaises(KeyError):
+                pdf_visual_check._write_report(
+                    output, {"invalid": True}, {}, default_limits()
+                )
+            self.assertFalse(output.exists())
+
+    def test_output_directory_must_not_preexist(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            output = Path(temporary) / "report"
+            output.mkdir()
+            with self.assertRaises(pdf_visual_check.VisualCheckError):
+                pdf_visual_check._ensure_output_target(output)
+
+    def test_t0_t1_require_self_attested_provenance_fields(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            candidate = root / "candidate.pdf"
+            reference = root / "reference.pdf"
+            candidate.write_bytes(b"candidate")
+            reference.write_bytes(b"reference")
+            args = pdf_visual_check._build_parser().parse_args(
+                [
+                    str(candidate),
+                    "--reference",
+                    str(reference),
+                    "--reference-tier",
+                    "T1",
+                    "--output-dir",
+                    str(root / "report"),
+                ]
+            )
+
+            with self.assertRaisesRegex(
+                pdf_visual_check.VisualCheckError, "requires provenance fields"
+            ):
+                pdf_visual_check._run_visual_check(args)
+
+    def test_self_attested_t1_provenance_and_environment_reach_html(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            candidate = root / "candidate.pdf"
+            reference = root / "reference.pdf"
+            candidate.write_bytes(b"candidate")
+            reference.write_bytes(b"reference")
+            output = root / "report"
+            args = pdf_visual_check._build_parser().parse_args(
+                [
+                    str(candidate),
+                    "--reference",
+                    str(reference),
+                    "--reference-tier",
+                    "T1",
+                    "--reference-product",
+                    "Official publisher PDF",
+                    "--reference-build",
+                    "producer-1",
+                    "--reference-os",
+                    "publisher-system",
+                    "--font-fingerprint",
+                    "sha256:fontset",
+                    "--reference-note",
+                    "same-post attachment",
+                    "--candidate-font-fingerprint",
+                    "sha256:candidate-fontset",
+                    "--output-dir",
+                    str(output),
+                ]
+            )
+            candidate_info = pdf_visual_check.PdfInfo(
+                2,
+                (
+                    pdf_visual_check.PdfPageInfo(1, (0.0, 0.0, 595.0, 842.0), 0),
+                    pdf_visual_check.PdfPageInfo(2, (0.0, 0.0, 595.0, 842.0), 0),
+                ),
+            )
+            reference_info = pdf_visual_check.PdfInfo(
+                1,
+                (pdf_visual_check.PdfPageInfo(1, (0.0, 0.0, 595.0, 842.0), 0),),
+            )
+            with (
+                mock.patch.object(pdf_visual_check.shutil, "which", return_value="/mock"),
+                mock.patch.object(pdf_visual_check, "_tool_version", return_value="mock 1"),
+                mock.patch.object(
+                    pdf_visual_check,
+                    "_inspect_pdf",
+                    side_effect=[candidate_info, reference_info],
+                ),
+            ):
+                report = pdf_visual_check._run_visual_check(args)
+
+            self.assertEqual(
+                report["inputs"]["reference"]["provenance_validation"]["status"],
+                "self_attested",
+            )
+            self.assertRegex(
+                report["environment"]["fingerprint_sha256"], r"^[0-9a-f]{64}$"
+            )
+            html_text = (output / "index.html").read_text()
+            self.assertIn("self_attested", html_text)
+            self.assertIn("Official publisher PDF", html_text)
+            self.assertIn("producer-1", html_text)
+            self.assertIn("sha256:fontset", html_text)
+
+
+class ResourceLimitTests(unittest.TestCase):
+    def test_snapshot_input_byte_limit_is_streaming_and_fail_closed(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "source.pdf"
+            destination = root / "snapshot.pdf"
+            source.write_bytes(b"0123456789")
+
+            with self.assertRaisesRegex(
+                pdf_visual_check.VisualCheckError, "max-input-bytes"
+            ):
+                pdf_visual_check._snapshot_file(source, destination, 9)
+
+    def test_pdf_page_limit_stops_before_detailed_pdfinfo(self):
+        limits = default_limits(max_pages=1)
+        with mock.patch.object(
+            pdf_visual_check, "_run_command", return_value="Pages:          2\n"
+        ) as run:
+            with self.assertRaisesRegex(
+                pdf_visual_check.VisualCheckError, "exceeds --max-pages"
+            ):
+                pdf_visual_check._inspect_pdf(Path("too-many.pdf"), limits)
+        self.assertEqual(run.call_count, 1)
+
+    def test_preflight_enforces_per_page_and_total_pixel_limits(self):
+        info = pdf_visual_check.PdfInfo(
+            1,
+            (pdf_visual_check.PdfPageInfo(1, (0.0, 0.0, 595.0, 842.0), 0),),
+        )
+        with self.assertRaisesRegex(
+            pdf_visual_check.VisualCheckError, "max-page-pixels"
+        ):
+            pdf_visual_check._preflight_pixels(
+                info, info, default_limits(max_page_pixels=100)
+            )
+        one_page_pixels = 1190 * 1684
+        with self.assertRaisesRegex(
+            pdf_visual_check.VisualCheckError, "max-total-pixels"
+        ):
+            pdf_visual_check._preflight_pixels(
+                info,
+                info,
+                default_limits(
+                    max_page_pixels=3_000_000,
+                    max_total_pixels=one_page_pixels,
+                ),
+            )
+
+    def test_subprocess_timeout_is_reported(self):
+        with self.assertRaisesRegex(
+            pdf_visual_check.VisualCheckError, "timed out"
+        ):
+            pdf_visual_check._run_command(
+                [sys.executable, "-c", "import time; time.sleep(10)"],
+                0.01,
+            )
+
+    def test_subprocess_stdout_and_stderr_share_a_hard_byte_cap(self):
+        programs = {
+            "stdout": "import os; os.write(1, b'x' * 1000000)",
+            "stderr": "import os; os.write(2, b'x' * 1000000)",
+            "combined": (
+                "import os; os.write(1, b'x' * 700); "
+                "os.write(2, b'y' * 700)"
+            ),
+        }
+        for case, program in programs.items():
+            with self.subTest(case=case):
+                with self.assertRaisesRegex(
+                    pdf_visual_check.VisualCheckError,
+                    "stdout/stderr exceeded --max-subprocess-output-bytes 1024",
+                ):
+                    pdf_visual_check._run_command(
+                        [sys.executable, "-c", program],
+                        10,
+                        output_limit_bytes=1024,
+                    )
+
+    def test_subprocess_output_overflow_kills_child_without_waiting_for_timeout(self):
+        program = (
+            "import os, time; "
+            "os.write(1, b'x' * 1000000); "
+            "time.sleep(10)"
+        )
+        started = time.monotonic()
+        with self.assertRaisesRegex(
+            pdf_visual_check.VisualCheckError,
+            "stdout/stderr exceeded --max-subprocess-output-bytes 1024",
+        ):
+            pdf_visual_check._run_command(
+                [sys.executable, "-c", program],
+                10,
+                output_limit_bytes=1024,
+            )
+        self.assertLess(time.monotonic() - started, 5.0)
+
+    def test_tool_version_uses_the_same_bounded_capture_path(self):
+        capture_result = pdf_visual_check._CommandCapture(
+            returncode=0,
+            stdout="",
+            stderr="pdfinfo version fixture\nignored\n",
+        )
+        with mock.patch.object(
+            pdf_visual_check,
+            "_capture_command",
+            return_value=capture_result,
+        ) as capture:
+            version = pdf_visual_check._tool_version(
+                "pdfinfo",
+                7.5,
+                output_limit_bytes=321,
+            )
+
+        self.assertEqual(version, "pdfinfo version fixture")
+        capture.assert_called_once_with(["pdfinfo", "-v"], 7.5, 321)
+
+    def test_page_raster_uses_cropbox_and_enforces_output_bytes(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            pdf = root / "fixture.pdf"
+            pdf.write_bytes(b"fixture")
+            commands = []
+
+            def fake_run(
+                command,
+                timeout_seconds,
+                file_size_limit_bytes=None,
+                output_limit_bytes=pdf_visual_check.DEFAULT_MAX_SUBPROCESS_OUTPUT_BYTES,
+            ):
+                commands.append(
+                    (
+                        command,
+                        timeout_seconds,
+                        file_size_limit_bytes,
+                        output_limit_bytes,
+                    )
+                )
+                output = Path(command[-1]).with_suffix(".png")
+                pdf_visual_check._write_gray_png(output, gray_image(4, 4, [(1, 1)]))
+                return ""
+
+            with mock.patch.object(
+                pdf_visual_check, "_run_command", side_effect=fake_run
+            ):
+                output, output_bytes = pdf_visual_check._rasterize_pdf_page(
+                    pdf, root, "candidate", 3, default_limits()
+                )
+
+            self.assertTrue(output.is_file())
+            self.assertEqual(output_bytes, output.stat().st_size)
+            command = commands[0][0]
+            self.assertIn("-cropbox", command)
+            self.assertIn("-singlefile", command)
+            self.assertEqual(command[command.index("-f") + 1], "3")
+            self.assertEqual(command[command.index("-l") + 1], "3")
+            self.assertEqual(
+                commands[0][2], pdf_visual_check.DEFAULT_MAX_RASTER_BYTES
+            )
+            self.assertEqual(
+                commands[0][3],
+                pdf_visual_check.DEFAULT_MAX_SUBPROCESS_OUTPUT_BYTES,
+            )
+            self.assertEqual(stat.S_IMODE(output.stat().st_mode), 0o600)
+
+            with mock.patch.object(
+                pdf_visual_check, "_run_command", side_effect=fake_run
+            ):
+                with self.assertRaisesRegex(
+                    pdf_visual_check.VisualCheckError, "raster page"
+                ):
+                    pdf_visual_check._rasterize_pdf_page(
+                        pdf,
+                        root,
+                        "reference",
+                        1,
+                        default_limits(max_raster_bytes=1),
+                    )
+
+    def test_total_raster_byte_limit_aborts_without_partial_report(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            candidate = root / "candidate.pdf"
+            reference = root / "reference.pdf"
+            raster = root / "page.png"
+            candidate.write_bytes(b"candidate")
+            reference.write_bytes(b"reference")
+            pdf_visual_check._write_gray_png(raster, gray_image(4, 4, [(1, 1)]))
+            output = root / "report"
+            args = pdf_visual_check._build_parser().parse_args(
+                [
+                    str(candidate),
+                    "--reference",
+                    str(reference),
+                    "--reference-tier",
+                    "T3",
+                    "--max-total-raster-bytes",
+                    "15",
+                    "--output-dir",
+                    str(output),
+                ]
+            )
+            info = pdf_visual_check.PdfInfo(
+                1,
+                (pdf_visual_check.PdfPageInfo(1, (0.0, 0.0, 595.0, 842.0), 0),),
+            )
+            with (
+                mock.patch.object(pdf_visual_check.shutil, "which", return_value="/mock"),
+                mock.patch.object(pdf_visual_check, "_tool_version", return_value="mock 1"),
+                mock.patch.object(
+                    pdf_visual_check, "_inspect_pdf", side_effect=[info, info]
+                ),
+                mock.patch.object(
+                    pdf_visual_check,
+                    "_rasterize_pdf_page",
+                    side_effect=[(raster, 10), (raster, 10)],
+                ),
+            ):
+                with self.assertRaisesRegex(
+                    pdf_visual_check.VisualCheckError, "max-total-raster-bytes"
+                ):
+                    pdf_visual_check._run_visual_check(args)
+
+            self.assertFalse(output.exists())
+
+    def test_metric_preflight_caps_ink_sets_and_alignment_work(self):
+        full_ink = gray_image(
+            10,
+            10,
+            rectangle(0, 0, 9, 9),
+        )
+        with self.assertRaisesRegex(
+            pdf_visual_check.VisualCheckError, "before set allocation"
+        ):
+            pdf_visual_check._preflight_metric_work(
+                full_ink,
+                full_ink,
+                3,
+                default_limits(max_ink_pixels=99),
+            )
+
+        sparse = gray_image(10, 10, rectangle(0, 0, 4, 1))
+        with self.assertRaisesRegex(
+            pdf_visual_check.VisualCheckError, "alignment work"
+        ):
+            pdf_visual_check._preflight_metric_work(
+                sparse,
+                sparse,
+                3,
+                default_limits(max_ink_pixels=100, max_alignment_work=489),
+            )
+
+        with self.assertRaisesRegex(
+            pdf_visual_check.VisualCheckError,
+            "edge work upper bound .* before set allocation",
+        ):
+            pdf_visual_check._preflight_metric_work(
+                sparse,
+                sparse,
+                0,
+                default_limits(
+                    max_ink_pixels=100,
+                    max_alignment_work=100,
+                    max_edge_work=259,
+                ),
+            )
+
+    def test_edge_matching_checks_exact_work_before_neighbor_scan(self):
+        reference = gray_image(10, 10, [(3, 3), (3, 4)])
+        candidate = gray_image(10, 10, [(4, 3), (4, 4)])
+        with mock.patch.object(
+            pdf_visual_check, "_disk_offsets", wraps=pdf_visual_check._disk_offsets
+        ) as offsets:
+            with self.assertRaisesRegex(
+                pdf_visual_check.VisualCheckError, "edge match work"
+            ):
+                pdf_visual_check._compare_images(
+                    reference,
+                    candidate,
+                    max_translation=0,
+                    max_edge_work=1,
+                )
+        self.assertEqual(offsets.call_count, 1)
+
+    def test_resource_limits_reject_hard_ceiling_and_nonfinite_timeout(self):
+        self.assertLess(
+            pdf_visual_check.DEFAULT_MAX_PAGE_PIXELS,
+            pdf_visual_check.HARD_MAX_PAGE_PIXELS,
+        )
+        with self.assertRaisesRegex(ValueError, "hard ceiling"):
+            default_limits(
+                max_page_pixels=pdf_visual_check.HARD_MAX_PAGE_PIXELS + 1
+            )
+        with self.assertRaisesRegex(ValueError, "hard ceiling"):
+            default_limits(
+                max_subprocess_output_bytes=(
+                    pdf_visual_check.HARD_MAX_SUBPROCESS_OUTPUT_BYTES + 1
+                )
+            )
+        with self.assertRaisesRegex(ValueError, "positive and finite"):
+            default_limits(subprocess_timeout_seconds=float("nan"))
+
+    @unittest.skipUnless(
+        pdf_visual_check._file_size_limit_preexec(1024) is not None,
+        "POSIX RLIMIT_FSIZE unavailable",
+    )
+    def test_runtime_file_size_cap_stops_writer_before_unbounded_output(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            output = Path(temporary) / "oversize.bin"
+            program = (
+                "from pathlib import Path; "
+                f"Path({str(output)!r}).write_bytes(b'x' * 1000000)"
+            )
+            with self.assertRaises(pdf_visual_check.VisualCheckError):
+                pdf_visual_check._run_command(
+                    [sys.executable, "-c", program],
+                    10,
+                    file_size_limit_bytes=1024,
+                )
+            if output.exists():
+                self.assertLessEqual(output.stat().st_size, 1024)
+
+    def test_memory_and_overflow_errors_become_visual_check_errors(self):
+        for error in (MemoryError(), OverflowError()):
+            with self.subTest(error=type(error).__name__):
+                with mock.patch.object(
+                    pdf_visual_check,
+                    "_run_visual_check_impl",
+                    side_effect=error,
+                ):
+                    with self.assertRaisesRegex(
+                        pdf_visual_check.VisualCheckError,
+                        "resource exhaustion",
+                    ):
+                        pdf_visual_check._run_visual_check(mock.sentinel.args)
+
+
+class OutputSecurityTests(unittest.TestCase):
+    def test_private_modes_are_forced_under_permissive_umasks(self):
+        for mask in (0o000, 0o022):
+            with self.subTest(umask=oct(mask)):
+                with tempfile.TemporaryDirectory() as temporary:
+                    root = Path(temporary)
+                    source_asset = root / "source.png"
+                    output = root / "report"
+                    previous_umask = os.umask(mask)
+                    try:
+                        pdf_visual_check._write_gray_png(
+                            source_asset,
+                            gray_image(4, 4, [(1, 1)]),
+                        )
+                        observed_directory_modes = []
+                        original_make_directory = (
+                            pdf_visual_check._make_private_directory
+                        )
+
+                        def make_and_record(path, **kwargs):
+                            original_make_directory(path, **kwargs)
+                            observed_directory_modes.append(
+                                stat.S_IMODE(path.stat().st_mode)
+                            )
+
+                        with (
+                            mock.patch.object(
+                                pdf_visual_check,
+                                "_render_html",
+                                return_value="<!doctype html><title>fixture</title>",
+                            ),
+                            mock.patch.object(
+                                pdf_visual_check,
+                                "_make_private_directory",
+                                side_effect=make_and_record,
+                            ),
+                        ):
+                            pdf_visual_check._write_report(
+                                output,
+                                {"status": "fixture"},
+                                {"source.png": source_asset},
+                                default_limits(),
+                            )
+                    finally:
+                        os.umask(previous_umask)
+
+                    self.assertGreaterEqual(len(observed_directory_modes), 3)
+                    self.assertEqual(set(observed_directory_modes), {0o700})
+                    self.assertEqual(
+                        stat.S_IMODE(source_asset.stat().st_mode), 0o600
+                    )
+                    self.assertEqual(stat.S_IMODE(output.stat().st_mode), 0o700)
+                    self.assertEqual(
+                        stat.S_IMODE((output / "assets").stat().st_mode), 0o700
+                    )
+                    for path in (
+                        output / "report.json",
+                        output / "index.html",
+                        output / "assets" / "source.png",
+                    ):
+                        self.assertEqual(stat.S_IMODE(path.stat().st_mode), 0o600)
+
+    def test_report_asset_and_total_byte_caps_fail_atomically(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            asset = root / "asset.png"
+            pdf_visual_check._write_gray_png(
+                asset,
+                gray_image(8, 8, rectangle(0, 0, 7, 7)),
+            )
+            asset_bytes = asset.stat().st_size
+            with self.assertRaisesRegex(
+                pdf_visual_check.VisualCheckError, "report asset"
+            ):
+                pdf_visual_check._register_report_asset(
+                    {},
+                    "asset.png",
+                    asset,
+                    default_limits(max_report_asset_bytes=asset_bytes - 1),
+                    0,
+                )
+
+            output = root / "report"
+            with mock.patch.object(
+                pdf_visual_check,
+                "_render_html",
+                return_value="<!doctype html><title>fixture</title>",
+            ):
+                with self.assertRaisesRegex(
+                    pdf_visual_check.VisualCheckError, "final report would be"
+                ):
+                    pdf_visual_check._write_report(
+                        output,
+                        {"status": "fixture"},
+                        {"asset.png": asset},
+                        default_limits(max_report_bytes=asset_bytes),
+                    )
+            self.assertFalse(output.exists())
+
+    @unittest.skipUnless(hasattr(os, "O_NOFOLLOW"), "O_NOFOLLOW unavailable")
+    def test_snapshot_rejects_symlink_input(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "source.pdf"
+            link = root / "link.pdf"
+            destination = root / "snapshot.pdf"
+            source.write_bytes(b"fixture")
+            link.symlink_to(source)
+
+            with self.assertRaisesRegex(
+                pdf_visual_check.VisualCheckError, "non-symlink regular file"
+            ):
+                pdf_visual_check._snapshot_file(link, destination, 100)
+
+    def test_nonfinite_boxes_and_invalid_rotation_are_structural(self):
+        invalid = pdf_visual_check.PdfInfo(
+            1,
+            (
+                pdf_visual_check.PdfPageInfo(
+                    1,
+                    (0.0, 0.0, float("nan"), 842.0),
+                    45,
+                ),
+            ),
+        )
+        reference = pdf_visual_check.PdfInfo(
+            1,
+            (
+                pdf_visual_check.PdfPageInfo(
+                    1,
+                    (0.0, 0.0, 595.0, 842.0),
+                    0,
+                ),
+            ),
+        )
+
+        result = pdf_visual_check._compare_pdf_structure(invalid, reference)
+
+        self.assertEqual(result["status"], "mismatch")
+        errors = result["mismatches"][0]["errors"]
+        self.assertIn("MediaBox and CropBox coordinates must be finite", errors)
+        rotation_errors = pdf_visual_check.PdfPageInfo(
+            1,
+            (0.0, 0.0, 595.0, 842.0),
+            45,
+        ).validation_errors()
+        self.assertIn(
+            "page rotation must be a finite 0/90/180/270 degree integer",
+            rotation_errors,
+        )
+
+    def test_nonfinite_values_cannot_escape_into_json(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            output = Path(temporary) / "report"
+            with self.assertRaisesRegex(
+                pdf_visual_check.VisualCheckError, "invalid JSON value"
+            ):
+                pdf_visual_check._write_report(
+                    output,
+                    {"invalid": float("nan")},
+                    {},
+                    default_limits(),
+                )
+            self.assertFalse(output.exists())
+
+
+REPOSITORY_ROOT = SCRIPT_PATH.parents[1]
+BENCHMARK_PDF = REPOSITORY_ROOT / "benchmarks" / "benchmark.pdf"
+HAS_POPPLER_FIXTURE = bool(
+    shutil.which("pdfinfo")
+    and shutil.which("pdftoppm")
+    and BENCHMARK_PDF.is_file()
+)
+
+
+@unittest.skipUnless(HAS_POPPLER_FIXTURE, "Poppler or benchmarks/benchmark.pdf unavailable")
+class PopplerIntegrationTests(unittest.TestCase):
+    def test_existing_benchmark_first_page_self_compare(self):
+        limits = default_limits()
+        info = pdf_visual_check._inspect_pdf(BENCHMARK_PDF, limits)
+        self.assertGreater(info.page_count, 0)
+        self.assertEqual(
+            info.pages[0].effective_crop_box, info.pages[0].media_box
+        )
+        with tempfile.TemporaryDirectory() as temporary:
+            page, _ = pdf_visual_check._rasterize_pdf_page(
+                BENCHMARK_PDF,
+                Path(temporary),
+                "self",
+                page=1,
+                limits=limits,
+            )
+            image = pdf_visual_check._read_png_gray(page)
+            _, metrics = pdf_visual_check._compare_images(image, image)
+        self.assertEqual(metrics["ssim_like"]["global"], 1.0)
+        self.assertEqual(metrics["ink"]["f1"], 1.0)
+        self.assertEqual(metrics["edge"]["f1"], 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/verify-local.sh
+++ b/scripts/verify-local.sh
@@ -15,6 +15,8 @@ echo "═══ clippy (-D warnings) ═══"
 cargo clippy --workspace --all-targets -- -D warnings
 echo "═══ tests (workspace) ═══"
 cargo test --workspace
+echo "═══ PDF visual oracle (standard-library unittest) ═══"
+python3 -m unittest discover -s scripts/tests -p 'test_pdf_visual_check.py'
 echo "═══ tests (hwp-rhwp features) ═══"
 cargo test -p hwp-rhwp --features "rhwp shaper"
 


### PR DESCRIPTION
## Summary

- add a bounded, report-only candidate-PDF versus explicit-reference-PDF visual comparator
- gate pixels behind page/MediaBox/CropBox/rotation/orientation structure checks
- emit per-page metrics plus local side-by-side, aligned, overlay, heatmap, and worst-page/tile evidence
- keep structural mismatch, unscorable, partially unscorable, and real zero scores distinct
- fail closed on input, page, pixel, metric-work, subprocess, raster, and report resource limits
- run the 51-test standard-library suite in both `verify-local` and required GitHub `build-test`
- prove raw byte determinism across `report.json`, HTML, and all five PNG assets over two full runs

## Honest scope boundary

- report-only: no pass/fail threshold and no relaxation/replacement of the 82-document lineseg oracle
- accepts already-exported PDFs; it does not yet orchestrate HWP/HWPX export
- T0/T1 provenance is required but explicitly self-attested, not authenticated
- #101 owns ≥20 trusted-pair calibration and a reviewed manifest
- #102 owns object/PaintOp production versus PDF replay/stub accounting and SVG/PDF sink parity

## Verification

- `scripts/verify-local.sh` — green on current `origin/main` (fmt, clippy, workspace tests, 51 PDF-oracle tests, rhwp-feature tests, 8/18/24 layout gates, 82-doc committed oracle contract, wasm hygiene, licenses)
- focused unittest discovery — 51/51 green, including local Poppler self-compare
- independent security and acceptance-criteria reviews — no remaining P0–P2 blocker for the #121 scope

Closes #121
Part of #93