### PR TITLE
fix: update app nanoid override to patched release

### DIFF
--- a/apps/hwp-lab/package-lock.json
+++ b/apps/hwp-lab/package-lock.json
@@ -3074,9 +3074,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/apps/hwp-lab/package.json
+++ b/apps/hwp-lab/package.json
@@ -47,7 +47,7 @@
     "vitest": "4.1.10"
   },
   "overrides": {
-    "nanoid": "3.3.17",
+    "nanoid": "3.3.18",
     "postcss": "8.5.23",
     "sharp": "0.35.0"
   },


### PR DESCRIPTION
Closes #116

## Summary

- update the hwp-lab exact nanoid override from 3.3.17 to 3.3.18
- refresh only the matching app lockfile entry
- keep independent workspace lockfiles out of scope for #118

## Verification

- npm ci --ignore-scripts: pass, audit reports 0 vulnerabilities
- npm audit --audit-level=low: 0 vulnerabilities
- npm ls nanoid: hwp-lab Next/postcss path resolves overridden 3.3.18
- npm test: 247/247
- npm run typecheck: pass
- npm run build: pass
- npm run build:demo: pass and models route restored
- scripts/verify-local.sh: quick suite green
- git diff --check: pass
