### PR TITLE
fix: sweep patched nanoid through first-party lockfiles

### DIFF
--- a/packages/ai-protocol/package-lock.json
+++ b/packages/ai-protocol/package-lock.json
@@ -912,9 +912,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/packages/editor-core/package-lock.json
+++ b/packages/editor-core/package-lock.json
@@ -912,9 +912,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/packages/react/package-lock.json
+++ b/packages/react/package-lock.json
@@ -2451,9 +2451,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/services/demo-ai-proxy/package-lock.json
+++ b/services/demo-ai-proxy/package-lock.json
@@ -2141,9 +2141,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/services/demo-ai-proxy/package.json
+++ b/services/demo-ai-proxy/package.json
@@ -22,7 +22,7 @@
     "wrangler": "^4.114.0"
   },
   "overrides": {
-    "nanoid": "3.3.17",
+    "nanoid": "3.3.18",
     "undici": "7.29.0"
   }
 }


### PR DESCRIPTION
## Summary

- update `nanoid` to 3.3.18 in the four root-tracked first-party JavaScript lockfiles that resolve it
- update the demo AI proxy's exact `nanoid` override from 3.3.17 to 3.3.18 so `npm ci` can reproduce the patched lock graph
- preserve the `undici` override, first-party package versions, and every unrelated dependency edge
- leave the vendored `external/rhwp` tree untouched

## Verification

- `scripts/verify-local.sh --full`
  - canonical layout gate: 8 / 18 / 24 pages and line accuracy >= 98.9%
  - committed oracle sweep: 82 documents
  - PDF visual oracle: 51/51
  - Vitest: editor-core 269, ai-protocol 64, React 425, hwp-lab 247, demo proxy 11
  - Playwright: 85 passed, 3 intentionally skipped
- `npm ci --ignore-scripts --no-audit --no-fund` in all four affected package roots
- `npm audit --audit-level=low`: 0 vulnerabilities in all four affected package roots
- tracked lockfile sweep: all five root-tracked `nanoid` resolutions are 3.3.18
- independent security and test reviews found no P0-P2 issues

Closes #118
Closes #130
