### PR TITLE
feat: add reproducible public corpus intake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,8 +80,11 @@ jobs:
             scripts/tests/gov-sources.test.mjs \
             scripts/tests/fetch-gov-corpus.test.mjs \
             scripts/tests/gov-source-catalog.test.mjs \
+            scripts/tests/public-corpus-manifest.test.mjs \
+            scripts/tests/safe-document-download.test.mjs \
             scripts/tests/oracle-sweep.test.mjs
           node scripts/gov-source-catalog.mjs --check
+          node scripts/public-corpus-intake.mjs --check
           node scripts/oracle-sweep.mjs --check-committed
       - name: canonical layout gate (issue 98 — bounded three-document run)
         run: |

--- a/corpus/PUBLIC-CORPUS.md
+++ b/corpus/PUBLIC-CORPUS.md
@@ -1,0 +1,42 @@
+# Public corpus intake — 권리·개인정보·컨테이너 검증을 통과한 50개
+
+정본은 `public-corpus-manifest.json`이다. #99 후보 카탈로그의 메타데이터만 믿지 않고 원 게시물의
+권리 표기와 공개 접근성을 다시 확인한 뒤, 실제 바이트를 내려받아 HWP5 CFB·HWPX OWPML ZIP·PDF
+매직, 크기, SHA-256을 측정했다. 바이너리는 `.gitignore`의 `corpus/private/`에만 있으며 이 저장소는
+메타데이터만 배포한다.
+
+승격 뒤 40개 HWP/HWPX 전부를 production parser와 `tag-layout`의 `place_doc` 경로로 다시 열었고
+40/40이 정상 종료했다. 이 확인은 문서가 안전하게 열리고 조판 feature를 계측할 수 있다는 증거이지,
+한/글과의 시각 동일성 점수는 아니다.
+
+| 형식 | 승격 | 역할 |
+|---|---:|---|
+| HWP5 | 20 | 법령 별지 빈 양식·표·form-control 축 |
+| HWPX | 20 | 보도자료·공고·양식의 표·이미지·차트·각주·다단 축 |
+| 공식 PDF | 10 | 같은 법령 별지 HWP5와 `pair_id`로 묶인 시각 비교 reference |
+
+## 권리와 개인정보 경계
+
+- 국가법령정보센터 별지 HWP/PDF 30건은 저작권법 제7조 근거와 같은 공식 source page를 기록했다.
+- 기관별 KOGL-0/1 자료는 항목 페이지에서 표기를 확인했다. 정책브리핑 8건은 페이지 문구대로
+  **텍스트에 한한 이용**으로 기록했으며 첨부 안 사진·삽화의 재배포를 허용한다고 해석하지 않는다.
+- 전 항목은 빈 양식 또는 공식 공개물로 분류하고 `privacy_review.decision=include`를 기록했다.
+  작성 완료 문서·민원·명단·개인정보 가능 파일과 격리 결과는 공개 매니페스트에 넣지 않는다.
+- 2026-08-23 확인 당시 산업통상부 후보 1건은 공식 페이지의 첨부가 404여서 승격하지 않았다.
+  대신 교육부 항목의 KOGL-1 표기와 정상 HWPX 첨부를 브라우저에서 재확인해 사용했다.
+
+## 재현과 실패 규칙
+
+```bash
+node scripts/public-corpus-intake.mjs --check  # 공개 메타데이터·20/20/10 계약만, 네트워크 없음
+node scripts/public-corpus-intake.mjs          # 승인된 50 URL만 private/에 재현
+```
+
+수집기는 HTTPS·자격증명 없는 URL, 명시 redirect host, 매 hop의 public DNS, 전체 30초, 32MiB,
+HWPX entry 10,000개·inflate 256MiB·팽창률 500배 상한을 강제한다. HWPX는 ZIP64·암호화·경로 탈출·
+local/central 불일치·CRC 오류를 거부하고 HWP5는 CFB FAT/디렉터리와 `FileHeader` 서명까지 확인한다.
+기존 파일은 단일-link regular inode와 SHA/크기/컨테이너를 다시 확인하며, 다른 파일을 덮어쓰지 않는다.
+로그는 공개 artifact id와 통과/정책 실패만 남기고 문서명·본문·SHA를 출력하지 않는다.
+
+공식 PDF는 한/글 자체 렌더의 절대 참값으로 선언하지 않는다. #101에서 페이지 구조를 먼저 맞춘 뒤
+정렬 오차와 시각 지표를 report-only로 보정하고, #88·#93의 pair/oracle 입력으로 사용한다.

--- a/corpus/README.md
+++ b/corpus/README.md
@@ -5,6 +5,10 @@
 - `hwpxlib_corpus/` — neolord0/hwpxlib의 `testFile/**/*.hwpx` 샘플(Apache-2.0 **데이터**). 클린룸 경계: 데이터는 사용 가능, 코드는 참조 전용. 재현: `node scripts/fetch-hwpxlib-corpus.mjs`.
 - `gov-sources.json` + `GOV-SOURCES.md` — KOGL 실측 공공문서. 바이너리 커밋 금지, `node scripts/fetch-gov-corpus.mjs`로 재현.
 - `gov-source-catalog.json` + `GOV-SOURCE-CATALOG.md` — 12개 이상 공식 출처 family의 HWP5/HWPX/PDF 후보 200건 이상을 담은 **metadata-only** 카탈로그(이슈 #99). URL은 비활성 메타데이터이며 다운로드 경로에 연결하지 않는다. `node scripts/gov-source-catalog.mjs --check`로 스키마·개인정보 제외 규율·생성 요약 drift를 검증한다.
+- `public-corpus-manifest.json` + `PUBLIC-CORPUS.md` — #99 후보 중 권리·개인정보·접근성·실제
+  컨테이너 검사를 통과해 승격한 HWP5 20건, HWPX 20건, 공식 PDF pair 10쌍. 공개 저장소에는
+  출처·권리·SHA-256·매직·크기·feature tag만 두며 바이너리는 `private/`에만 둔다.
+  재현: `node scripts/public-corpus-intake.mjs`.
 - `TYPESET-COVERAGE.md` + `typeset-coverage.json` — 조판 요소 태깅 지도 (이슈 #71). 재현: `node scripts/tag-corpus.mjs`.
 - `TYPESET-ORACLE.md` + `typeset-oracle.json` — 코퍼스 전수 `layout-check` 점수 (이슈 #72). **한/글의 참값이 아니라 저장 lineseg 기준의 회귀 잠금**. 채점 불가(빈 linesegarray)는 0점이 아니다. 재현: `node scripts/oracle-sweep.mjs` (전수는 로컬, CI는 `--check-committed`).
 - `private/` — 사내/실문서(.gitignore로 제외).

--- a/corpus/public-corpus-manifest.json
+++ b/corpus/public-corpus-manifest.json
@@ -1,0 +1,1581 @@
+{
+  "schema_version": 1,
+  "policy": {
+    "binary_storage": "gitignored-private",
+    "redistribution": "metadata-only",
+    "minimums": {
+      "hwp5": 20,
+      "hwpx": 20,
+      "official_pdf_pairs": 10
+    }
+  },
+  "artifacts": [
+    {
+      "id": "kdca-311074-hwpx",
+      "file": "kdca-311074-hwpx.hwpx",
+      "format": "hwpx",
+      "publisher": "질병관리청",
+      "kind": "official-publication",
+      "source_page": "https://www.kdca.go.kr/kdca/2847/subview.do?enc=Zm5jdDF8QEB8JTJGYmJzJTJGa2RjYSUyRjQxJTJGMzExMDc0JTJGYXJ0Y2xWaWV3LmRvJTNG",
+      "source_url": "https://www.kdca.go.kr/bbs/kdca/42/307112/download.do",
+      "allowed_redirect_hosts": [
+        "www.kdca.go.kr"
+      ],
+      "license": {
+        "code": "KOGL-0",
+        "evidence_url": "https://www.kdca.go.kr/kdca/2847/subview.do?enc=Zm5jdDF8QEB8JTJGYmJzJTJGa2RjYSUyRjQxJTJGMzExMDc0JTJGYXJ0Y2xWaWV3LmRvJTNG",
+        "observed_at": "2026-08-22",
+        "scope": "license-as-observed-private-evaluation"
+      },
+      "retrieved_at": "2026-08-22T17:08:43.166Z",
+      "sha256": "dfc8603ea7d99b68e8ec866c42deafeb1f392fafb64d8407aebecb6a23226eb1",
+      "detected_magic": "hwpx-owpml-zip",
+      "size_bytes": 438470,
+      "feature_tags": [
+        "chart",
+        "multipage_table"
+      ],
+      "pair_id": "kdca-311074",
+      "privacy_review": {
+        "classification": "official-publication",
+        "decision": "include",
+        "reviewed_at": "2026-08-22"
+      }
+    },
+    {
+      "id": "korea-kr-198358317-hwpx",
+      "file": "korea-kr-198358317-hwpx.hwpx",
+      "format": "hwpx",
+      "publisher": "문화체육관광부(정책브리핑)",
+      "kind": "official-publication",
+      "source_page": "https://www.korea.kr/briefing/pressReleaseView.do?newsId=156744367",
+      "source_url": "https://www.korea.kr/common/download.do?fileId=198358317&tblKey=GMN",
+      "allowed_redirect_hosts": [
+        "www.korea.kr"
+      ],
+      "license": {
+        "code": "KOGL-1",
+        "evidence_url": "https://www.korea.kr/briefing/pressReleaseView.do?newsId=156744367",
+        "observed_at": "2026-08-22",
+        "scope": "text-only-private-evaluation"
+      },
+      "retrieved_at": "2026-08-22T17:08:43.174Z",
+      "sha256": "f7ff611ee9d3ad9a076de2c63e6053e006b8cc9dd96853f60a24f57195d3820c",
+      "detected_magic": "hwpx-owpml-zip",
+      "size_bytes": 111711,
+      "feature_tags": [
+        "body_text"
+      ],
+      "pair_id": null,
+      "privacy_review": {
+        "classification": "official-publication",
+        "decision": "include",
+        "reviewed_at": "2026-08-22"
+      }
+    },
+    {
+      "id": "korea-kr-198399778-hwpx",
+      "file": "korea-kr-198399778-hwpx.hwpx",
+      "format": "hwpx",
+      "publisher": "문화체육관광부(정책브리핑)",
+      "kind": "official-publication",
+      "source_page": "https://www.korea.kr/briefing/pressReleaseView.do?newsId=156750968",
+      "source_url": "https://www.korea.kr/common/download.do?fileId=198399778&tblKey=GMN",
+      "allowed_redirect_hosts": [
+        "www.korea.kr"
+      ],
+      "license": {
+        "code": "KOGL-0",
+        "evidence_url": "https://www.korea.kr/briefing/pressReleaseView.do?newsId=156750968",
+        "observed_at": "2026-08-22",
+        "scope": "text-only-private-evaluation"
+      },
+      "retrieved_at": "2026-08-22T17:08:43.179Z",
+      "sha256": "6d3356866c25c43ebd505ae4c2c4f0dd7bfef8fbabbccc5a1b575fb57f37de97",
+      "detected_magic": "hwpx-owpml-zip",
+      "size_bytes": 561932,
+      "feature_tags": [
+        "body_text"
+      ],
+      "pair_id": null,
+      "privacy_review": {
+        "classification": "official-publication",
+        "decision": "include",
+        "reviewed_at": "2026-08-22"
+      }
+    },
+    {
+      "id": "korea-kr-198406157-hwpx",
+      "file": "korea-kr-198406157-hwpx.hwpx",
+      "format": "hwpx",
+      "publisher": "고용노동부(정책브리핑)",
+      "kind": "official-publication",
+      "source_page": "https://www.korea.kr/briefing/pressReleaseView.do?newsId=156752041",
+      "source_url": "https://www.korea.kr/common/download.do?fileId=198406157&tblKey=GMN",
+      "allowed_redirect_hosts": [
+        "www.korea.kr"
+      ],
+      "license": {
+        "code": "KOGL-1",
+        "evidence_url": "https://www.korea.kr/briefing/pressReleaseView.do?newsId=156752041",
+        "observed_at": "2026-08-22",
+        "scope": "text-only-private-evaluation"
+      },
+      "retrieved_at": "2026-08-22T17:08:43.183Z",
+      "sha256": "1e4785355e7af5e47eb24168a2bc1f98ad7f1b2f9aa0a9010e59f3041cee5238",
+      "detected_magic": "hwpx-owpml-zip",
+      "size_bytes": 105748,
+      "feature_tags": [
+        "body_text"
+      ],
+      "pair_id": null,
+      "privacy_review": {
+        "classification": "official-publication",
+        "decision": "include",
+        "reviewed_at": "2026-08-22"
+      }
+    },
+    {
+      "id": "korea-kr-198421223-hwpx",
+      "file": "korea-kr-198421223-hwpx.hwpx",
+      "format": "hwpx",
+      "publisher": "문화체육관광부(정책브리핑)",
+      "kind": "official-publication",
+      "source_page": "https://www.korea.kr/briefing/pressReleaseView.do?newsId=156754077",
+      "source_url": "https://www.korea.kr/common/download.do?fileId=198421223&tblKey=GMN",
+      "allowed_redirect_hosts": [
+        "www.korea.kr"
+      ],
+      "license": {
+        "code": "KOGL-0",
+        "evidence_url": "https://www.korea.kr/briefing/pressReleaseView.do?newsId=156754077",
+        "observed_at": "2026-08-22",
+        "scope": "text-only-private-evaluation"
+      },
+      "retrieved_at": "2026-08-22T17:08:43.189Z",
+      "sha256": "05028f7210c55724e719717ecbac4e4026d6c44d9e8dba8de18dea74be04134e",
+      "detected_magic": "hwpx-owpml-zip",
+      "size_bytes": 567529,
+      "feature_tags": [
+        "body_text"
+      ],
+      "pair_id": null,
+      "privacy_review": {
+        "classification": "official-publication",
+        "decision": "include",
+        "reviewed_at": "2026-08-22"
+      }
+    },
+    {
+      "id": "korea-kr-198421990-hwpx",
+      "file": "korea-kr-198421990-hwpx.hwpx",
+      "format": "hwpx",
+      "publisher": "국가보훈부(정책브리핑)",
+      "kind": "official-publication",
+      "source_page": "https://www.korea.kr/briefing/pressReleaseView.do?newsId=156754206",
+      "source_url": "https://www.korea.kr/common/download.do?fileId=198421990&tblKey=GMN",
+      "allowed_redirect_hosts": [
+        "www.korea.kr"
+      ],
+      "license": {
+        "code": "KOGL-1",
+        "evidence_url": "https://www.korea.kr/briefing/pressReleaseView.do?newsId=156754206",
+        "observed_at": "2026-08-22",
+        "scope": "text-only-private-evaluation"
+      },
+      "retrieved_at": "2026-08-22T17:08:43.197Z",
+      "sha256": "93f63161ba3d86022bafa8b888c01edaebb5dd5f2fa55aeda58b554b33462c81",
+      "detected_magic": "hwpx-owpml-zip",
+      "size_bytes": 722892,
+      "feature_tags": [
+        "body_text"
+      ],
+      "pair_id": null,
+      "privacy_review": {
+        "classification": "official-publication",
+        "decision": "include",
+        "reviewed_at": "2026-08-22"
+      }
+    },
+    {
+      "id": "korea-kr-198422462-hwpx",
+      "file": "korea-kr-198422462-hwpx.hwpx",
+      "format": "hwpx",
+      "publisher": "문화체육관광부(정책브리핑)",
+      "kind": "official-publication",
+      "source_page": "https://www.korea.kr/briefing/pressReleaseView.do?newsId=156754121",
+      "source_url": "https://www.korea.kr/common/download.do?fileId=198422462&tblKey=GMN",
+      "allowed_redirect_hosts": [
+        "www.korea.kr"
+      ],
+      "license": {
+        "code": "KOGL-0",
+        "evidence_url": "https://www.korea.kr/briefing/pressReleaseView.do?newsId=156754121",
+        "observed_at": "2026-08-22",
+        "scope": "text-only-private-evaluation"
+      },
+      "retrieved_at": "2026-08-22T17:08:43.207Z",
+      "sha256": "338a76aa6700a769a432795f59a003a032607f47ac4f57c533981d3e116ba310",
+      "detected_magic": "hwpx-owpml-zip",
+      "size_bytes": 1392858,
+      "feature_tags": [
+        "body_text"
+      ],
+      "pair_id": null,
+      "privacy_review": {
+        "classification": "official-publication",
+        "decision": "include",
+        "reviewed_at": "2026-08-22"
+      }
+    },
+    {
+      "id": "korea-kr-198527427-hwpx",
+      "file": "korea-kr-198527427-hwpx.hwpx",
+      "format": "hwpx",
+      "publisher": "교육부(정책브리핑)",
+      "kind": "official-publication",
+      "source_page": "https://www.korea.kr/briefing/pressReleaseView.do?newsId=156774930",
+      "source_url": "https://www.korea.kr/common/download.do?fileId=198527427&tblKey=GMN",
+      "allowed_redirect_hosts": [
+        "www.korea.kr"
+      ],
+      "license": {
+        "code": "KOGL-1",
+        "evidence_url": "https://www.korea.kr/briefing/pressReleaseView.do?newsId=156774930",
+        "observed_at": "2026-08-23",
+        "scope": "text-only-private-evaluation"
+      },
+      "retrieved_at": "2026-08-22T17:08:43.457Z",
+      "sha256": "36f90eac5a8641429c266615b530dd74147da921db4f6e09d7694250ccda61bf",
+      "detected_magic": "hwpx-owpml-zip",
+      "size_bytes": 23216816,
+      "feature_tags": [
+        "multipage_table"
+      ],
+      "pair_id": null,
+      "privacy_review": {
+        "classification": "official-publication",
+        "decision": "include",
+        "reviewed_at": "2026-08-23"
+      }
+    },
+    {
+      "id": "korea-kr-198527872-hwpx",
+      "file": "korea-kr-198527872-hwpx.hwpx",
+      "format": "hwpx",
+      "publisher": "관세청(정책브리핑)",
+      "kind": "official-publication",
+      "source_page": "https://www.korea.kr/briefing/pressReleaseView.do?newsId=156774999",
+      "source_url": "https://www.korea.kr/common/download.do?fileId=198527872&tblKey=GMN",
+      "allowed_redirect_hosts": [
+        "www.korea.kr"
+      ],
+      "license": {
+        "code": "KOGL-1",
+        "evidence_url": "https://www.korea.kr/briefing/pressReleaseView.do?newsId=156774999",
+        "observed_at": "2026-08-23",
+        "scope": "text-only-private-evaluation"
+      },
+      "retrieved_at": "2026-08-22T17:08:43.467Z",
+      "sha256": "f47b6b7cb4342797c3cab743a878fb10194206a2b5b518dfabbe92856582c826",
+      "detected_magic": "hwpx-owpml-zip",
+      "size_bytes": 181333,
+      "feature_tags": [
+        "image_object"
+      ],
+      "pair_id": null,
+      "privacy_review": {
+        "classification": "official-publication",
+        "decision": "include",
+        "reviewed_at": "2026-08-23"
+      }
+    },
+    {
+      "id": "law-go-271027-17184499-hwp5",
+      "file": "law-go-271027-17184499-hwp5.hwp",
+      "format": "hwp5",
+      "publisher": "고용노동부·법제처",
+      "kind": "blank-form-template",
+      "source_page": "https://www.law.go.kr/LSW/lsInfoP.do?ancYnChk=0&lsiSeq=271027",
+      "source_url": "https://www.law.go.kr/LSW/flDownload.do?flSeq=151361771",
+      "allowed_redirect_hosts": [
+        "www.law.go.kr"
+      ],
+      "license": {
+        "code": "Copyright Act Article 7",
+        "evidence_url": "https://www.law.go.kr/lsLinkCommonInfo.do?lsJoLnkSeq=1029423769",
+        "observed_at": "2026-08-22",
+        "scope": "statutory-public-domain"
+      },
+      "retrieved_at": "2026-08-22T17:08:43.468Z",
+      "sha256": "39192069329373f80cdd812d7e6a8de9061021c4b0ec4d7caf4be5e42ca1f191",
+      "detected_magic": "hwp5-cfb",
+      "size_bytes": 24576,
+      "feature_tags": [
+        "form_control",
+        "multipage_table"
+      ],
+      "pair_id": "law-go-271027-17184499",
+      "privacy_review": {
+        "classification": "blank-form-template",
+        "decision": "include",
+        "reviewed_at": "2026-08-22"
+      }
+    },
+    {
+      "id": "law-go-271027-17184499-pdf",
+      "file": "law-go-271027-17184499-pdf.pdf",
+      "format": "pdf",
+      "publisher": "고용노동부·법제처",
+      "kind": "blank-form-template",
+      "source_page": "https://www.law.go.kr/LSW/lsInfoP.do?ancYnChk=0&lsiSeq=271027",
+      "source_url": "https://www.law.go.kr/LSW/flDownload.do?flSeq=151361773",
+      "allowed_redirect_hosts": [
+        "www.law.go.kr"
+      ],
+      "license": {
+        "code": "Copyright Act Article 7",
+        "evidence_url": "https://www.law.go.kr/lsLinkCommonInfo.do?lsJoLnkSeq=1029423769",
+        "observed_at": "2026-08-22",
+        "scope": "statutory-public-domain"
+      },
+      "retrieved_at": "2026-08-22T17:08:43.468Z",
+      "sha256": "01d013d2dbe59e286fcc5879ab83b3cd4f1be7d82870c3b870ee5a8c6a3a5fc6",
+      "detected_magic": "pdf",
+      "size_bytes": 165598,
+      "feature_tags": [
+        "form_control",
+        "multipage_table"
+      ],
+      "pair_id": "law-go-271027-17184499",
+      "privacy_review": {
+        "classification": "blank-form-template",
+        "decision": "include",
+        "reviewed_at": "2026-08-22"
+      }
+    },
+    {
+      "id": "law-go-271027-17184501-hwp5",
+      "file": "law-go-271027-17184501-hwp5.hwp",
+      "format": "hwp5",
+      "publisher": "고용노동부·법제처",
+      "kind": "blank-form-template",
+      "source_page": "https://www.law.go.kr/LSW/lsInfoP.do?ancYnChk=0&lsiSeq=271027",
+      "source_url": "https://www.law.go.kr/LSW/flDownload.do?flSeq=151361779",
+      "allowed_redirect_hosts": [
+        "www.law.go.kr"
+      ],
+      "license": {
+        "code": "Copyright Act Article 7",
+        "evidence_url": "https://www.law.go.kr/lsLinkCommonInfo.do?lsJoLnkSeq=1029423769",
+        "observed_at": "2026-08-22",
+        "scope": "statutory-public-domain"
+      },
+      "retrieved_at": "2026-08-22T17:08:43.469Z",
+      "sha256": "811183a397a4fa55f04fd9714879cdb320d90b08597f9bc3579a89458ef30ce5",
+      "detected_magic": "hwp5-cfb",
+      "size_bytes": 52224,
+      "feature_tags": [
+        "form_control"
+      ],
+      "pair_id": "law-go-271027-17184501",
+      "privacy_review": {
+        "classification": "blank-form-template",
+        "decision": "include",
+        "reviewed_at": "2026-08-22"
+      }
+    },
+    {
+      "id": "law-go-271027-17184501-pdf",
+      "file": "law-go-271027-17184501-pdf.pdf",
+      "format": "pdf",
+      "publisher": "고용노동부·법제처",
+      "kind": "blank-form-template",
+      "source_page": "https://www.law.go.kr/LSW/lsInfoP.do?ancYnChk=0&lsiSeq=271027",
+      "source_url": "https://www.law.go.kr/LSW/flDownload.do?flSeq=151361781",
+      "allowed_redirect_hosts": [
+        "www.law.go.kr"
+      ],
+      "license": {
+        "code": "Copyright Act Article 7",
+        "evidence_url": "https://www.law.go.kr/lsLinkCommonInfo.do?lsJoLnkSeq=1029423769",
+        "observed_at": "2026-08-22",
+        "scope": "statutory-public-domain"
+      },
+      "retrieved_at": "2026-08-22T17:08:43.469Z",
+      "sha256": "c0b94f5d13316b92a5c3b81ef54b4c0bfec33a526b9ff25e3f153a1f4f74f65f",
+      "detected_magic": "pdf",
+      "size_bytes": 41442,
+      "feature_tags": [
+        "form_control"
+      ],
+      "pair_id": "law-go-271027-17184501",
+      "privacy_review": {
+        "classification": "blank-form-template",
+        "decision": "include",
+        "reviewed_at": "2026-08-22"
+      }
+    },
+    {
+      "id": "law-go-271027-17184503-hwp5",
+      "file": "law-go-271027-17184503-hwp5.hwp",
+      "format": "hwp5",
+      "publisher": "고용노동부·법제처",
+      "kind": "blank-form-template",
+      "source_page": "https://www.law.go.kr/LSW/lsInfoP.do?ancYnChk=0&lsiSeq=271027",
+      "source_url": "https://www.law.go.kr/LSW/flDownload.do?flSeq=151361785",
+      "allowed_redirect_hosts": [
+        "www.law.go.kr"
+      ],
+      "license": {
+        "code": "Copyright Act Article 7",
+        "evidence_url": "https://www.law.go.kr/lsLinkCommonInfo.do?lsJoLnkSeq=1029423769",
+        "observed_at": "2026-08-22",
+        "scope": "statutory-public-domain"
+      },
+      "retrieved_at": "2026-08-22T17:08:43.469Z",
+      "sha256": "96885f4e5df7887e5147fd2317b10b376cf9c67f030ee99228c6c6eba4375e92",
+      "detected_magic": "hwp5-cfb",
+      "size_bytes": 70144,
+      "feature_tags": [
+        "form_control"
+      ],
+      "pair_id": "law-go-271027-17184503",
+      "privacy_review": {
+        "classification": "blank-form-template",
+        "decision": "include",
+        "reviewed_at": "2026-08-22"
+      }
+    },
+    {
+      "id": "law-go-271027-17184503-pdf",
+      "file": "law-go-271027-17184503-pdf.pdf",
+      "format": "pdf",
+      "publisher": "고용노동부·법제처",
+      "kind": "blank-form-template",
+      "source_page": "https://www.law.go.kr/LSW/lsInfoP.do?ancYnChk=0&lsiSeq=271027",
+      "source_url": "https://www.law.go.kr/LSW/flDownload.do?flSeq=151361787",
+      "allowed_redirect_hosts": [
+        "www.law.go.kr"
+      ],
+      "license": {
+        "code": "Copyright Act Article 7",
+        "evidence_url": "https://www.law.go.kr/lsLinkCommonInfo.do?lsJoLnkSeq=1029423769",
+        "observed_at": "2026-08-22",
+        "scope": "statutory-public-domain"
+      },
+      "retrieved_at": "2026-08-22T17:08:43.469Z",
+      "sha256": "56d9497a1fab0d0a73046ea6ef34500cee7620b5dfc129de1b8af47563ef11ea",
+      "detected_magic": "pdf",
+      "size_bytes": 51588,
+      "feature_tags": [
+        "form_control"
+      ],
+      "pair_id": "law-go-271027-17184503",
+      "privacy_review": {
+        "classification": "blank-form-template",
+        "decision": "include",
+        "reviewed_at": "2026-08-22"
+      }
+    },
+    {
+      "id": "law-go-271027-17184505-hwp5",
+      "file": "law-go-271027-17184505-hwp5.hwp",
+      "format": "hwp5",
+      "publisher": "고용노동부·법제처",
+      "kind": "blank-form-template",
+      "source_page": "https://www.law.go.kr/LSW/lsInfoP.do?ancYnChk=0&lsiSeq=271027",
+      "source_url": "https://www.law.go.kr/LSW/flDownload.do?flSeq=151361799",
+      "allowed_redirect_hosts": [
+        "www.law.go.kr"
+      ],
+      "license": {
+        "code": "Copyright Act Article 7",
+        "evidence_url": "https://www.law.go.kr/lsLinkCommonInfo.do?lsJoLnkSeq=1029423769",
+        "observed_at": "2026-08-22",
+        "scope": "statutory-public-domain"
+      },
+      "retrieved_at": "2026-08-22T17:08:43.469Z",
+      "sha256": "682cbf6d11a8bbddc5667e4c7b860a048204f47eabf2df67a6c068a2332e4c23",
+      "detected_magic": "hwp5-cfb",
+      "size_bytes": 50688,
+      "feature_tags": [
+        "form_control"
+      ],
+      "pair_id": "law-go-271027-17184505",
+      "privacy_review": {
+        "classification": "blank-form-template",
+        "decision": "include",
+        "reviewed_at": "2026-08-22"
+      }
+    },
+    {
+      "id": "law-go-271027-17184505-pdf",
+      "file": "law-go-271027-17184505-pdf.pdf",
+      "format": "pdf",
+      "publisher": "고용노동부·법제처",
+      "kind": "blank-form-template",
+      "source_page": "https://www.law.go.kr/LSW/lsInfoP.do?ancYnChk=0&lsiSeq=271027",
+      "source_url": "https://www.law.go.kr/LSW/flDownload.do?flSeq=151361801",
+      "allowed_redirect_hosts": [
+        "www.law.go.kr"
+      ],
+      "license": {
+        "code": "Copyright Act Article 7",
+        "evidence_url": "https://www.law.go.kr/lsLinkCommonInfo.do?lsJoLnkSeq=1029423769",
+        "observed_at": "2026-08-22",
+        "scope": "statutory-public-domain"
+      },
+      "retrieved_at": "2026-08-22T17:08:43.469Z",
+      "sha256": "e069e4184746ce959c6430b2a3c3de48d17735d3d96234006788468ac9bbd5d1",
+      "detected_magic": "pdf",
+      "size_bytes": 51105,
+      "feature_tags": [
+        "form_control"
+      ],
+      "pair_id": "law-go-271027-17184505",
+      "privacy_review": {
+        "classification": "blank-form-template",
+        "decision": "include",
+        "reviewed_at": "2026-08-22"
+      }
+    },
+    {
+      "id": "law-go-271027-17184507-hwp5",
+      "file": "law-go-271027-17184507-hwp5.hwp",
+      "format": "hwp5",
+      "publisher": "고용노동부·법제처",
+      "kind": "blank-form-template",
+      "source_page": "https://www.law.go.kr/LSW/lsInfoP.do?ancYnChk=0&lsiSeq=271027",
+      "source_url": "https://www.law.go.kr/LSW/flDownload.do?flSeq=151361825",
+      "allowed_redirect_hosts": [
+        "www.law.go.kr"
+      ],
+      "license": {
+        "code": "Copyright Act Article 7",
+        "evidence_url": "https://www.law.go.kr/lsLinkCommonInfo.do?lsJoLnkSeq=1029423769",
+        "observed_at": "2026-08-22",
+        "scope": "statutory-public-domain"
+      },
+      "retrieved_at": "2026-08-22T17:08:43.470Z",
+      "sha256": "2239613b8609103bec2a3ee68e02ebfebab6829800756fcc918a8dcc181b6510",
+      "detected_magic": "hwp5-cfb",
+      "size_bytes": 15360,
+      "feature_tags": [
+        "form_control"
+      ],
+      "pair_id": "law-go-271027-17184507",
+      "privacy_review": {
+        "classification": "blank-form-template",
+        "decision": "include",
+        "reviewed_at": "2026-08-22"
+      }
+    },
+    {
+      "id": "law-go-271027-17184507-pdf",
+      "file": "law-go-271027-17184507-pdf.pdf",
+      "format": "pdf",
+      "publisher": "고용노동부·법제처",
+      "kind": "blank-form-template",
+      "source_page": "https://www.law.go.kr/LSW/lsInfoP.do?ancYnChk=0&lsiSeq=271027",
+      "source_url": "https://www.law.go.kr/LSW/flDownload.do?flSeq=151361829",
+      "allowed_redirect_hosts": [
+        "www.law.go.kr"
+      ],
+      "license": {
+        "code": "Copyright Act Article 7",
+        "evidence_url": "https://www.law.go.kr/lsLinkCommonInfo.do?lsJoLnkSeq=1029423769",
+        "observed_at": "2026-08-22",
+        "scope": "statutory-public-domain"
+      },
+      "retrieved_at": "2026-08-22T17:08:43.470Z",
+      "sha256": "04685c76a3eb07a3009c4a2a2160fddcc12d63a5f76b8da4e1e7fd662bdc3c12",
+      "detected_magic": "pdf",
+      "size_bytes": 32943,
+      "feature_tags": [
+        "form_control"
+      ],
+      "pair_id": "law-go-271027-17184507",
+      "privacy_review": {
+        "classification": "blank-form-template",
+        "decision": "include",
+        "reviewed_at": "2026-08-22"
+      }
+    },
+    {
+      "id": "law-go-271027-17184509-hwp5",
+      "file": "law-go-271027-17184509-hwp5.hwp",
+      "format": "hwp5",
+      "publisher": "고용노동부·법제처",
+      "kind": "blank-form-template",
+      "source_page": "https://www.law.go.kr/LSW/lsInfoP.do?ancYnChk=0&lsiSeq=271027",
+      "source_url": "https://www.law.go.kr/LSW/flDownload.do?flSeq=151361835",
+      "allowed_redirect_hosts": [
+        "www.law.go.kr"
+      ],
+      "license": {
+        "code": "Copyright Act Article 7",
+        "evidence_url": "https://www.law.go.kr/lsLinkCommonInfo.do?lsJoLnkSeq=1029423769",
+        "observed_at": "2026-08-22",
+        "scope": "statutory-public-domain"
+      },
+      "retrieved_at": "2026-08-22T17:08:43.470Z",
+      "sha256": "62e0f560a14d5406c7850a8ddf08ee547cc9a7a9ec4e880e38b073c5a8c5a491",
+      "detected_magic": "hwp5-cfb",
+      "size_bytes": 19456,
+      "feature_tags": [
+        "form_control"
+      ],
+      "pair_id": "law-go-271027-17184509",
+      "privacy_review": {
+        "classification": "blank-form-template",
+        "decision": "include",
+        "reviewed_at": "2026-08-22"
+      }
+    },
+    {
+      "id": "law-go-271027-17184509-pdf",
+      "file": "law-go-271027-17184509-pdf.pdf",
+      "format": "pdf",
+      "publisher": "고용노동부·법제처",
+      "kind": "blank-form-template",
+      "source_page": "https://www.law.go.kr/LSW/lsInfoP.do?ancYnChk=0&lsiSeq=271027",
+      "source_url": "https://www.law.go.kr/LSW/flDownload.do?flSeq=151361837",
+      "allowed_redirect_hosts": [
+        "www.law.go.kr"
+      ],
+      "license": {
+        "code": "Copyright Act Article 7",
+        "evidence_url": "https://www.law.go.kr/lsLinkCommonInfo.do?lsJoLnkSeq=1029423769",
+        "observed_at": "2026-08-22",
+        "scope": "statutory-public-domain"
+      },
+      "retrieved_at": "2026-08-22T17:08:43.470Z",
+      "sha256": "280047052c43ab09e092c17a5ff70bd621ca3b9cedd33ac0a4cbbdafc52ca141",
+      "detected_magic": "pdf",
+      "size_bytes": 57389,
+      "feature_tags": [
+        "form_control"
+      ],
+      "pair_id": "law-go-271027-17184509",
+      "privacy_review": {
+        "classification": "blank-form-template",
+        "decision": "include",
+        "reviewed_at": "2026-08-22"
+      }
+    },
+    {
+      "id": "law-go-271027-17184511-hwp5",
+      "file": "law-go-271027-17184511-hwp5.hwp",
+      "format": "hwp5",
+      "publisher": "고용노동부·법제처",
+      "kind": "blank-form-template",
+      "source_page": "https://www.law.go.kr/LSW/lsInfoP.do?ancYnChk=0&lsiSeq=271027",
+      "source_url": "https://www.law.go.kr/LSW/flDownload.do?flSeq=151361841",
+      "allowed_redirect_hosts": [
+        "www.law.go.kr"
+      ],
+      "license": {
+        "code": "Copyright Act Article 7",
+        "evidence_url": "https://www.law.go.kr/lsLinkCommonInfo.do?lsJoLnkSeq=1029423769",
+        "observed_at": "2026-08-22",
+        "scope": "statutory-public-domain"
+      },
+      "retrieved_at": "2026-08-22T17:08:43.470Z",
+      "sha256": "58d4302527076799988dd54279a10de4f2a489fa731e4bad596ca209f160e0b3",
+      "detected_magic": "hwp5-cfb",
+      "size_bytes": 86016,
+      "feature_tags": [
+        "form_control"
+      ],
+      "pair_id": "law-go-271027-17184511",
+      "privacy_review": {
+        "classification": "blank-form-template",
+        "decision": "include",
+        "reviewed_at": "2026-08-22"
+      }
+    },
+    {
+      "id": "law-go-271027-17184511-pdf",
+      "file": "law-go-271027-17184511-pdf.pdf",
+      "format": "pdf",
+      "publisher": "고용노동부·법제처",
+      "kind": "blank-form-template",
+      "source_page": "https://www.law.go.kr/LSW/lsInfoP.do?ancYnChk=0&lsiSeq=271027",
+      "source_url": "https://www.law.go.kr/LSW/flDownload.do?flSeq=151361843",
+      "allowed_redirect_hosts": [
+        "www.law.go.kr"
+      ],
+      "license": {
+        "code": "Copyright Act Article 7",
+        "evidence_url": "https://www.law.go.kr/lsLinkCommonInfo.do?lsJoLnkSeq=1029423769",
+        "observed_at": "2026-08-22",
+        "scope": "statutory-public-domain"
+      },
+      "retrieved_at": "2026-08-22T17:08:43.470Z",
+      "sha256": "9bf747f2dd88b8d844ae0c5c3d7fa998a65591c305690853177cd76f66f90be8",
+      "detected_magic": "pdf",
+      "size_bytes": 84728,
+      "feature_tags": [
+        "form_control"
+      ],
+      "pair_id": "law-go-271027-17184511",
+      "privacy_review": {
+        "classification": "blank-form-template",
+        "decision": "include",
+        "reviewed_at": "2026-08-22"
+      }
+    },
+    {
+      "id": "law-go-271027-17184513-hwp5",
+      "file": "law-go-271027-17184513-hwp5.hwp",
+      "format": "hwp5",
+      "publisher": "고용노동부·법제처",
+      "kind": "blank-form-template",
+      "source_page": "https://www.law.go.kr/LSW/lsInfoP.do?ancYnChk=0&lsiSeq=271027",
+      "source_url": "https://www.law.go.kr/LSW/flDownload.do?flSeq=151361847",
+      "allowed_redirect_hosts": [
+        "www.law.go.kr"
+      ],
+      "license": {
+        "code": "Copyright Act Article 7",
+        "evidence_url": "https://www.law.go.kr/lsLinkCommonInfo.do?lsJoLnkSeq=1029423769",
+        "observed_at": "2026-08-22",
+        "scope": "statutory-public-domain"
+      },
+      "retrieved_at": "2026-08-22T17:08:43.471Z",
+      "sha256": "32cb80a08144c9e79f27d373f436bc5979030a9b9246f2a0ec566a5008e8b79b",
+      "detected_magic": "hwp5-cfb",
+      "size_bytes": 91648,
+      "feature_tags": [
+        "form_control"
+      ],
+      "pair_id": "law-go-271027-17184513",
+      "privacy_review": {
+        "classification": "blank-form-template",
+        "decision": "include",
+        "reviewed_at": "2026-08-22"
+      }
+    },
+    {
+      "id": "law-go-271027-17184513-pdf",
+      "file": "law-go-271027-17184513-pdf.pdf",
+      "format": "pdf",
+      "publisher": "고용노동부·법제처",
+      "kind": "blank-form-template",
+      "source_page": "https://www.law.go.kr/LSW/lsInfoP.do?ancYnChk=0&lsiSeq=271027",
+      "source_url": "https://www.law.go.kr/LSW/flDownload.do?flSeq=151361849",
+      "allowed_redirect_hosts": [
+        "www.law.go.kr"
+      ],
+      "license": {
+        "code": "Copyright Act Article 7",
+        "evidence_url": "https://www.law.go.kr/lsLinkCommonInfo.do?lsJoLnkSeq=1029423769",
+        "observed_at": "2026-08-22",
+        "scope": "statutory-public-domain"
+      },
+      "retrieved_at": "2026-08-22T17:08:43.471Z",
+      "sha256": "cdbbcd0b5cc7c853354e570caed98d6fc59186691d6c3aa8d855fe819b2cce6b",
+      "detected_magic": "pdf",
+      "size_bytes": 55437,
+      "feature_tags": [
+        "form_control"
+      ],
+      "pair_id": "law-go-271027-17184513",
+      "privacy_review": {
+        "classification": "blank-form-template",
+        "decision": "include",
+        "reviewed_at": "2026-08-22"
+      }
+    },
+    {
+      "id": "law-go-271027-17184515-hwp5",
+      "file": "law-go-271027-17184515-hwp5.hwp",
+      "format": "hwp5",
+      "publisher": "고용노동부·법제처",
+      "kind": "blank-form-template",
+      "source_page": "https://www.law.go.kr/LSW/lsInfoP.do?ancYnChk=0&lsiSeq=271027",
+      "source_url": "https://www.law.go.kr/LSW/flDownload.do?flSeq=151361853",
+      "allowed_redirect_hosts": [
+        "www.law.go.kr"
+      ],
+      "license": {
+        "code": "Copyright Act Article 7",
+        "evidence_url": "https://www.law.go.kr/lsLinkCommonInfo.do?lsJoLnkSeq=1029423769",
+        "observed_at": "2026-08-22",
+        "scope": "statutory-public-domain"
+      },
+      "retrieved_at": "2026-08-22T17:08:43.471Z",
+      "sha256": "85e9d52ce12f8e8bd8df812519f7882454521e10448cbef95ed7e4cda8e08c8f",
+      "detected_magic": "hwp5-cfb",
+      "size_bytes": 41472,
+      "feature_tags": [
+        "form_control"
+      ],
+      "pair_id": "law-go-271027-17184515",
+      "privacy_review": {
+        "classification": "blank-form-template",
+        "decision": "include",
+        "reviewed_at": "2026-08-22"
+      }
+    },
+    {
+      "id": "law-go-271027-17184515-pdf",
+      "file": "law-go-271027-17184515-pdf.pdf",
+      "format": "pdf",
+      "publisher": "고용노동부·법제처",
+      "kind": "blank-form-template",
+      "source_page": "https://www.law.go.kr/LSW/lsInfoP.do?ancYnChk=0&lsiSeq=271027",
+      "source_url": "https://www.law.go.kr/LSW/flDownload.do?flSeq=151361855",
+      "allowed_redirect_hosts": [
+        "www.law.go.kr"
+      ],
+      "license": {
+        "code": "Copyright Act Article 7",
+        "evidence_url": "https://www.law.go.kr/lsLinkCommonInfo.do?lsJoLnkSeq=1029423769",
+        "observed_at": "2026-08-22",
+        "scope": "statutory-public-domain"
+      },
+      "retrieved_at": "2026-08-22T17:08:43.471Z",
+      "sha256": "1ed78601b44edfd75a97e97107a3f18e0a29e345615fdce2e23f57f20fb5c0d7",
+      "detected_magic": "pdf",
+      "size_bytes": 35796,
+      "feature_tags": [
+        "form_control"
+      ],
+      "pair_id": "law-go-271027-17184515",
+      "privacy_review": {
+        "classification": "blank-form-template",
+        "decision": "include",
+        "reviewed_at": "2026-08-22"
+      }
+    },
+    {
+      "id": "law-go-271027-17184517-hwp5",
+      "file": "law-go-271027-17184517-hwp5.hwp",
+      "format": "hwp5",
+      "publisher": "고용노동부·법제처",
+      "kind": "blank-form-template",
+      "source_page": "https://www.law.go.kr/LSW/lsInfoP.do?ancYnChk=0&lsiSeq=271027",
+      "source_url": "https://www.law.go.kr/LSW/flDownload.do?flSeq=151361861",
+      "allowed_redirect_hosts": [
+        "www.law.go.kr"
+      ],
+      "license": {
+        "code": "Copyright Act Article 7",
+        "evidence_url": "https://www.law.go.kr/lsLinkCommonInfo.do?lsJoLnkSeq=1029423769",
+        "observed_at": "2026-08-22",
+        "scope": "statutory-public-domain"
+      },
+      "retrieved_at": "2026-08-22T17:08:43.471Z",
+      "sha256": "f4b9699c78f9ac63ca271008296b76390226728df084c33d9d7027071d918a18",
+      "detected_magic": "hwp5-cfb",
+      "size_bytes": 38912,
+      "feature_tags": [
+        "form_control"
+      ],
+      "pair_id": "law-go-271027-17184517",
+      "privacy_review": {
+        "classification": "blank-form-template",
+        "decision": "include",
+        "reviewed_at": "2026-08-22"
+      }
+    },
+    {
+      "id": "law-go-271027-17184517-pdf",
+      "file": "law-go-271027-17184517-pdf.pdf",
+      "format": "pdf",
+      "publisher": "고용노동부·법제처",
+      "kind": "blank-form-template",
+      "source_page": "https://www.law.go.kr/LSW/lsInfoP.do?ancYnChk=0&lsiSeq=271027",
+      "source_url": "https://www.law.go.kr/LSW/flDownload.do?flSeq=151361863",
+      "allowed_redirect_hosts": [
+        "www.law.go.kr"
+      ],
+      "license": {
+        "code": "Copyright Act Article 7",
+        "evidence_url": "https://www.law.go.kr/lsLinkCommonInfo.do?lsJoLnkSeq=1029423769",
+        "observed_at": "2026-08-22",
+        "scope": "statutory-public-domain"
+      },
+      "retrieved_at": "2026-08-22T17:08:43.471Z",
+      "sha256": "75e628b1c57bddc931848d5fe6eeb22d0a20a5d5d018530cd5f717c2f186261f",
+      "detected_magic": "pdf",
+      "size_bytes": 39215,
+      "feature_tags": [
+        "form_control"
+      ],
+      "pair_id": "law-go-271027-17184517",
+      "privacy_review": {
+        "classification": "blank-form-template",
+        "decision": "include",
+        "reviewed_at": "2026-08-22"
+      }
+    },
+    {
+      "id": "law-go-271027-17184519-hwp5",
+      "file": "law-go-271027-17184519-hwp5.hwp",
+      "format": "hwp5",
+      "publisher": "고용노동부·법제처",
+      "kind": "blank-form-template",
+      "source_page": "https://www.law.go.kr/LSW/lsInfoP.do?ancYnChk=0&lsiSeq=271027",
+      "source_url": "https://www.law.go.kr/LSW/flDownload.do?flSeq=151361867",
+      "allowed_redirect_hosts": [
+        "www.law.go.kr"
+      ],
+      "license": {
+        "code": "Copyright Act Article 7",
+        "evidence_url": "https://www.law.go.kr/lsLinkCommonInfo.do?lsJoLnkSeq=1029423769",
+        "observed_at": "2026-08-22",
+        "scope": "statutory-public-domain"
+      },
+      "retrieved_at": "2026-08-22T17:08:43.471Z",
+      "sha256": "2c8d0fcedcb4933a1ac2833f431bf71f1a994b798982569292b48fce047af4df",
+      "detected_magic": "hwp5-cfb",
+      "size_bytes": 56320,
+      "feature_tags": [
+        "form_control"
+      ],
+      "pair_id": "law-go-271027-17184519",
+      "privacy_review": {
+        "classification": "blank-form-template",
+        "decision": "include",
+        "reviewed_at": "2026-08-22"
+      }
+    },
+    {
+      "id": "law-go-271027-17184521-hwp5",
+      "file": "law-go-271027-17184521-hwp5.hwp",
+      "format": "hwp5",
+      "publisher": "고용노동부·법제처",
+      "kind": "blank-form-template",
+      "source_page": "https://www.law.go.kr/LSW/lsInfoP.do?ancYnChk=0&lsiSeq=271027",
+      "source_url": "https://www.law.go.kr/LSW/flDownload.do?flSeq=151361873",
+      "allowed_redirect_hosts": [
+        "www.law.go.kr"
+      ],
+      "license": {
+        "code": "Copyright Act Article 7",
+        "evidence_url": "https://www.law.go.kr/lsLinkCommonInfo.do?lsJoLnkSeq=1029423769",
+        "observed_at": "2026-08-22",
+        "scope": "statutory-public-domain"
+      },
+      "retrieved_at": "2026-08-22T17:08:43.472Z",
+      "sha256": "5674a44e7fec3d78501c2dbc46a0d63b2241264c15c7488783eaf355bfdb56d9",
+      "detected_magic": "hwp5-cfb",
+      "size_bytes": 48640,
+      "feature_tags": [
+        "form_control"
+      ],
+      "pair_id": "law-go-271027-17184521",
+      "privacy_review": {
+        "classification": "blank-form-template",
+        "decision": "include",
+        "reviewed_at": "2026-08-22"
+      }
+    },
+    {
+      "id": "law-go-271027-17184523-hwp5",
+      "file": "law-go-271027-17184523-hwp5.hwp",
+      "format": "hwp5",
+      "publisher": "고용노동부·법제처",
+      "kind": "blank-form-template",
+      "source_page": "https://www.law.go.kr/LSW/lsInfoP.do?ancYnChk=0&lsiSeq=271027",
+      "source_url": "https://www.law.go.kr/LSW/flDownload.do?flSeq=151361881",
+      "allowed_redirect_hosts": [
+        "www.law.go.kr"
+      ],
+      "license": {
+        "code": "Copyright Act Article 7",
+        "evidence_url": "https://www.law.go.kr/lsLinkCommonInfo.do?lsJoLnkSeq=1029423769",
+        "observed_at": "2026-08-22",
+        "scope": "statutory-public-domain"
+      },
+      "retrieved_at": "2026-08-22T17:08:43.472Z",
+      "sha256": "4c5207a4896acfe8572c6c02b317792933b6b806fa829067346cfe9dcfd99dd3",
+      "detected_magic": "hwp5-cfb",
+      "size_bytes": 20480,
+      "feature_tags": [
+        "form_control"
+      ],
+      "pair_id": "law-go-271027-17184523",
+      "privacy_review": {
+        "classification": "blank-form-template",
+        "decision": "include",
+        "reviewed_at": "2026-08-22"
+      }
+    },
+    {
+      "id": "law-go-271027-17184525-hwp5",
+      "file": "law-go-271027-17184525-hwp5.hwp",
+      "format": "hwp5",
+      "publisher": "고용노동부·법제처",
+      "kind": "blank-form-template",
+      "source_page": "https://www.law.go.kr/LSW/lsInfoP.do?ancYnChk=0&lsiSeq=271027",
+      "source_url": "https://www.law.go.kr/LSW/flDownload.do?flSeq=151361887",
+      "allowed_redirect_hosts": [
+        "www.law.go.kr"
+      ],
+      "license": {
+        "code": "Copyright Act Article 7",
+        "evidence_url": "https://www.law.go.kr/lsLinkCommonInfo.do?lsJoLnkSeq=1029423769",
+        "observed_at": "2026-08-22",
+        "scope": "statutory-public-domain"
+      },
+      "retrieved_at": "2026-08-22T17:08:43.472Z",
+      "sha256": "283d39dcb83a4950d539639d0c60e091429d97602cb40be679266817fc70deb8",
+      "detected_magic": "hwp5-cfb",
+      "size_bytes": 21504,
+      "feature_tags": [
+        "form_control"
+      ],
+      "pair_id": "law-go-271027-17184525",
+      "privacy_review": {
+        "classification": "blank-form-template",
+        "decision": "include",
+        "reviewed_at": "2026-08-22"
+      }
+    },
+    {
+      "id": "law-go-271027-17184527-hwp5",
+      "file": "law-go-271027-17184527-hwp5.hwp",
+      "format": "hwp5",
+      "publisher": "고용노동부·법제처",
+      "kind": "blank-form-template",
+      "source_page": "https://www.law.go.kr/LSW/lsInfoP.do?ancYnChk=0&lsiSeq=271027",
+      "source_url": "https://www.law.go.kr/LSW/flDownload.do?flSeq=151361893",
+      "allowed_redirect_hosts": [
+        "www.law.go.kr"
+      ],
+      "license": {
+        "code": "Copyright Act Article 7",
+        "evidence_url": "https://www.law.go.kr/lsLinkCommonInfo.do?lsJoLnkSeq=1029423769",
+        "observed_at": "2026-08-22",
+        "scope": "statutory-public-domain"
+      },
+      "retrieved_at": "2026-08-22T17:08:43.472Z",
+      "sha256": "bd4b55725c0b3904aac770d5aee3722484458041a4384a27e0a17f60cdcadf76",
+      "detected_magic": "hwp5-cfb",
+      "size_bytes": 14848,
+      "feature_tags": [
+        "form_control"
+      ],
+      "pair_id": "law-go-271027-17184527",
+      "privacy_review": {
+        "classification": "blank-form-template",
+        "decision": "include",
+        "reviewed_at": "2026-08-22"
+      }
+    },
+    {
+      "id": "law-go-271027-17184529-hwp5",
+      "file": "law-go-271027-17184529-hwp5.hwp",
+      "format": "hwp5",
+      "publisher": "고용노동부·법제처",
+      "kind": "blank-form-template",
+      "source_page": "https://www.law.go.kr/LSW/lsInfoP.do?ancYnChk=0&lsiSeq=271027",
+      "source_url": "https://www.law.go.kr/LSW/flDownload.do?flSeq=151361901",
+      "allowed_redirect_hosts": [
+        "www.law.go.kr"
+      ],
+      "license": {
+        "code": "Copyright Act Article 7",
+        "evidence_url": "https://www.law.go.kr/lsLinkCommonInfo.do?lsJoLnkSeq=1029423769",
+        "observed_at": "2026-08-22",
+        "scope": "statutory-public-domain"
+      },
+      "retrieved_at": "2026-08-22T17:08:43.472Z",
+      "sha256": "ffebb654df18e2524ddb28df7d63bb58442aa431cfeb21d8732ccbd57be2a416",
+      "detected_magic": "hwp5-cfb",
+      "size_bytes": 16384,
+      "feature_tags": [
+        "form_control"
+      ],
+      "pair_id": "law-go-271027-17184529",
+      "privacy_review": {
+        "classification": "blank-form-template",
+        "decision": "include",
+        "reviewed_at": "2026-08-22"
+      }
+    },
+    {
+      "id": "law-go-271027-17184531-hwp5",
+      "file": "law-go-271027-17184531-hwp5.hwp",
+      "format": "hwp5",
+      "publisher": "고용노동부·법제처",
+      "kind": "blank-form-template",
+      "source_page": "https://www.law.go.kr/LSW/lsInfoP.do?ancYnChk=0&lsiSeq=271027",
+      "source_url": "https://www.law.go.kr/LSW/flDownload.do?flSeq=151361907",
+      "allowed_redirect_hosts": [
+        "www.law.go.kr"
+      ],
+      "license": {
+        "code": "Copyright Act Article 7",
+        "evidence_url": "https://www.law.go.kr/lsLinkCommonInfo.do?lsJoLnkSeq=1029423769",
+        "observed_at": "2026-08-22",
+        "scope": "statutory-public-domain"
+      },
+      "retrieved_at": "2026-08-22T17:08:43.472Z",
+      "sha256": "af1bafe1f95778af9ad0c0cddb2240aea67c22ed69dbf2e0f09a83ea22045037",
+      "detected_magic": "hwp5-cfb",
+      "size_bytes": 20480,
+      "feature_tags": [
+        "form_control"
+      ],
+      "pair_id": "law-go-271027-17184531",
+      "privacy_review": {
+        "classification": "blank-form-template",
+        "decision": "include",
+        "reviewed_at": "2026-08-22"
+      }
+    },
+    {
+      "id": "law-go-271027-17184533-hwp5",
+      "file": "law-go-271027-17184533-hwp5.hwp",
+      "format": "hwp5",
+      "publisher": "고용노동부·법제처",
+      "kind": "blank-form-template",
+      "source_page": "https://www.law.go.kr/LSW/lsInfoP.do?ancYnChk=0&lsiSeq=271027",
+      "source_url": "https://www.law.go.kr/LSW/flDownload.do?flSeq=151361913",
+      "allowed_redirect_hosts": [
+        "www.law.go.kr"
+      ],
+      "license": {
+        "code": "Copyright Act Article 7",
+        "evidence_url": "https://www.law.go.kr/lsLinkCommonInfo.do?lsJoLnkSeq=1029423769",
+        "observed_at": "2026-08-22",
+        "scope": "statutory-public-domain"
+      },
+      "retrieved_at": "2026-08-22T17:08:43.473Z",
+      "sha256": "eb1f9a967a882c062fe17af6d9659fcc3f4e90318863ba43c3fdfebb6c733f48",
+      "detected_magic": "hwp5-cfb",
+      "size_bytes": 15360,
+      "feature_tags": [
+        "form_control"
+      ],
+      "pair_id": "law-go-271027-17184533",
+      "privacy_review": {
+        "classification": "blank-form-template",
+        "decision": "include",
+        "reviewed_at": "2026-08-22"
+      }
+    },
+    {
+      "id": "law-go-271027-17184535-hwp5",
+      "file": "law-go-271027-17184535-hwp5.hwp",
+      "format": "hwp5",
+      "publisher": "고용노동부·법제처",
+      "kind": "blank-form-template",
+      "source_page": "https://www.law.go.kr/LSW/lsInfoP.do?ancYnChk=0&lsiSeq=271027",
+      "source_url": "https://www.law.go.kr/LSW/flDownload.do?flSeq=151361919",
+      "allowed_redirect_hosts": [
+        "www.law.go.kr"
+      ],
+      "license": {
+        "code": "Copyright Act Article 7",
+        "evidence_url": "https://www.law.go.kr/lsLinkCommonInfo.do?lsJoLnkSeq=1029423769",
+        "observed_at": "2026-08-22",
+        "scope": "statutory-public-domain"
+      },
+      "retrieved_at": "2026-08-22T17:08:43.473Z",
+      "sha256": "470aaacd0079677d3b6387b9d92a2cf25042edce8928080fad1e6a344d1521ec",
+      "detected_magic": "hwp5-cfb",
+      "size_bytes": 18432,
+      "feature_tags": [
+        "form_control"
+      ],
+      "pair_id": "law-go-271027-17184535",
+      "privacy_review": {
+        "classification": "blank-form-template",
+        "decision": "include",
+        "reviewed_at": "2026-08-22"
+      }
+    },
+    {
+      "id": "law-go-271027-17184537-hwp5",
+      "file": "law-go-271027-17184537-hwp5.hwp",
+      "format": "hwp5",
+      "publisher": "고용노동부·법제처",
+      "kind": "blank-form-template",
+      "source_page": "https://www.law.go.kr/LSW/lsInfoP.do?ancYnChk=0&lsiSeq=271027",
+      "source_url": "https://www.law.go.kr/LSW/flDownload.do?flSeq=151361925",
+      "allowed_redirect_hosts": [
+        "www.law.go.kr"
+      ],
+      "license": {
+        "code": "Copyright Act Article 7",
+        "evidence_url": "https://www.law.go.kr/lsLinkCommonInfo.do?lsJoLnkSeq=1029423769",
+        "observed_at": "2026-08-22",
+        "scope": "statutory-public-domain"
+      },
+      "retrieved_at": "2026-08-22T17:08:43.473Z",
+      "sha256": "2a0fc6865d2494b3268954389a6ec958fb44b898a988fb80fd4b32423a48b075",
+      "detected_magic": "hwp5-cfb",
+      "size_bytes": 20480,
+      "feature_tags": [
+        "form_control",
+        "multipage_table"
+      ],
+      "pair_id": "law-go-271027-17184537",
+      "privacy_review": {
+        "classification": "blank-form-template",
+        "decision": "include",
+        "reviewed_at": "2026-08-22"
+      }
+    },
+    {
+      "id": "mafra-570867-579163",
+      "file": "mafra-570867-579163.hwpx",
+      "format": "hwpx",
+      "publisher": "농림축산식품부",
+      "kind": "public-guidance",
+      "source_page": "https://www.mafra.go.kr/bbs/home/791/570867/artclView.do",
+      "source_url": "https://www.mafra.go.kr/bbs/home/791/579163/download.do",
+      "allowed_redirect_hosts": [
+        "www.mafra.go.kr"
+      ],
+      "license": {
+        "code": "KOGL-1",
+        "evidence_url": "https://www.mafra.go.kr/bbs/home/791/570867/artclView.do",
+        "observed_at": "2026-08-22",
+        "scope": "license-as-observed-private-evaluation"
+      },
+      "retrieved_at": "2026-08-22T17:08:43.474Z",
+      "sha256": "75df170708ddeefa207ea760ae1e0944efb2b32752b22341e49c6c60fe8ace6b",
+      "detected_magic": "hwpx-owpml-zip",
+      "size_bytes": 31261,
+      "feature_tags": [
+        "equation",
+        "footnote",
+        "multipage_table"
+      ],
+      "pair_id": null,
+      "privacy_review": {
+        "classification": "public-guidance",
+        "decision": "include",
+        "reviewed_at": "2026-08-22"
+      }
+    },
+    {
+      "id": "mafra-570867-579164",
+      "file": "mafra-570867-579164.hwpx",
+      "format": "hwpx",
+      "publisher": "농림축산식품부",
+      "kind": "public-guidance",
+      "source_page": "https://www.mafra.go.kr/bbs/home/791/570867/artclView.do",
+      "source_url": "https://www.mafra.go.kr/bbs/home/791/579164/download.do",
+      "allowed_redirect_hosts": [
+        "www.mafra.go.kr"
+      ],
+      "license": {
+        "code": "KOGL-1",
+        "evidence_url": "https://www.mafra.go.kr/bbs/home/791/570867/artclView.do",
+        "observed_at": "2026-08-22",
+        "scope": "license-as-observed-private-evaluation"
+      },
+      "retrieved_at": "2026-08-22T17:08:43.587Z",
+      "sha256": "f7c59132144457812f4ce51b29831edb9d9e0df94eb764553bdd2e196ccc2556",
+      "detected_magic": "hwpx-owpml-zip",
+      "size_bytes": 1309717,
+      "feature_tags": [
+        "equation",
+        "footnote",
+        "multipage_table"
+      ],
+      "pair_id": null,
+      "privacy_review": {
+        "classification": "public-guidance",
+        "decision": "include",
+        "reviewed_at": "2026-08-22"
+      }
+    },
+    {
+      "id": "mafra-570867-579165",
+      "file": "mafra-570867-579165.hwpx",
+      "format": "hwpx",
+      "publisher": "농림축산식품부",
+      "kind": "public-guidance",
+      "source_page": "https://www.mafra.go.kr/bbs/home/791/570867/artclView.do",
+      "source_url": "https://www.mafra.go.kr/bbs/home/791/579165/download.do",
+      "allowed_redirect_hosts": [
+        "www.mafra.go.kr"
+      ],
+      "license": {
+        "code": "KOGL-1",
+        "evidence_url": "https://www.mafra.go.kr/bbs/home/791/570867/artclView.do",
+        "observed_at": "2026-08-22",
+        "scope": "license-as-observed-private-evaluation"
+      },
+      "retrieved_at": "2026-08-22T17:08:43.589Z",
+      "sha256": "da3a7c24a8918102e2620853a0849290fbc8d7330a5be20a465b8f126ae098c1",
+      "detected_magic": "hwpx-owpml-zip",
+      "size_bytes": 58428,
+      "feature_tags": [
+        "equation",
+        "footnote",
+        "multipage_table"
+      ],
+      "pair_id": null,
+      "privacy_review": {
+        "classification": "public-guidance",
+        "decision": "include",
+        "reviewed_at": "2026-08-22"
+      }
+    },
+    {
+      "id": "mafra-570867-579166",
+      "file": "mafra-570867-579166.hwpx",
+      "format": "hwpx",
+      "publisher": "농림축산식품부",
+      "kind": "public-guidance",
+      "source_page": "https://www.mafra.go.kr/bbs/home/791/570867/artclView.do",
+      "source_url": "https://www.mafra.go.kr/bbs/home/791/579166/download.do",
+      "allowed_redirect_hosts": [
+        "www.mafra.go.kr"
+      ],
+      "license": {
+        "code": "KOGL-1",
+        "evidence_url": "https://www.mafra.go.kr/bbs/home/791/570867/artclView.do",
+        "observed_at": "2026-08-22",
+        "scope": "license-as-observed-private-evaluation"
+      },
+      "retrieved_at": "2026-08-22T17:08:43.607Z",
+      "sha256": "820b2a39a3c5f060d0ca33f7db1667d1e480acaee32427e270fadb3fb3ae2fea",
+      "detected_magic": "hwpx-owpml-zip",
+      "size_bytes": 243857,
+      "feature_tags": [
+        "equation",
+        "footnote",
+        "multipage_table"
+      ],
+      "pair_id": null,
+      "privacy_review": {
+        "classification": "public-guidance",
+        "decision": "include",
+        "reviewed_at": "2026-08-22"
+      }
+    },
+    {
+      "id": "moe-104863-hwpx",
+      "file": "moe-104863-hwpx.hwpx",
+      "format": "hwpx",
+      "publisher": "교육부",
+      "kind": "official-publication",
+      "source_page": "https://www.moe.go.kr/boardCnts/viewRenew.do?boardID=294&boardSeq=104863&lev=0&m=020402&s=moe",
+      "source_url": "https://www.moe.go.kr/boardCnts/fileDown.do?m=020402&s=moe&fileSeq=9aa25b9277d1bffeca15f0c625719d77",
+      "allowed_redirect_hosts": [
+        "www.moe.go.kr"
+      ],
+      "license": {
+        "code": "KOGL-1",
+        "evidence_url": "https://www.moe.go.kr/boardCnts/viewRenew.do?boardID=294&boardSeq=104863&lev=0&m=020402&s=moe",
+        "observed_at": "2026-08-23",
+        "scope": "license-as-observed-private-evaluation"
+      },
+      "retrieved_at": "2026-08-22T17:08:43.838Z",
+      "sha256": "e229a8dd9a44eb56fead78965856a006c800fe7864b04f898ff1f087452e8837",
+      "detected_magic": "hwpx-owpml-zip",
+      "size_bytes": 460070,
+      "feature_tags": [
+        "footnote",
+        "mixed_orientation",
+        "multicolumn",
+        "multipage_table"
+      ],
+      "pair_id": null,
+      "privacy_review": {
+        "classification": "official-publication",
+        "decision": "include",
+        "reviewed_at": "2026-08-22"
+      }
+    },
+    {
+      "id": "mohw-1480808-hwpx",
+      "file": "mohw-1480808-hwpx.hwpx",
+      "format": "hwpx",
+      "publisher": "보건복지부",
+      "kind": "official-publication",
+      "source_page": "https://www.mohw.go.kr/board.es?act=view&bid=0027&list_no=1480808&mid=a10503000000",
+      "source_url": "https://www.mohw.go.kr/boardDownload.es?bid=0027&list_no=1480808&seq=1",
+      "allowed_redirect_hosts": [
+        "www.mohw.go.kr"
+      ],
+      "license": {
+        "code": "KOGL-1",
+        "evidence_url": "https://www.mohw.go.kr/board.es?act=view&bid=0027&list_no=1480808&mid=a10503000000",
+        "observed_at": "2026-08-22",
+        "scope": "license-as-observed-private-evaluation"
+      },
+      "retrieved_at": "2026-08-22T17:08:43.846Z",
+      "sha256": "0acf3a1868a485f0f4f6a2eeb275b89bf15443800f39522f1ca0bfff69146713",
+      "detected_magic": "hwpx-owpml-zip",
+      "size_bytes": 530619,
+      "feature_tags": [
+        "multipage_table"
+      ],
+      "pair_id": "mohw-1480808",
+      "privacy_review": {
+        "classification": "official-publication",
+        "decision": "include",
+        "reviewed_at": "2026-08-22"
+      }
+    },
+    {
+      "id": "mohw-1490937-hwpx",
+      "file": "mohw-1490937-hwpx.hwpx",
+      "format": "hwpx",
+      "publisher": "보건복지부",
+      "kind": "official-publication",
+      "source_page": "https://www.mohw.go.kr/board.es?act=view&bid=0027&list_no=1490937&mid=a10503010100",
+      "source_url": "https://www.mohw.go.kr/boardDownload.es?bid=0027&list_no=1490937&seq=1",
+      "allowed_redirect_hosts": [
+        "www.mohw.go.kr"
+      ],
+      "license": {
+        "code": "KOGL-1",
+        "evidence_url": "https://www.mohw.go.kr/board.es?act=view&bid=0027&list_no=1490937&mid=a10503010100",
+        "observed_at": "2026-08-21",
+        "scope": "license-as-observed-private-evaluation"
+      },
+      "retrieved_at": "2026-08-22T17:08:43.850Z",
+      "sha256": "72fa704001c7a144589e8faa5069a0ffbacefa718710cd9327e216d6125e5c50",
+      "detected_magic": "hwpx-owpml-zip",
+      "size_bytes": 130796,
+      "feature_tags": [
+        "multipage_table"
+      ],
+      "pair_id": null,
+      "privacy_review": {
+        "classification": "official-publication",
+        "decision": "include",
+        "reviewed_at": "2026-08-23"
+      }
+    },
+    {
+      "id": "nfa-458-forms-hwpx",
+      "file": "nfa-458-forms-hwpx.hwpx",
+      "format": "hwpx",
+      "publisher": "소방청",
+      "kind": "blank-form-template",
+      "source_page": "https://www.nfa.go.kr/nfa/news/job/nfajob/?cntId=458&mode=view",
+      "source_url": "https://www.nfa.go.kr/board/file/bbs_0000000000000012/458/FILE_000000000026202/2026010510521616538",
+      "allowed_redirect_hosts": [
+        "www.nfa.go.kr"
+      ],
+      "license": {
+        "code": "KOGL-1",
+        "evidence_url": "https://www.nfa.go.kr/nfa/news/job/nfajob/?cntId=458&mode=view",
+        "observed_at": "2026-08-22",
+        "scope": "license-as-observed-private-evaluation"
+      },
+      "retrieved_at": "2026-08-22T17:08:43.886Z",
+      "sha256": "dfff25c0f0a0c4b2070856731bf77324ba9ec5b2cff45a9922a6b7bcdb93a1b5",
+      "detected_magic": "hwpx-owpml-zip",
+      "size_bytes": 362745,
+      "feature_tags": [
+        "form_control",
+        "multipage_table",
+        "nested_table"
+      ],
+      "pair_id": "nfa-458-forms",
+      "privacy_review": {
+        "classification": "blank-form-template",
+        "decision": "include",
+        "reviewed_at": "2026-08-22"
+      }
+    },
+    {
+      "id": "nfa-458-plan-hwpx",
+      "file": "nfa-458-plan-hwpx.hwpx",
+      "format": "hwpx",
+      "publisher": "소방청",
+      "kind": "official-publication",
+      "source_page": "https://www.nfa.go.kr/nfa/news/job/nfajob/?cntId=458&mode=view",
+      "source_url": "https://www.nfa.go.kr/board/file/bbs_0000000000000012/673167/FILE_000000000026183/2026010509522049188",
+      "allowed_redirect_hosts": [
+        "www.nfa.go.kr"
+      ],
+      "license": {
+        "code": "KOGL-1",
+        "evidence_url": "https://www.nfa.go.kr/nfa/news/job/nfajob/?cntId=458&mode=view",
+        "observed_at": "2026-08-22",
+        "scope": "license-as-observed-private-evaluation"
+      },
+      "retrieved_at": "2026-08-22T17:08:43.903Z",
+      "sha256": "d3506891420e8d55cf36ee502c291124952643c53c7feb071ecd4d671035db90",
+      "detected_magic": "hwpx-owpml-zip",
+      "size_bytes": 382443,
+      "feature_tags": [
+        "multipage_table"
+      ],
+      "pair_id": "nfa-458-plan",
+      "privacy_review": {
+        "classification": "official-publication",
+        "decision": "include",
+        "reviewed_at": "2026-08-22"
+      }
+    },
+    {
+      "id": "nfa-458-qualification-hwpx",
+      "file": "nfa-458-qualification-hwpx.hwpx",
+      "format": "hwpx",
+      "publisher": "소방청",
+      "kind": "public-guidance",
+      "source_page": "https://www.nfa.go.kr/nfa/news/job/nfajob/?cntId=458&mode=view",
+      "source_url": "https://www.nfa.go.kr/board/file/bbs_0000000000000012/673167/FILE_000000000026186/2026010509524070484",
+      "allowed_redirect_hosts": [
+        "www.nfa.go.kr"
+      ],
+      "license": {
+        "code": "KOGL-1",
+        "evidence_url": "https://www.nfa.go.kr/nfa/news/job/nfajob/?cntId=458&mode=view",
+        "observed_at": "2026-08-22",
+        "scope": "license-as-observed-private-evaluation"
+      },
+      "retrieved_at": "2026-08-22T17:08:43.914Z",
+      "sha256": "e96fd5f36fe97f39ba6c8258ac89f56cdc062602ce5133228f818cdc4c2efb63",
+      "detected_magic": "hwpx-owpml-zip",
+      "size_bytes": 171542,
+      "feature_tags": [
+        "multipage_table"
+      ],
+      "pair_id": "nfa-458-qualification",
+      "privacy_review": {
+        "classification": "public-guidance",
+        "decision": "include",
+        "reviewed_at": "2026-08-22"
+      }
+    },
+    {
+      "id": "rda-100000807526-hwpx",
+      "file": "rda-100000807526-hwpx.hwpx",
+      "format": "hwpx",
+      "publisher": "농촌진흥청 농촌인적자원개발센터",
+      "kind": "official-publication",
+      "source_page": "https://rda.go.kr/board/board.do?dataNo=100000807526&mode=view&prgId=day_farmprmninfoEntry",
+      "source_url": "https://rda.go.kr/fileDownLoadDw.do?boardId=farmprmninfo&dataNo=100000807526&sortNo=1",
+      "allowed_redirect_hosts": [
+        "rda.go.kr"
+      ],
+      "license": {
+        "code": "KOGL-1",
+        "evidence_url": "https://rda.go.kr/board/board.do?dataNo=100000807526&mode=view&prgId=day_farmprmninfoEntry",
+        "observed_at": "2026-08-22",
+        "scope": "license-as-observed-private-evaluation"
+      },
+      "retrieved_at": "2026-08-22T17:08:43.924Z",
+      "sha256": "4dee539496c36c83060d7e2ffa9487587c0ac2ebeeb735e18336beb4234bd26e",
+      "detected_magic": "hwpx-owpml-zip",
+      "size_bytes": 1514620,
+      "feature_tags": [
+        "body_text"
+      ],
+      "pair_id": "rda-100000807526",
+      "privacy_review": {
+        "classification": "official-publication",
+        "decision": "include",
+        "reviewed_at": "2026-08-22"
+      }
+    }
+  ]
+}

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,6 +3,17 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
+- 갱신: 2026-08-23 · Codex(sol) — **#100 구현·실수집 완료 · 커밋/PR 전 최종 diff 검수**.
+  `codex/issue-100-public-corpus`에서 공식 HWP5 20건·HWPX 20건·같은 서식의 PDF pair
+  10쌍(총 50)을 권리·privacy·접근성 재검토 후 `corpus/private/`에 수집했고, 재실행 50/50
+  SHA·크기·컨테이너 일치 및 production `tag-layout` 40/40 open을 확인했다. 공개 diff에는
+  바이너리·본문·로컬 경로·격리 메타데이터가 없고 `public-corpus-manifest.json`의 provenance,
+  license scope, retrieval time, SHA, magic, size, feature tag, pair id만 남는다. 수집기는 HTTPS,
+  redirect host, 매 hop public DNS pin, 30초·32MiB, HWP5 CFB/HWPX ZIP/PDF 구조, exclusive
+  no-overwrite를 강제한다. 공개 계약 72건과 `verify-local` quick가 PASS했고 canonical
+  8/18/24쪽·98.9%+, PDF visual 51/51도 유지됐다. **다음:** 전체 diff/보안 검수 → commit·push →
+  PR(`Closes #100`) 필수 CI → 사용자 병합 승인. 이후 #101 calibration → #102 parity.
+
 - 갱신: 2026-08-23 · Codex(sol) — **P0 보안 수정·공개 완료 · #100 unblocked**.
   GHSA-5jw4-mcv6-c6gv를 공개했고 production 수정은 main `2ec233f`, Linux inode 재사용까지
   잠근 테스트 보강 뒤 최신 main은 `6af878c`다. public-main CI `32579085452`에서 Rust/native,

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,12 @@
 
 ---
 
+## 2026-08-23 (Codex sol) · #100 public corpus intake 구현 완료
+- HWP5 20·HWPX 20·공식 PDF pair 10쌍을 private 수집; SHA/구조 50/50·production open 40/40.
+- 공개에는 provenance·권리·privacy·SHA·magic·size·feature/pair만, 바이너리·본문·격리정보 0.
+- HTTPS/DNS pin/redirect/timeout/size/CFB·ZIP·PDF/no-overwrite 계약 72건·quick verify PASS.
+- 다음: diff 검수 → commit/PR CI → 승인 병합 → #101 → #102.
+
 ## 2026-08-23 (Codex sol) · P0 Security Advisory 공개 완료
 - GHSA-5jw4-mcv6-c6gv 공개; 수정 `2ec233f`, Linux 회귀 보강 포함 최신 main `6af878c`.
 - public-main CI `32579085452` green, 관리자 보호 예외는 즉시 원복·필수 보호 규칙 유지.

--- a/scripts/fetch-gov-corpus.mjs
+++ b/scripts/fetch-gov-corpus.mjs
@@ -46,7 +46,8 @@ function namedPathExists(path) {
 function hasDocumentMagic(bytes) {
   return (
     (bytes[0] === 0x50 && bytes[1] === 0x4b) ||
-    (bytes[0] === 0xd0 && bytes[1] === 0xcf)
+    (bytes[0] === 0xd0 && bytes[1] === 0xcf) ||
+    bytes.subarray(0, 5).toString("ascii") === "%PDF-"
   );
 }
 

--- a/scripts/lib/public-corpus-manifest.mjs
+++ b/scripts/lib/public-corpus-manifest.mjs
@@ -26,6 +26,16 @@ const LICENSE_SCOPES = new Set([
 const PRIVACY_CLASSES = new Set(["blank-form-template", "official-publication", "public-guidance"]);
 const SHA256 = /^[0-9a-f]{64}$/;
 const SLUG = /^[a-z0-9]+(?:[-_][a-z0-9]+)*$/;
+const APPROVED_OFFICIAL_HOSTS = new Set([
+  "rda.go.kr",
+  "www.kdca.go.kr",
+  "www.korea.kr",
+  "www.law.go.kr",
+  "www.mafra.go.kr",
+  "www.moe.go.kr",
+  "www.mohw.go.kr",
+  "www.nfa.go.kr",
+]);
 
 function exactKeys(value, keys, path, errors) {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
@@ -45,11 +55,19 @@ function realDate(value) {
 }
 
 function realTimestamp(value) {
-  return typeof value === "string" && /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/.test(value) && !Number.isNaN(Date.parse(value));
+  if (typeof value !== "string" || !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/.test(value)) return false;
+  const parsed = Date.parse(value);
+  if (Number.isNaN(parsed)) return false;
+  const normalized = value.includes(".") ? value : value.replace("Z", ".000Z");
+  return new Date(parsed).toISOString() === normalized;
 }
 
 function publicUrl(value, path, errors) {
-  try { return parsePublicHttpsUrl(value, path); }
+  try {
+    const url = parsePublicHttpsUrl(value, path);
+    if (!APPROVED_OFFICIAL_HOSTS.has(url.hostname)) errors.push(`${path}: host is not in the reviewed official allowlist`);
+    return url;
+  }
   catch (error) { errors.push(error.message); return null; }
 }
 
@@ -106,7 +124,11 @@ export function validatePublicCorpusManifest(doc, { enforceMinimums = true } = {
     else {
       const normalized = [];
       for (const [hostIndex, host] of artifact.allowed_redirect_hosts.entries()) {
-        try { normalized.push(parseAllowedRedirectHostname(host, `${path}.allowed_redirect_hosts[${hostIndex}]`)); }
+        try {
+          const normalizedHost = parseAllowedRedirectHostname(host, `${path}.allowed_redirect_hosts[${hostIndex}]`);
+          normalized.push(normalizedHost);
+          if (!APPROVED_OFFICIAL_HOSTS.has(normalizedHost)) errors.push(`${path}.allowed_redirect_hosts[${hostIndex}]: host is not in the reviewed official allowlist`);
+        }
         catch (error) { errors.push(error.message); }
       }
       if (new Set(normalized).size !== normalized.length || [...normalized].sort().join("\0") !== normalized.join("\0")) errors.push(`${path}.allowed_redirect_hosts: sorted unique hosts required`);

--- a/scripts/lib/public-corpus-manifest.mjs
+++ b/scripts/lib/public-corpus-manifest.mjs
@@ -1,0 +1,175 @@
+import { extname } from "node:path";
+import { parseAllowedRedirectHostname, parsePublicHttpsUrl } from "./public-network-boundary.mjs";
+
+const ROOT_KEYS = new Set(["schema_version", "policy", "artifacts"]);
+const POLICY_KEYS = new Set(["binary_storage", "redistribution", "minimums"]);
+const MINIMUM_KEYS = new Set(["hwp5", "hwpx", "official_pdf_pairs"]);
+const ARTIFACT_KEYS = new Set([
+  "id", "file", "format", "publisher", "kind", "source_page", "source_url",
+  "allowed_redirect_hosts", "license", "retrieved_at", "sha256", "detected_magic",
+  "size_bytes", "feature_tags", "pair_id", "privacy_review",
+]);
+const LICENSE_KEYS = new Set(["code", "evidence_url", "observed_at", "scope"]);
+const PRIVACY_KEYS = new Set(["classification", "decision", "reviewed_at"]);
+const FORMATS = new Set(["hwp5", "hwpx", "pdf"]);
+const MAGIC_BY_FORMAT = new Map([
+  ["hwp5", "hwp5-cfb"],
+  ["hwpx", "hwpx-owpml-zip"],
+  ["pdf", "pdf"],
+]);
+const EXTENSION_BY_FORMAT = new Map([["hwp5", ".hwp"], ["hwpx", ".hwpx"], ["pdf", ".pdf"]]);
+const LICENSE_SCOPES = new Set([
+  "statutory-public-domain",
+  "license-as-observed-private-evaluation",
+  "text-only-private-evaluation",
+]);
+const PRIVACY_CLASSES = new Set(["blank-form-template", "official-publication", "public-guidance"]);
+const SHA256 = /^[0-9a-f]{64}$/;
+const SLUG = /^[a-z0-9]+(?:[-_][a-z0-9]+)*$/;
+
+function exactKeys(value, keys, path, errors) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    errors.push(`${path}: object required`);
+    return false;
+  }
+  for (const key of Object.keys(value)) if (!keys.has(key)) errors.push(`${path}: unknown field ${key}`);
+  for (const key of keys) if (!(key in value)) errors.push(`${path}: missing field ${key}`);
+  return true;
+}
+
+function realDate(value) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(String(value ?? ""))) return false;
+  const [year, month, day] = value.split("-").map(Number);
+  const date = new Date(Date.UTC(year, month - 1, day));
+  return date.getUTCFullYear() === year && date.getUTCMonth() === month - 1 && date.getUTCDate() === day;
+}
+
+function realTimestamp(value) {
+  return typeof value === "string" && /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/.test(value) && !Number.isNaN(Date.parse(value));
+}
+
+function publicUrl(value, path, errors) {
+  try { return parsePublicHttpsUrl(value, path); }
+  catch (error) { errors.push(error.message); return null; }
+}
+
+export function validatePublicCorpusManifest(doc, { enforceMinimums = true } = {}) {
+  const errors = [];
+  if (!exactKeys(doc, ROOT_KEYS, "manifest", errors)) return errors;
+  if (doc.schema_version !== 1) errors.push("manifest.schema_version must be 1");
+  if (exactKeys(doc.policy, POLICY_KEYS, "manifest.policy", errors)) {
+    if (doc.policy.binary_storage !== "gitignored-private") errors.push("manifest.policy.binary_storage must be gitignored-private");
+    if (doc.policy.redistribution !== "metadata-only") errors.push("manifest.policy.redistribution must be metadata-only");
+    if (exactKeys(doc.policy.minimums, MINIMUM_KEYS, "manifest.policy.minimums", errors)) {
+      if (doc.policy.minimums.hwp5 !== 20 || doc.policy.minimums.hwpx !== 20 || doc.policy.minimums.official_pdf_pairs !== 10) {
+        errors.push("manifest.policy.minimums must be hwp5=20, hwpx=20, official_pdf_pairs=10");
+      }
+    }
+  }
+  if (!Array.isArray(doc.artifacts)) {
+    errors.push("manifest.artifacts must be an array");
+    return errors;
+  }
+
+  const ids = new Set();
+  const files = new Set();
+  const urls = new Set();
+  const hashes = new Set();
+  const pairs = new Map();
+  let previousId = "";
+  const counts = { hwp5: 0, hwpx: 0, pdf: 0 };
+
+  for (const [index, artifact] of doc.artifacts.entries()) {
+    const path = `manifest.artifacts[${index}]`;
+    if (!exactKeys(artifact, ARTIFACT_KEYS, path, errors)) continue;
+    if (typeof artifact.id !== "string" || !SLUG.test(artifact.id)) errors.push(`${path}.id: lowercase slug required`);
+    else {
+      if (artifact.id <= previousId) errors.push(`${path}.id: artifacts must be strictly sorted`);
+      previousId = artifact.id;
+      if (ids.has(artifact.id)) errors.push(`${path}.id: duplicate`);
+      ids.add(artifact.id);
+    }
+    if (!FORMATS.has(artifact.format)) errors.push(`${path}.format: hwp5, hwpx, or pdf required`);
+    else counts[artifact.format]++;
+    if (typeof artifact.file !== "string" || artifact.file !== `${artifact.id}${EXTENSION_BY_FORMAT.get(artifact.format) ?? ""}`) {
+      errors.push(`${path}.file: deterministic id plus format extension required`);
+    } else {
+      if (files.has(artifact.file.toLowerCase())) errors.push(`${path}.file: duplicate`);
+      files.add(artifact.file.toLowerCase());
+    }
+    if (![artifact.publisher, artifact.kind].every((value) => typeof value === "string" && value.trim())) errors.push(`${path}: publisher and kind required`);
+    publicUrl(artifact.source_page, `${path}.source_page`, errors);
+    publicUrl(artifact.source_url, `${path}.source_url`, errors);
+    if (urls.has(artifact.source_url)) errors.push(`${path}.source_url: duplicate`);
+    urls.add(artifact.source_url);
+    if (!Array.isArray(artifact.allowed_redirect_hosts)) errors.push(`${path}.allowed_redirect_hosts: array required`);
+    else {
+      const normalized = [];
+      for (const [hostIndex, host] of artifact.allowed_redirect_hosts.entries()) {
+        try { normalized.push(parseAllowedRedirectHostname(host, `${path}.allowed_redirect_hosts[${hostIndex}]`)); }
+        catch (error) { errors.push(error.message); }
+      }
+      if (new Set(normalized).size !== normalized.length || [...normalized].sort().join("\0") !== normalized.join("\0")) errors.push(`${path}.allowed_redirect_hosts: sorted unique hosts required`);
+    }
+    if (exactKeys(artifact.license, LICENSE_KEYS, `${path}.license`, errors)) {
+      if (typeof artifact.license.code !== "string" || !artifact.license.code.trim()) errors.push(`${path}.license.code required`);
+      publicUrl(artifact.license.evidence_url, `${path}.license.evidence_url`, errors);
+      if (!realDate(artifact.license.observed_at)) errors.push(`${path}.license.observed_at: real date required`);
+      if (!LICENSE_SCOPES.has(artifact.license.scope)) errors.push(`${path}.license.scope: approved private-evaluation scope required`);
+    }
+    if (!realTimestamp(artifact.retrieved_at)) errors.push(`${path}.retrieved_at: UTC RFC3339 timestamp required`);
+    if (!SHA256.test(String(artifact.sha256 ?? ""))) errors.push(`${path}.sha256: lowercase SHA-256 required`);
+    else {
+      if (hashes.has(artifact.sha256)) errors.push(`${path}.sha256: duplicate content`);
+      hashes.add(artifact.sha256);
+    }
+    if (artifact.detected_magic !== MAGIC_BY_FORMAT.get(artifact.format)) errors.push(`${path}.detected_magic: format mismatch`);
+    if (!Number.isSafeInteger(artifact.size_bytes) || artifact.size_bytes < 1 || artifact.size_bytes > 64 * 1024 * 1024) errors.push(`${path}.size_bytes: 1..67108864 required`);
+    if (!Array.isArray(artifact.feature_tags) || artifact.feature_tags.length < 1 || artifact.feature_tags.some((tag) => typeof tag !== "string" || !SLUG.test(tag)) || new Set(artifact.feature_tags).size !== artifact.feature_tags.length || [...artifact.feature_tags].sort().join("\0") !== artifact.feature_tags.join("\0")) errors.push(`${path}.feature_tags: sorted unique lowercase slugs required`);
+    if (artifact.pair_id !== null && (typeof artifact.pair_id !== "string" || !SLUG.test(artifact.pair_id))) errors.push(`${path}.pair_id: null or lowercase slug required`);
+    if (artifact.pair_id !== null) {
+      const members = pairs.get(artifact.pair_id) ?? [];
+      members.push(artifact);
+      pairs.set(artifact.pair_id, members);
+    }
+    if (exactKeys(artifact.privacy_review, PRIVACY_KEYS, `${path}.privacy_review`, errors)) {
+      if (!PRIVACY_CLASSES.has(artifact.privacy_review.classification)) errors.push(`${path}.privacy_review.classification: approved public class required`);
+      if (artifact.privacy_review.decision !== "include") errors.push(`${path}.privacy_review.decision must be include`);
+      if (!realDate(artifact.privacy_review.reviewed_at)) errors.push(`${path}.privacy_review.reviewed_at: real date required`);
+    }
+  }
+
+  let officialPdfPairs = 0;
+  for (const [pairId, members] of pairs) {
+    const formats = new Set(members.map((member) => member.format));
+    if (formats.has("pdf") && (formats.has("hwp5") || formats.has("hwpx"))) {
+      officialPdfPairs++;
+      if (new Set(members.map((member) => member.source_page)).size !== 1) errors.push(`pair ${pairId}: source_page must match`);
+    }
+  }
+  if (enforceMinimums && (counts.hwp5 < 20 || counts.hwpx < 20 || officialPdfPairs < 10)) {
+    errors.push(`manifest minimums unmet: hwp5=${counts.hwp5}, hwpx=${counts.hwpx}, official_pdf_pairs=${officialPdfPairs}`);
+  }
+  return errors;
+}
+
+export function loadPublicCorpusManifest(jsonText, options) {
+  const doc = JSON.parse(jsonText);
+  const errors = validatePublicCorpusManifest(doc, options);
+  if (errors.length) throw new Error(`public-corpus manifest invalid:\n- ${errors.join("\n- ")}`);
+  return doc;
+}
+
+export function summarizePublicCorpus(doc) {
+  const formats = { hwp5: 0, hwpx: 0, pdf: 0 };
+  const pairs = new Map();
+  for (const artifact of doc.artifacts) {
+    formats[artifact.format]++;
+    if (artifact.pair_id) {
+      const set = pairs.get(artifact.pair_id) ?? new Set();
+      set.add(artifact.format);
+      pairs.set(artifact.pair_id, set);
+    }
+  }
+  return { artifacts: doc.artifacts.length, formats, official_pdf_pairs: [...pairs.values()].filter((set) => set.has("pdf") && (set.has("hwp5") || set.has("hwpx"))).length };
+}

--- a/scripts/lib/public-network-boundary.mjs
+++ b/scripts/lib/public-network-boundary.mjs
@@ -1,0 +1,152 @@
+import { lookup } from "node:dns/promises";
+import { BlockList, isIP } from "node:net";
+
+const PUBLIC_IPV6 = new BlockList();
+PUBLIC_IPV6.addSubnet("2000::", 3, "ipv6");
+
+const RESERVED_IPV4 = new BlockList();
+for (const [address, prefix] of [
+  ["0.0.0.0", 8],
+  ["10.0.0.0", 8],
+  ["100.64.0.0", 10],
+  ["127.0.0.0", 8],
+  ["169.254.0.0", 16],
+  ["172.16.0.0", 12],
+  ["192.0.0.0", 24],
+  ["192.0.2.0", 24],
+  ["192.88.99.0", 24],
+  ["192.168.0.0", 16],
+  ["198.18.0.0", 15],
+  ["198.51.100.0", 24],
+  ["203.0.113.0", 24],
+  ["224.0.0.0", 4],
+  ["240.0.0.0", 4],
+]) {
+  RESERVED_IPV4.addSubnet(address, prefix, "ipv4");
+}
+const RESERVED_IPV6 = new BlockList();
+for (const [address, prefix] of [
+  ["2001::", 23], // IETF special-purpose space (Teredo/benchmarking/ORCHID/etc.)
+  ["2001:db8::", 32], // documentation
+  ["2002::", 16], // 6to4 can encode a non-public IPv4 destination
+  ["3fff::", 20], // documentation
+]) {
+  RESERVED_IPV6.addSubnet(address, prefix, "ipv6");
+}
+
+function fail(label, message) {
+  throw new Error(`${label}: ${message}`);
+}
+
+/**
+ * Return one canonical, public-looking DNS hostname. This is deliberately only the syntactic gate;
+ * assertPublicResolution() must also run immediately before each network hop.
+ */
+export function canonicalPublicHostname(value, label = "hostname") {
+  if (typeof value !== "string" || value !== value.trim() || !value) {
+    fail(label, "hostname string required");
+  }
+  const host = value.toLowerCase();
+  if (host.endsWith(".")) fail(label, "terminal-dot hostnames are not accepted");
+  if (host.length > 253 || !host.includes(".")) fail(label, "public DNS hostname required");
+  if (isIP(host) !== 0) fail(label, "IP literals are not accepted");
+  if (host === "localhost" || host.endsWith(".localhost") || host.endsWith(".local")) {
+    fail(label, "local hostname is not accepted");
+  }
+  const labels = host.split(".");
+  if (
+    labels.some(
+      (part) =>
+        part.length < 1 ||
+        part.length > 63 ||
+        !/^[a-z0-9-]+$/.test(part) ||
+        part.startsWith("-") ||
+        part.endsWith("-"),
+    )
+  ) {
+    fail(label, "canonical ASCII DNS hostname required");
+  }
+  return host;
+}
+
+/** Parse an HTTPS URL without credentials or a non-default port and canonicalize its hostname. */
+export function parsePublicHttpsUrl(value, label = "URL") {
+  let url;
+  try {
+    url = new URL(value);
+  } catch {
+    fail(label, "valid HTTPS URL required");
+  }
+  if (url.protocol !== "https:" || url.username || url.password) {
+    fail(label, "HTTPS without credentials required");
+  }
+  if (url.port) fail(label, "non-default HTTPS ports require a separate reviewed origin");
+  const hostname = canonicalPublicHostname(url.hostname, label);
+  // URL already performs IDNA and case canonicalization. Reassign to make the returned object explicit.
+  url.hostname = hostname;
+  return url;
+}
+
+/** Validate a manifest redirect-host value without accidentally accepting a URL, port, or path. */
+export function parseAllowedRedirectHostname(value, label = "redirect hostname") {
+  if (typeof value !== "string" || !/^[A-Za-z0-9.-]+$/.test(value)) {
+    fail(label, "hostname string required");
+  }
+  return canonicalPublicHostname(value, label);
+}
+
+export function isPublicIpAddress(address) {
+  const family = isIP(address);
+  if (family === 4) return !RESERVED_IPV4.check(address, "ipv4");
+  if (family === 6) {
+    return PUBLIC_IPV6.check(address, "ipv6") && !RESERVED_IPV6.check(address, "ipv6");
+  }
+  return false;
+}
+
+export async function defaultPublicResolver(hostname) {
+  return lookup(hostname, { all: true, verbatim: true });
+}
+
+/**
+ * Resolve and reject the whole hop if any answer is private, reserved, malformed, or empty. A caller
+ * may inject a resolver in tests. The production fetch follows immediately after this check.
+ */
+export async function assertPublicResolution(
+  urlOrHostname,
+  { resolver = defaultPublicResolver, label = "network hop", signal } = {},
+) {
+  const hostname =
+    urlOrHostname instanceof URL
+      ? canonicalPublicHostname(urlOrHostname.hostname, label)
+      : canonicalPublicHostname(String(urlOrHostname), label);
+  let answers;
+  let abortListener;
+  try {
+    if (signal?.aborted) fail(label, `DNS resolution aborted for ${hostname}`);
+    const resolution = Promise.resolve().then(() => resolver(hostname));
+    if (signal) {
+      const aborted = new Promise((_, reject) => {
+        abortListener = () => reject(new Error(`${label}: DNS resolution aborted for ${hostname}`));
+        signal.addEventListener("abort", abortListener, { once: true });
+      });
+      answers = await Promise.race([resolution, aborted]);
+    } else {
+      answers = await resolution;
+    }
+  } catch (error) {
+    if (String(error?.message ?? error).includes("DNS resolution aborted")) throw error;
+    throw new Error(`${label}: DNS resolution failed for ${hostname}: ${error?.message ?? error}`);
+  } finally {
+    if (abortListener) signal.removeEventListener("abort", abortListener);
+  }
+  const list = Array.isArray(answers) ? answers : [answers];
+  if (list.length === 0) fail(label, `DNS returned no addresses for ${hostname}`);
+  for (const answer of list) {
+    const address = typeof answer === "string" ? answer : answer?.address;
+    if (typeof address !== "string" || !isPublicIpAddress(address)) {
+      fail(label, `DNS returned non-public address ${String(address)} for ${hostname}`);
+    }
+  }
+  return list.map((answer) => (typeof answer === "string" ? answer : answer.address));
+}

--- a/scripts/lib/safe-document-download.mjs
+++ b/scripts/lib/safe-document-download.mjs
@@ -1,0 +1,210 @@
+import { request as httpsRequest } from "node:https";
+import { isIP } from "node:net";
+import { extname } from "node:path";
+import { Readable } from "node:stream";
+import {
+  assertPublicResolution,
+  parseAllowedRedirectHostname,
+  parsePublicHttpsUrl,
+} from "./public-network-boundary.mjs";
+import {
+  inspectStrictHwp5Cfb,
+  inspectStrictHwpxZip,
+} from "./strict-document-validation.mjs";
+
+export const DEFAULT_DOWNLOAD_LIMITS = Object.freeze({
+  maxBytes: 32 * 1024 * 1024,
+  maxRedirects: 4,
+  timeoutMs: 30_000,
+  maxZipEntries: 10_000,
+  maxZipUncompressedBytes: 256 * 1024 * 1024,
+  maxZipExpansionRatio: 500,
+});
+
+function inspectPdf(bytes) {
+  const header = bytes.subarray(0, 8).toString("ascii");
+  if (!/^%PDF-(?:1\.[0-7]|2\.0)/.test(header)) {
+    throw new Error("PDF: canonical header required");
+  }
+  const tail = bytes.subarray(Math.max(0, bytes.length - 4096)).toString("latin1");
+  if (!/%%EOF(?:\s|$)/.test(tail)) throw new Error("PDF: end-of-file marker required");
+  return { version: header.slice(5, 8) };
+}
+
+function normalizedAllowedHosts(sourceUrl, extraHosts = []) {
+  const source = parsePublicHttpsUrl(sourceUrl, "source_url");
+  const hosts = new Set([source.hostname]);
+  for (const [index, host] of extraHosts.entries()) {
+    hosts.add(parseAllowedRedirectHostname(host, `allowed_redirect_hosts[${index}]`));
+  }
+  return hosts;
+}
+
+function requireAllowedUrl(value, allowedHosts, label) {
+  const url = parsePublicHttpsUrl(value, label);
+  if (!allowedHosts.has(url.hostname)) {
+    throw new Error(`${label}: redirect host ${url.hostname} is not allowlisted`);
+  }
+  return url;
+}
+
+/** Inspect the complete HWPX package with bounded in-memory inflation. ZIP64 is rejected. */
+export function inspectHwpxZip(bytes, limits = DEFAULT_DOWNLOAD_LIMITS) {
+  const policy = { ...DEFAULT_DOWNLOAD_LIMITS, ...limits };
+  return inspectStrictHwpxZip(bytes, policy);
+}
+
+export const inspectHwp5Cfb = inspectStrictHwp5Cfb;
+
+export function validateDocumentBytes(bytes, file, limits = DEFAULT_DOWNLOAD_LIMITS) {
+  const policy = { ...DEFAULT_DOWNLOAD_LIMITS, ...limits };
+  if (!Buffer.isBuffer(bytes)) throw new TypeError("document bytes must be a Buffer");
+  if (bytes.length === 0 || bytes.length > policy.maxBytes) {
+    throw new Error(`document size ${bytes.length} exceeds policy`);
+  }
+  const extension = extname(file).toLowerCase();
+  if (extension === ".hwp") {
+    return { format: "hwp5", bytes: bytes.length, cfb: inspectHwp5Cfb(bytes) };
+  }
+  if (extension === ".hwpx") {
+    return { format: "hwpx", bytes: bytes.length, zip: inspectHwpxZip(bytes, policy) };
+  }
+  if (extension === ".pdf") {
+    return { format: "pdf", bytes: bytes.length, pdf: inspectPdf(bytes) };
+  }
+  throw new Error(`unsupported document extension: ${extension || "(none)"}`);
+}
+
+async function rejectResponse(response, message) {
+  try {
+    await response.body?.cancel();
+  } catch {
+    // Preserve the primary policy error instead of hiding it behind stream cleanup.
+  }
+  throw new Error(message);
+}
+
+/** HTTPS GET whose TCP lookup is pinned to the already-reviewed DNS answer while TLS keeps hostname SNI. */
+export async function pinnedHttpsGet(
+  url,
+  init,
+  addresses,
+  { requestImpl = httpsRequest } = {},
+) {
+  if (!Array.isArray(addresses) || addresses.length === 0) {
+    throw new Error(`source_url: no reviewed address available for ${url.hostname}`);
+  }
+  return new Promise((resolve, reject) => {
+    const attempt = (index) => {
+      const address = addresses[index];
+      const family = isIP(address);
+      let receivedResponse = false;
+      const request = requestImpl(
+        url,
+        {
+          method: "GET",
+          headers: init.headers,
+          signal: init.signal,
+          agent: false,
+          servername: url.hostname,
+          lookup(_hostname, options, callback) {
+            if (options?.all) callback(null, [{ address, family }]);
+            else callback(null, address, family);
+          },
+        },
+        (incoming) => {
+          receivedResponse = true;
+          const status = incoming.statusCode;
+          if (!status || status < 200 || status > 599) {
+            incoming.destroy();
+            reject(new Error(`invalid HTTP status ${String(status)}`));
+            return;
+          }
+          const headers = new Headers();
+          for (let header = 0; header < incoming.rawHeaders.length; header += 2) {
+            headers.append(incoming.rawHeaders[header], incoming.rawHeaders[header + 1]);
+          }
+          const noBody = status === 204 || status === 205 || status === 304;
+          resolve(
+            new Response(noBody ? null : Readable.toWeb(incoming), {
+              status,
+              statusText: incoming.statusMessage,
+              headers,
+            }),
+          );
+        },
+      );
+      request.once("error", (error) => {
+        if (receivedResponse) return;
+        if (!init.signal?.aborted && index + 1 < addresses.length) attempt(index + 1);
+        else reject(error);
+      });
+      request.end();
+    };
+    attempt(0);
+  });
+}
+
+/** Download one bounded document. Every redirect is allowlisted and DNS-checked before fetch. */
+export async function downloadDocument(
+  item,
+  {
+    fetchImpl,
+    resolver,
+    limits = DEFAULT_DOWNLOAD_LIMITS,
+    userAgent = "auto-hwp-public-corpus/1 (+https://github.com/kwakseongjae/auto-hwp/issues/100)",
+  } = {},
+) {
+  const policy = { ...DEFAULT_DOWNLOAD_LIMITS, ...limits };
+  const allowedHosts = normalizedAllowedHosts(item.source_url, item.allowed_redirect_hosts);
+  let current = requireAllowedUrl(item.source_url, allowedHosts, "source_url");
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), policy.timeoutMs);
+  try {
+    for (let redirects = 0; redirects <= policy.maxRedirects; redirects++) {
+      const reviewedAddresses = await assertPublicResolution(current, {
+        ...(resolver ? { resolver } : {}),
+        label: redirects === 0 ? "source_url" : `redirect[${redirects}]`,
+        signal: controller.signal,
+      });
+      const requestInit = {
+        redirect: "manual",
+        signal: controller.signal,
+        headers: { "User-Agent": userAgent, "Accept-Encoding": "identity" },
+      };
+      const response = fetchImpl
+        ? await fetchImpl(current, requestInit, { reviewedAddresses })
+        : await pinnedHttpsGet(current, requestInit, reviewedAddresses);
+      if (response.status >= 300 && response.status < 400) {
+        const location = response.headers.get("location");
+        if (!location) await rejectResponse(response, `HTTP ${response.status} without Location`);
+        if (redirects === policy.maxRedirects) {
+          await rejectResponse(response, "redirect limit exceeded");
+        }
+        await response.body?.cancel();
+        current = requireAllowedUrl(new URL(location, current).href, allowedHosts, "redirect");
+        continue;
+      }
+      if (!response.ok) await rejectResponse(response, `HTTP ${response.status}`);
+      const declared = Number(response.headers.get("content-length"));
+      if (Number.isFinite(declared) && declared > policy.maxBytes) {
+        await rejectResponse(response, `Content-Length ${declared} exceeds policy`);
+      }
+      if (!response.body) throw new Error("response body is missing");
+
+      const chunks = [];
+      let received = 0;
+      for await (const chunk of response.body) {
+        const part = Buffer.from(chunk);
+        received += part.length;
+        if (received > policy.maxBytes) throw new Error(`download exceeds ${policy.maxBytes} bytes`);
+        chunks.push(part);
+      }
+      const bytes = Buffer.concat(chunks, received);
+      return { bytes, finalUrl: current.href, envelope: validateDocumentBytes(bytes, item.file, policy) };
+    }
+    throw new Error("redirect loop");
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/scripts/lib/strict-document-validation.mjs
+++ b/scripts/lib/strict-document-validation.mjs
@@ -1,0 +1,514 @@
+import { TextDecoder } from "node:util";
+import { inflateRawSync } from "node:zlib";
+
+const HWP_CFB_MAGIC = Buffer.from([0xd0, 0xcf, 0x11, 0xe0, 0xa1, 0xb1, 0x1a, 0xe1]);
+const HWP_FILE_HEADER_SIGNATURE = Buffer.from("HWP Document File", "ascii");
+const HWPX_MIMETYPE = Buffer.from("application/hwp+zip", "ascii");
+const ZIP_LOCAL_MAGIC = 0x04034b50;
+const ZIP_CENTRAL_MAGIC = 0x02014b50;
+const ZIP_EOCD_MAGIC = 0x06054b50;
+const ZIP64_EXTRA_ID = 0x0001;
+const ZIP_ALLOWED_FLAGS = 0x0806; // deflate options and UTF-8 names; data descriptors are rejected
+const ZIP_ENCRYPTION_FLAGS = 0x2041;
+
+const CFB_FREE = 0xffffffff;
+const CFB_END = 0xfffffffe;
+const CFB_FAT = 0xfffffffd;
+const CFB_DIFAT = 0xfffffffc;
+const CFB_MAX_REGULAR = 0xfffffffa;
+
+const CRC32_TABLE = new Uint32Array(256);
+for (let value = 0; value < 256; value++) {
+  let crc = value;
+  for (let bit = 0; bit < 8; bit++) crc = (crc & 1) !== 0 ? 0xedb88320 ^ (crc >>> 1) : crc >>> 1;
+  CRC32_TABLE[value] = crc >>> 0;
+}
+function crc32(bytes) {
+  let crc = 0xffffffff;
+  for (const byte of bytes) crc = CRC32_TABLE[(crc ^ byte) & 0xff] ^ (crc >>> 8);
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function checkedRead(bytes, offset, length, label) {
+  if (!Number.isSafeInteger(offset) || offset < 0 || offset + length > bytes.length) {
+    throw new Error(`${label}: truncated structure`);
+  }
+}
+
+function findStrictEocd(bytes) {
+  const floor = Math.max(0, bytes.length - 65_557);
+  for (let offset = bytes.length - 22; offset >= floor; offset--) {
+    if (bytes.readUInt32LE(offset) !== ZIP_EOCD_MAGIC) continue;
+    const commentLength = bytes.readUInt16LE(offset + 20);
+    if (offset + 22 + commentLength === bytes.length) return offset;
+  }
+  throw new Error("HWPX ZIP: canonical end-of-central-directory not found");
+}
+
+function inspectZipExtra(extra, label) {
+  let offset = 0;
+  while (offset < extra.length) {
+    if (offset + 4 > extra.length) throw new Error(`${label}: malformed ZIP extra field`);
+    const id = extra.readUInt16LE(offset);
+    const size = extra.readUInt16LE(offset + 2);
+    offset += 4;
+    if (offset + size > extra.length) throw new Error(`${label}: malformed ZIP extra field`);
+    if (id === ZIP64_EXTRA_ID) throw new Error(`${label}: ZIP64 is not accepted by the corpus intake`);
+    offset += size;
+  }
+}
+
+function decodeZipName(raw, flags, index) {
+  if (raw.length === 0) throw new Error(`HWPX ZIP: empty entry name at ${index}`);
+  let name;
+  if ((flags & 0x0800) !== 0) {
+    try {
+      name = new TextDecoder("utf-8", { fatal: true }).decode(raw);
+    } catch {
+      throw new Error(`HWPX ZIP: invalid UTF-8 entry name at ${index}`);
+    }
+  } else {
+    if (raw.some((byte) => byte > 0x7f)) {
+      throw new Error(`HWPX ZIP: non-ASCII entry name lacks the UTF-8 flag at ${index}`);
+    }
+    name = raw.toString("ascii");
+  }
+  if (name !== name.normalize("NFC")) throw new Error(`HWPX ZIP: non-NFC entry name ${name}`);
+  if (name.includes("\0") || name.includes("\\") || name.startsWith("/") || /^[a-z]:/i.test(name)) {
+    throw new Error(`HWPX ZIP: unsafe entry path ${name}`);
+  }
+  const directory = name.endsWith("/");
+  const parts = name.split("/");
+  if (directory) parts.pop();
+  if (parts.length === 0 || parts.some((part) => !part || part === "." || part === "..")) {
+    throw new Error(`HWPX ZIP: unsafe entry path ${name}`);
+  }
+  return { name, directory };
+}
+
+/** Inspect a strict HWPX/OWPML ZIP without extracting untrusted content. */
+export function inspectStrictHwpxZip(bytes, policy) {
+  if (bytes.length < 22 || bytes.readUInt32LE(0) !== ZIP_LOCAL_MAGIC) {
+    throw new Error("HWPX: ZIP local-header magic required");
+  }
+  const eocd = findStrictEocd(bytes);
+  const disk = bytes.readUInt16LE(eocd + 4);
+  const centralDisk = bytes.readUInt16LE(eocd + 6);
+  const entriesOnDisk = bytes.readUInt16LE(eocd + 8);
+  const entries = bytes.readUInt16LE(eocd + 10);
+  const centralSize = bytes.readUInt32LE(eocd + 12);
+  const centralOffset = bytes.readUInt32LE(eocd + 16);
+  if (
+    disk !== 0 ||
+    centralDisk !== 0 ||
+    entriesOnDisk !== entries ||
+    entries === 0xffff ||
+    centralSize === 0xffffffff ||
+    centralOffset === 0xffffffff
+  ) {
+    throw new Error("HWPX ZIP: multi-disk/ZIP64 is not accepted by the corpus intake");
+  }
+  if (entries < 1 || entries > policy.maxZipEntries) {
+    throw new Error(`HWPX ZIP: entry count ${entries} exceeds policy`);
+  }
+  if (centralOffset + centralSize !== eocd || centralOffset >= bytes.length) {
+    throw new Error("HWPX ZIP: central directory bounds are invalid");
+  }
+
+  const names = new Map();
+  const caseFoldedNames = new Set();
+  const spans = [];
+  let offset = centralOffset;
+  let compressed = 0;
+  let uncompressed = 0;
+  for (let index = 0; index < entries; index++) {
+    if (offset + 46 > eocd || bytes.readUInt32LE(offset) !== ZIP_CENTRAL_MAGIC) {
+      throw new Error(`HWPX ZIP: invalid central entry ${index}`);
+    }
+    const madeBy = bytes.readUInt16LE(offset + 4);
+    const flags = bytes.readUInt16LE(offset + 8);
+    const method = bytes.readUInt16LE(offset + 10);
+    const crc = bytes.readUInt32LE(offset + 16);
+    const packed = bytes.readUInt32LE(offset + 20);
+    const unpacked = bytes.readUInt32LE(offset + 24);
+    const nameLength = bytes.readUInt16LE(offset + 28);
+    const extraLength = bytes.readUInt16LE(offset + 30);
+    const commentLength = bytes.readUInt16LE(offset + 32);
+    const startDisk = bytes.readUInt16LE(offset + 34);
+    const externalAttributes = bytes.readUInt32LE(offset + 38);
+    const localOffset = bytes.readUInt32LE(offset + 42);
+    const centralEnd = offset + 46 + nameLength + extraLength + commentLength;
+    if (centralEnd > centralOffset + centralSize) {
+      throw new Error(`HWPX ZIP: truncated central entry ${index}`);
+    }
+    if (
+      packed === 0xffffffff ||
+      unpacked === 0xffffffff ||
+      localOffset === 0xffffffff ||
+      startDisk !== 0
+    ) {
+      throw new Error("HWPX ZIP: ZIP64/multi-disk entry is not accepted by the corpus intake");
+    }
+    if ((flags & ZIP_ENCRYPTION_FLAGS) !== 0) {
+      throw new Error(`HWPX ZIP: encrypted entry is not accepted at ${index}`);
+    }
+    if ((flags & ~ZIP_ALLOWED_FLAGS) !== 0 || (method !== 0 && method !== 8)) {
+      throw new Error(`HWPX ZIP: unsupported flags/compression at entry ${index}`);
+    }
+    const rawName = bytes.subarray(offset + 46, offset + 46 + nameLength);
+    const { name, directory } = decodeZipName(rawName, flags, index);
+    const nameKey = name.toLowerCase();
+    if (caseFoldedNames.has(nameKey)) throw new Error(`HWPX ZIP: duplicate entry path ${name}`);
+    caseFoldedNames.add(nameKey);
+    const centralExtra = bytes.subarray(
+      offset + 46 + nameLength,
+      offset + 46 + nameLength + extraLength,
+    );
+    inspectZipExtra(centralExtra, `HWPX ZIP entry ${name}`);
+    const unixMode = madeBy >> 8 === 3 ? externalAttributes >>> 16 : 0;
+    if ((unixMode & 0o170000) === 0o120000) {
+      throw new Error(`HWPX ZIP: symbolic-link entry is not accepted: ${name}`);
+    }
+
+    checkedRead(bytes, localOffset, 30, `HWPX ZIP local entry ${name}`);
+    if (bytes.readUInt32LE(localOffset) !== ZIP_LOCAL_MAGIC) {
+      throw new Error(`HWPX ZIP: local header missing for ${name}`);
+    }
+    const localFlags = bytes.readUInt16LE(localOffset + 6);
+    const localMethod = bytes.readUInt16LE(localOffset + 8);
+    const localCrc = bytes.readUInt32LE(localOffset + 14);
+    const localPacked = bytes.readUInt32LE(localOffset + 18);
+    const localUnpacked = bytes.readUInt32LE(localOffset + 22);
+    const localNameLength = bytes.readUInt16LE(localOffset + 26);
+    const localExtraLength = bytes.readUInt16LE(localOffset + 28);
+    checkedRead(
+      bytes,
+      localOffset + 30,
+      localNameLength + localExtraLength,
+      `HWPX ZIP local entry ${name}`,
+    );
+    const localName = bytes.subarray(localOffset + 30, localOffset + 30 + localNameLength);
+    if (localFlags !== flags || localMethod !== method || !localName.equals(rawName)) {
+      throw new Error(`HWPX ZIP: local/central header mismatch for ${name}`);
+    }
+    const localExtra = bytes.subarray(
+      localOffset + 30 + localNameLength,
+      localOffset + 30 + localNameLength + localExtraLength,
+    );
+    inspectZipExtra(localExtra, `HWPX ZIP local entry ${name}`);
+    if (localCrc !== crc || localPacked !== packed || localUnpacked !== unpacked) {
+      throw new Error(`HWPX ZIP: local/central sizes mismatch for ${name}`);
+    }
+    const dataOffset = localOffset + 30 + localNameLength + localExtraLength;
+    const dataEnd = dataOffset + packed;
+    if (dataEnd > centralOffset) throw new Error(`HWPX ZIP: data bounds are invalid for ${name}`);
+    spans.push({ start: localOffset, end: dataEnd, name });
+
+    compressed += packed;
+    uncompressed += unpacked;
+    if (uncompressed > policy.maxZipUncompressedBytes) {
+      throw new Error(`HWPX ZIP: uncompressed size ${uncompressed} exceeds policy`);
+    }
+    const entryRatio = unpacked / Math.max(1, packed);
+    if (entryRatio > policy.maxZipExpansionRatio) {
+      throw new Error(`HWPX ZIP: entry expansion ratio exceeds policy for ${name}`);
+    }
+    const compressedPayload = bytes.subarray(dataOffset, dataEnd);
+    let payload;
+    if (method === 0) {
+      if (packed !== unpacked) throw new Error(`HWPX ZIP: stored entry size mismatch for ${name}`);
+      payload = compressedPayload;
+    } else {
+      try {
+        const inflated = inflateRawSync(compressedPayload, {
+          info: true,
+          maxOutputLength: Math.max(1, unpacked),
+        });
+        if (inflated.engine.bytesWritten !== packed) {
+          throw new Error("deflate stream has trailing or unconsumed input");
+        }
+        payload = inflated.buffer;
+      } catch (error) {
+        throw new Error(`HWPX ZIP: invalid/bounded deflate payload for ${name}: ${error?.message ?? error}`);
+      }
+      if (payload.length !== unpacked) {
+        throw new Error(`HWPX ZIP: inflated size mismatch for ${name}`);
+      }
+    }
+    if (crc32(payload) !== crc) throw new Error(`HWPX ZIP: CRC-32 mismatch for ${name}`);
+    names.set(name, { name, directory, method, packed, unpacked, dataOffset, localOffset });
+    offset = centralEnd;
+  }
+  if (offset !== centralOffset + centralSize) {
+    throw new Error("HWPX ZIP: central directory length mismatch");
+  }
+  spans.sort((a, b) => a.start - b.start);
+  for (let index = 1; index < spans.length; index++) {
+    if (spans[index - 1].end > spans[index].start) {
+      throw new Error(
+        `HWPX ZIP: overlapping local entries ${spans[index - 1].name} and ${spans[index].name}`,
+      );
+    }
+  }
+  if (uncompressed > policy.maxZipUncompressedBytes) {
+    throw new Error(`HWPX ZIP: uncompressed size ${uncompressed} exceeds policy`);
+  }
+  const ratio = uncompressed / Math.max(1, compressed);
+  if (ratio > policy.maxZipExpansionRatio) {
+    throw new Error(`HWPX ZIP: expansion ratio ${ratio.toFixed(1)} exceeds policy`);
+  }
+
+  const mimetype = names.get("mimetype");
+  if (!mimetype || mimetype.directory || mimetype.method !== 0 || mimetype.localOffset !== 0) {
+    throw new Error("HWPX: first uncompressed mimetype entry is required");
+  }
+  const mimetypeBytes = bytes.subarray(mimetype.dataOffset, mimetype.dataOffset + mimetype.packed);
+  if (!mimetypeBytes.equals(HWPX_MIMETYPE)) {
+    throw new Error("HWPX: mimetype must be application/hwp+zip");
+  }
+  for (const required of [
+    "version.xml",
+    "META-INF/container.xml",
+    "Contents/content.hpf",
+    "Contents/header.xml",
+  ]) {
+    if (!names.has(required) || names.get(required).directory) {
+      throw new Error(`HWPX: required OWPML entry missing: ${required}`);
+    }
+  }
+  if (![...names.keys()].some((name) => /^Contents\/section\d+\.xml$/.test(name))) {
+    throw new Error("HWPX: at least one Contents/sectionN.xml entry is required");
+  }
+  return {
+    entries,
+    compressedBytes: compressed,
+    uncompressedBytes: uncompressed,
+    expansionRatio: ratio,
+  };
+}
+
+function cfbSectorReader(bytes, sectorSize) {
+  if (bytes.length < sectorSize || bytes.length % sectorSize !== 0) {
+    throw new Error("HWP5 CFB: file length is not sector-aligned");
+  }
+  const sectorCount = bytes.length / sectorSize - 1;
+  const readSector = (sectorId, label) => {
+    if (!Number.isInteger(sectorId) || sectorId < 0 || sectorId >= sectorCount) {
+      throw new Error(`${label}: invalid sector ${sectorId}`);
+    }
+    const offset = (sectorId + 1) * sectorSize;
+    return bytes.subarray(offset, offset + sectorSize);
+  };
+  return { sectorCount, readSector };
+}
+
+function regularCfbSector(value) {
+  return Number.isInteger(value) && value >= 0 && value <= CFB_MAX_REGULAR;
+}
+
+function walkCfbChain(start, table, maximum, label) {
+  if (start === CFB_END) return [];
+  if (!regularCfbSector(start)) throw new Error(`${label}: invalid chain start`);
+  const seen = new Set();
+  const result = [];
+  let current = start;
+  while (current !== CFB_END) {
+    if (!regularCfbSector(current) || current >= table.length || current >= maximum) {
+      throw new Error(`${label}: invalid sector in chain`);
+    }
+    if (seen.has(current)) throw new Error(`${label}: sector chain cycle`);
+    seen.add(current);
+    result.push(current);
+    if (result.length > maximum) throw new Error(`${label}: sector chain exceeds file bounds`);
+    current = table[current];
+    if (current === CFB_FREE || current === CFB_FAT || current === CFB_DIFAT) {
+      throw new Error(`${label}: special sector inside stream chain`);
+    }
+  }
+  return result;
+}
+
+function readCfbStreamFromSectors(chain, readSector, size, sectorSize, label) {
+  if (!Number.isSafeInteger(size) || size < 0) throw new Error(`${label}: invalid stream size`);
+  const expected = Math.ceil(size / sectorSize);
+  if (chain.length !== expected) throw new Error(`${label}: stream chain length mismatch`);
+  if (size === 0) return Buffer.alloc(0);
+  return Buffer.concat(chain.map((sector) => readSector(sector, label)), chain.length * sectorSize).subarray(
+    0,
+    size,
+  );
+}
+
+function cfbDirectoryEntry(bytes, offset, majorVersion) {
+  const nameLength = bytes.readUInt16LE(offset + 64);
+  const type = bytes[offset + 66];
+  if (type === 0) return null;
+  if (nameLength < 2 || nameLength > 64 || nameLength % 2 !== 0) {
+    throw new Error("HWP5 CFB: invalid directory name length");
+  }
+  if (bytes.readUInt16LE(offset + nameLength - 2) !== 0) {
+    throw new Error("HWP5 CFB: directory name is not terminated");
+  }
+  const name = bytes.subarray(offset, offset + nameLength - 2).toString("utf16le");
+  const start = bytes.readUInt32LE(offset + 116);
+  const lowSize = bytes.readUInt32LE(offset + 120);
+  const highSize = majorVersion === 4 ? bytes.readUInt32LE(offset + 124) : 0;
+  const size = highSize * 0x1_0000_0000 + lowSize;
+  if (!Number.isSafeInteger(size)) throw new Error(`HWP5 CFB: stream ${name} is too large`);
+  return { name, type, start, size };
+}
+
+/** Verify a CFB container and read the HWP5 FileHeader stream through FAT/miniFAT. */
+export function inspectStrictHwp5Cfb(bytes) {
+  if (bytes.length < 512 || !bytes.subarray(0, 8).equals(HWP_CFB_MAGIC)) {
+    throw new Error("HWP5: full CFB magic mismatch (HTML/error page or wrong file)");
+  }
+  const majorVersion = bytes.readUInt16LE(26);
+  const byteOrder = bytes.readUInt16LE(28);
+  const sectorShift = bytes.readUInt16LE(30);
+  const miniSectorShift = bytes.readUInt16LE(32);
+  const sectorSize = 2 ** sectorShift;
+  const miniSectorSize = 2 ** miniSectorShift;
+  if (
+    (majorVersion !== 3 && majorVersion !== 4) ||
+    byteOrder !== 0xfffe ||
+    sectorShift !== (majorVersion === 3 ? 9 : 12) ||
+    miniSectorShift !== 6 ||
+    bytes.readUInt32LE(56) !== 4096
+  ) {
+    throw new Error("HWP5 CFB: unsupported or malformed compound-file header");
+  }
+  const { sectorCount, readSector } = cfbSectorReader(bytes, sectorSize);
+  const fatCount = bytes.readUInt32LE(44);
+  const firstDirectorySector = bytes.readUInt32LE(48);
+  const firstMiniFatSector = bytes.readUInt32LE(60);
+  const miniFatSectorCount = bytes.readUInt32LE(64);
+  let nextDifatSector = bytes.readUInt32LE(68);
+  const difatSectorCount = bytes.readUInt32LE(72);
+  if (fatCount < 1 || fatCount > sectorCount || difatSectorCount > sectorCount) {
+    throw new Error("HWP5 CFB: FAT/DIFAT count exceeds file bounds");
+  }
+
+  const fatSectors = [];
+  for (let offset = 76; offset < 512; offset += 4) {
+    const sector = bytes.readUInt32LE(offset);
+    if (sector !== CFB_FREE) fatSectors.push(sector);
+  }
+  const difatSectors = [];
+  const difatEntriesPerSector = sectorSize / 4 - 1;
+  for (let index = 0; index < difatSectorCount; index++) {
+    if (!regularCfbSector(nextDifatSector)) throw new Error("HWP5 CFB: invalid DIFAT chain");
+    if (difatSectors.includes(nextDifatSector)) throw new Error("HWP5 CFB: DIFAT cycle");
+    difatSectors.push(nextDifatSector);
+    const sector = readSector(nextDifatSector, "HWP5 CFB DIFAT");
+    for (let entry = 0; entry < difatEntriesPerSector; entry++) {
+      const fatSector = sector.readUInt32LE(entry * 4);
+      if (fatSector !== CFB_FREE) fatSectors.push(fatSector);
+    }
+    nextDifatSector = sector.readUInt32LE(sectorSize - 4);
+  }
+  if (nextDifatSector !== CFB_END) throw new Error("HWP5 CFB: DIFAT chain does not terminate");
+  if (fatSectors.length !== fatCount || new Set(fatSectors).size !== fatSectors.length) {
+    throw new Error("HWP5 CFB: FAT sector count/uniqueness mismatch");
+  }
+  if (fatSectors.some((sector) => !regularCfbSector(sector) || sector >= sectorCount)) {
+    throw new Error("HWP5 CFB: invalid FAT sector");
+  }
+  const fat = [];
+  for (const sectorId of fatSectors) {
+    const sector = readSector(sectorId, "HWP5 CFB FAT");
+    for (let offset = 0; offset < sectorSize; offset += 4) fat.push(sector.readUInt32LE(offset));
+  }
+  for (const sector of fatSectors) {
+    if (fat[sector] !== CFB_FAT) throw new Error("HWP5 CFB: FAT sector marker mismatch");
+  }
+  for (const sector of difatSectors) {
+    if (fat[sector] !== CFB_DIFAT) throw new Error("HWP5 CFB: DIFAT sector marker mismatch");
+  }
+
+  const directoryChain = walkCfbChain(
+    firstDirectorySector,
+    fat,
+    sectorCount,
+    "HWP5 CFB directory",
+  );
+  if (directoryChain.length === 0) throw new Error("HWP5 CFB: directory stream is missing");
+  const directory = Buffer.concat(
+    directoryChain.map((sector) => readSector(sector, "HWP5 CFB directory")),
+    directoryChain.length * sectorSize,
+  );
+  const entries = [];
+  for (let offset = 0; offset + 128 <= directory.length; offset += 128) {
+    const entry = cfbDirectoryEntry(directory, offset, majorVersion);
+    if (entry) entries.push(entry);
+  }
+  const roots = entries.filter((entry) => entry.type === 5 && entry.name === "Root Entry");
+  const fileHeaders = entries.filter((entry) => entry.type === 2 && entry.name === "FileHeader");
+  if (roots.length !== 1 || fileHeaders.length !== 1) {
+    throw new Error("HWP5 CFB: one Root Entry and one FileHeader stream are required");
+  }
+  const root = roots[0];
+  const fileHeader = fileHeaders[0];
+  if (fileHeader.size !== 256) throw new Error("HWP5 CFB: FileHeader stream must be 256 bytes");
+  const readRegularStream = (entry, label) => {
+    const chain = walkCfbChain(entry.start, fat, sectorCount, label);
+    return readCfbStreamFromSectors(chain, readSector, entry.size, sectorSize, label);
+  };
+
+  let fileHeaderBytes;
+  if (fileHeader.size < 4096) {
+    if (miniFatSectorCount < 1 || miniFatSectorCount > sectorCount) {
+      throw new Error("HWP5 CFB: miniFAT is required for FileHeader");
+    }
+    const miniFatChain = walkCfbChain(
+      firstMiniFatSector,
+      fat,
+      sectorCount,
+      "HWP5 CFB miniFAT",
+    );
+    if (miniFatChain.length !== miniFatSectorCount) {
+      throw new Error("HWP5 CFB: miniFAT chain length mismatch");
+    }
+    const miniFatBytes = Buffer.concat(
+      miniFatChain.map((sector) => readSector(sector, "HWP5 CFB miniFAT")),
+      miniFatChain.length * sectorSize,
+    );
+    const miniFat = [];
+    for (let offset = 0; offset < miniFatBytes.length; offset += 4) {
+      miniFat.push(miniFatBytes.readUInt32LE(offset));
+    }
+    const rootMiniStream = readRegularStream(root, "HWP5 CFB root mini stream");
+    const miniChain = walkCfbChain(
+      fileHeader.start,
+      miniFat,
+      Math.ceil(rootMiniStream.length / miniSectorSize),
+      "HWP5 CFB FileHeader mini stream",
+    );
+    const expectedMiniSectors = Math.ceil(fileHeader.size / miniSectorSize);
+    if (miniChain.length !== expectedMiniSectors) {
+      throw new Error("HWP5 CFB: FileHeader mini stream length mismatch");
+    }
+    const parts = miniChain.map((sector) => {
+      const offset = sector * miniSectorSize;
+      if (offset + miniSectorSize > rootMiniStream.length) {
+        throw new Error("HWP5 CFB: FileHeader mini sector exceeds root stream");
+      }
+      return rootMiniStream.subarray(offset, offset + miniSectorSize);
+    });
+    fileHeaderBytes = Buffer.concat(parts, parts.length * miniSectorSize).subarray(
+      0,
+      fileHeader.size,
+    );
+  } else {
+    fileHeaderBytes = readRegularStream(fileHeader, "HWP5 CFB FileHeader");
+  }
+  if (
+    fileHeaderBytes.length < 32 ||
+    !fileHeaderBytes.subarray(0, HWP_FILE_HEADER_SIGNATURE.length).equals(HWP_FILE_HEADER_SIGNATURE) ||
+    fileHeaderBytes.subarray(HWP_FILE_HEADER_SIGNATURE.length, 32).some((byte) => byte !== 0)
+  ) {
+    throw new Error("HWP5 CFB: FileHeader stream signature mismatch");
+  }
+  if (fileHeaderBytes[35] !== 5) throw new Error("HWP5 CFB: FileHeader does not declare HWP major 5");
+  return { sectors: sectorCount, fileHeaderBytes: fileHeaderBytes.length };
+}

--- a/scripts/public-corpus-intake.mjs
+++ b/scripts/public-corpus-intake.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { admitExistingDocument, publishBytesNoReplace } from "./fetch-gov-corpus.mjs";
+import { downloadDocument, validateDocumentBytes } from "./lib/safe-document-download.mjs";
+import { loadPublicCorpusManifest, summarizePublicCorpus } from "./lib/public-corpus-manifest.mjs";
+
+const repo = join(dirname(fileURLToPath(import.meta.url)), "..");
+const manifestPath = join(repo, "corpus", "public-corpus-manifest.json");
+const outputPath = join(repo, "corpus", "private", "public-intake", "files");
+
+function sha256(bytes) { return createHash("sha256").update(bytes).digest("hex"); }
+function magicFor(envelope) { return envelope.format === "hwp5" ? "hwp5-cfb" : envelope.format === "hwpx" ? "hwpx-owpml-zip" : "pdf"; }
+
+export function verifyArtifactBytes(bytes, artifact) {
+  const envelope = validateDocumentBytes(bytes, artifact.file);
+  if (sha256(bytes) !== artifact.sha256) throw new Error("hash-change");
+  if (bytes.length !== artifact.size_bytes) throw new Error("size-change");
+  if (magicFor(envelope) !== artifact.detected_magic) throw new Error("magic-change");
+  return envelope;
+}
+
+export async function collectPublicCorpus({
+  manifest = manifestPath,
+  output = outputPath,
+  downloader = downloadDocument,
+  logger = console,
+} = {}) {
+  const doc = loadPublicCorpusManifest(readFileSync(manifest, "utf8"));
+  const outputRoot = resolve(output);
+  mkdirSync(outputRoot, { recursive: true });
+  const counts = { ok: 0, skip: 0, fail: 0 };
+  for (const artifact of doc.artifacts) {
+    const destination = resolve(outputRoot, artifact.file);
+    if (dirname(destination) !== outputRoot) throw new Error("destination-policy");
+    try {
+      if (existsSync(destination)) {
+        const admitted = admitExistingDocument(destination, artifact);
+        verifyArtifactBytes(admitted.bytes, artifact);
+        counts.skip++;
+        logger.log(`ok ${artifact.id} cached`);
+        continue;
+      }
+      const result = await downloader({
+        file: artifact.file,
+        source_url: artifact.source_url,
+        allowed_redirect_hosts: artifact.allowed_redirect_hosts,
+      });
+      verifyArtifactBytes(result.bytes, artifact);
+      publishBytesNoReplace(result.bytes, destination);
+      counts.ok++;
+      logger.log(`ok ${artifact.id} fetched`);
+    } catch {
+      counts.fail++;
+      logger.log(`fail ${artifact.id} policy-check`);
+    }
+  }
+  return counts;
+}
+
+const invoked = process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (invoked) {
+  const doc = loadPublicCorpusManifest(readFileSync(manifestPath, "utf8"));
+  if (process.argv.includes("--check")) {
+    const summary = summarizePublicCorpus(doc);
+    console.log(`public-corpus --check: ok (${summary.formats.hwp5} HWP5, ${summary.formats.hwpx} HWPX, ${summary.official_pdf_pairs} PDF pairs)`);
+  } else {
+    const counts = await collectPublicCorpus();
+    console.log(`public-corpus: ${counts.ok} fetched, ${counts.skip} cached, ${counts.fail} failed`);
+    if (counts.fail) process.exitCode = 1;
+  }
+}

--- a/scripts/tests/public-corpus-manifest.test.mjs
+++ b/scripts/tests/public-corpus-manifest.test.mjs
@@ -20,6 +20,9 @@ test("manifest rejects downgraded rights, privacy, hashes, ordering, and unknown
     (doc) => { doc.artifacts[0].license.scope = "unknown"; },
     (doc) => { doc.artifacts[0].privacy_review.decision = "quarantine"; },
     (doc) => { doc.artifacts[0].sha256 = "A".repeat(64); },
+    (doc) => { doc.artifacts[0].retrieved_at = "2026-02-31T00:00:00.000Z"; },
+    (doc) => { doc.artifacts[0].source_url = "https://attacker.example/download"; },
+    (doc) => { doc.artifacts[0].allowed_redirect_hosts = ["attacker.example"]; },
     (doc) => { doc.artifacts.reverse(); },
     (doc) => { doc.artifacts[0].local_path = "/private/example"; },
   ]) {

--- a/scripts/tests/public-corpus-manifest.test.mjs
+++ b/scripts/tests/public-corpus-manifest.test.mjs
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { loadPublicCorpusManifest, summarizePublicCorpus, validatePublicCorpusManifest } from "../lib/public-corpus-manifest.mjs";
+import { verifyArtifactBytes } from "../public-corpus-intake.mjs";
+
+const repo = join(dirname(fileURLToPath(import.meta.url)), "../..");
+const manifestText = readFileSync(join(repo, "corpus/public-corpus-manifest.json"), "utf8");
+
+test("committed intake manifest has 20 HWP5, 20 HWPX, and 10 official PDF pairs", () => {
+  const doc = loadPublicCorpusManifest(manifestText);
+  assert.deepEqual(summarizePublicCorpus(doc), { artifacts: 50, formats: { hwp5: 20, hwpx: 20, pdf: 10 }, official_pdf_pairs: 10 });
+});
+
+test("manifest rejects downgraded rights, privacy, hashes, ordering, and unknown fields", () => {
+  const base = JSON.parse(manifestText);
+  for (const mutate of [
+    (doc) => { doc.artifacts[0].license.scope = "unknown"; },
+    (doc) => { doc.artifacts[0].privacy_review.decision = "quarantine"; },
+    (doc) => { doc.artifacts[0].sha256 = "A".repeat(64); },
+    (doc) => { doc.artifacts.reverse(); },
+    (doc) => { doc.artifacts[0].local_path = "/private/example"; },
+  ]) {
+    const doc = structuredClone(base);
+    mutate(doc);
+    assert.notEqual(validatePublicCorpusManifest(doc).length, 0);
+  }
+});
+
+test("manifest rejects missing format floors and broken PDF pairing", () => {
+  const doc = JSON.parse(manifestText);
+  doc.artifacts = doc.artifacts.filter((artifact) => artifact.format !== "pdf");
+  assert.match(validatePublicCorpusManifest(doc).join("\n"), /minimums unmet/);
+});
+
+test("byte verification fails closed on hash, size, and format changes", () => {
+  const bytes = readFileSync(join(repo, "corpus/hwpx/00_smoke_min.hwpx"));
+  const artifact = {
+    file: "fixture.hwpx",
+    sha256: "0".repeat(64),
+    size_bytes: bytes.length,
+    detected_magic: "hwpx-owpml-zip",
+  };
+  assert.throws(() => verifyArtifactBytes(bytes, artifact), /hash-change/);
+});

--- a/scripts/tests/safe-document-download.test.mjs
+++ b/scripts/tests/safe-document-download.test.mjs
@@ -1,0 +1,341 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { Readable } from "node:stream";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  DEFAULT_DOWNLOAD_LIMITS,
+  downloadDocument,
+  inspectHwpxZip,
+  pinnedHttpsGet,
+  validateDocumentBytes,
+} from "../lib/safe-document-download.mjs";
+import {
+  isPublicIpAddress,
+  parsePublicHttpsUrl,
+} from "../lib/public-network-boundary.mjs";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const hwpx = readFileSync(join(root, "corpus/hwpx/00_smoke_min.hwpx"));
+const hwp = readFileSync(join(root, "corpus/hwp/test-image.hwp"));
+const xlsx = readFileSync(join(root, "testdata/roster/ok.xlsx"));
+const publicResolver = async () => [{ address: "93.184.216.34", family: 4 }];
+
+function firstDeflatedEntry(bytes) {
+  let central = bytes.indexOf(Buffer.from([0x50, 0x4b, 0x01, 0x02]));
+  while (central >= 0 && bytes.readUInt32LE(central) === 0x02014b50) {
+    const nameLength = bytes.readUInt16LE(central + 28);
+    const extraLength = bytes.readUInt16LE(central + 30);
+    const commentLength = bytes.readUInt16LE(central + 32);
+    if (bytes.readUInt16LE(central + 10) === 8) {
+      const local = bytes.readUInt32LE(central + 42);
+      const localNameLength = bytes.readUInt16LE(local + 26);
+      const localExtraLength = bytes.readUInt16LE(local + 28);
+      return {
+        central,
+        local,
+        data: local + 30 + localNameLength + localExtraLength,
+        packed: bytes.readUInt32LE(central + 20),
+      };
+    }
+    central += 46 + nameLength + extraLength + commentLength;
+  }
+  throw new Error("test fixture has no deflated entry");
+}
+
+test("network boundary classifies public and reserved IPv4/IPv6 conservatively", () => {
+  assert.equal(isPublicIpAddress("93.184.216.34"), true);
+  assert.equal(isPublicIpAddress("2606:2800:220:1:248:1893:25c8:1946"), true);
+  for (const address of [
+    "0.0.0.0",
+    "10.1.2.3",
+    "100.64.0.1",
+    "127.0.0.1",
+    "169.254.1.2",
+    "172.16.0.1",
+    "192.168.0.1",
+    "198.51.100.3",
+    "203.0.113.4",
+    "::1",
+    "fc00::1",
+    "fe80::1",
+    "2001:db8::1",
+    "::ffff:127.0.0.1",
+  ]) {
+    assert.equal(isPublicIpAddress(address), false, address);
+  }
+  assert.throws(() => parsePublicHttpsUrl("https://localhost./x"), /terminal-dot/);
+  assert.throws(() => parsePublicHttpsUrl("https://example.test:8443/x"), /non-default/);
+});
+
+test("full HWP5 magic and bounded HWPX central directory are accepted", () => {
+  const hwpResult = validateDocumentBytes(hwp, "sample.hwp");
+  assert.equal(hwpResult.format, "hwp5");
+  assert.equal(hwpResult.bytes, hwp.length);
+  assert.equal(hwpResult.cfb.fileHeaderBytes, 256);
+  const result = validateDocumentBytes(hwpx, "sample.hwpx");
+  assert.equal(result.format, "hwpx");
+  assert.ok(result.zip.entries > 0);
+  assert.ok(result.zip.uncompressedBytes >= result.zip.compressedBytes);
+});
+
+test("renamed office ZIPs and fabricated HWP/HWPX envelopes fail semantic container checks", () => {
+  assert.throws(() => validateDocumentBytes(xlsx, "renamed.hwpx"), /mimetype/);
+  assert.throws(
+    () =>
+      validateDocumentBytes(
+        Buffer.from([0xd0, 0xcf, 0x11, 0xe0, 0xa1, 0xb1, 0x1a, 0xe1]),
+        "fabricated.hwp",
+      ),
+    /CFB magic mismatch/,
+  );
+
+  const fakeZip = Buffer.alloc(72);
+  fakeZip.writeUInt32LE(0x04034b50, 0);
+  fakeZip.writeUInt32LE(0x02014b50, 4);
+  fakeZip.writeUInt32LE(0x06054b50, 50);
+  fakeZip.writeUInt16LE(1, 58);
+  fakeZip.writeUInt16LE(1, 60);
+  fakeZip.writeUInt32LE(46, 62);
+  fakeZip.writeUInt32LE(4, 66);
+  assert.throws(() => validateDocumentBytes(fakeZip, "fabricated.hwpx"), /empty entry name/);
+
+  const wrongFileHeader = Buffer.from(hwp);
+  const signature = wrongFileHeader.indexOf(Buffer.from("HWP Document File", "ascii"));
+  assert.ok(signature >= 0);
+  wrongFileHeader[signature] ^= 0xff;
+  assert.throws(() => validateDocumentBytes(wrongFileHeader, "wrong-header.hwp"), /signature mismatch/);
+});
+
+test("extension/magic swaps and HTML error pages fail before write", () => {
+  assert.throws(() => validateDocumentBytes(hwpx, "sample.hwp"), /full CFB magic mismatch/);
+  assert.throws(() => validateDocumentBytes(hwp, "sample.hwpx"), /ZIP local-header magic/);
+  assert.throws(
+    () => validateDocumentBytes(Buffer.from("<!doctype html>error"), "sample.hwpx"),
+    /ZIP local-header magic/,
+  );
+});
+
+test("PDF intake requires a real header and trailing EOF marker", () => {
+  const pdf = Buffer.from("%PDF-1.7\n1 0 obj\n<<>>\nendobj\nstartxref\n0\n%%EOF\n");
+  assert.deepEqual(validateDocumentBytes(pdf, "reference.pdf").pdf, { version: "1.7" });
+  assert.throws(() => validateDocumentBytes(Buffer.from("%PDF-1.7\nno eof"), "bad.pdf"), /end-of-file/);
+  assert.throws(() => validateDocumentBytes(Buffer.from("%PDF-9.9\n%%EOF"), "bad.pdf"), /header/);
+});
+
+test("ZIP64/bomb-shaped metadata is rejected without extraction", () => {
+  const poisoned = Buffer.from(hwpx);
+  const central = poisoned.indexOf(Buffer.from([0x50, 0x4b, 0x01, 0x02]));
+  assert.ok(central >= 0);
+  poisoned.writeUInt32LE(0xffffffff, central + 24);
+  assert.throws(() => inspectHwpxZip(poisoned), /ZIP64/);
+
+  assert.throws(
+    () =>
+      inspectHwpxZip(hwpx, {
+        ...DEFAULT_DOWNLOAD_LIMITS,
+        maxZipUncompressedBytes: 1,
+      }),
+    /uncompressed size/,
+  );
+});
+
+test("HWPX entry paths, encryption and local/central compression structure fail closed", () => {
+  const central = hwpx.indexOf(Buffer.from([0x50, 0x4b, 0x01, 0x02]));
+  assert.ok(central >= 0);
+  const local = hwpx.readUInt32LE(central + 42);
+
+  const unsafePath = Buffer.from(hwpx);
+  unsafePath.write("../x.xml", central + 46, "ascii");
+  unsafePath.write("../x.xml", local + 30, "ascii");
+  assert.throws(() => inspectHwpxZip(unsafePath), /unsafe entry path/);
+
+  const encrypted = Buffer.from(hwpx);
+  encrypted.writeUInt16LE(encrypted.readUInt16LE(central + 8) | 1, central + 8);
+  encrypted.writeUInt16LE(encrypted.readUInt16LE(local + 6) | 1, local + 6);
+  assert.throws(() => inspectHwpxZip(encrypted), /encrypted entry/);
+
+  const mismatched = Buffer.from(hwpx);
+  mismatched.writeUInt16LE(8, local + 8);
+  assert.throws(() => inspectHwpxZip(mismatched), /local\/central header mismatch/);
+
+  const unsupported = Buffer.from(hwpx);
+  unsupported.writeUInt16LE(99, central + 10);
+  unsupported.writeUInt16LE(99, local + 8);
+  assert.throws(() => inspectHwpxZip(unsupported), /unsupported flags\/compression/);
+});
+
+test("HWPX validates actual inflate size and CRC instead of trusting declared ZIP metadata", () => {
+  const { central, local, data, packed } = firstDeflatedEntry(hwpx);
+  const missingDescriptor = Buffer.from(hwpx);
+  missingDescriptor.writeUInt16LE(missingDescriptor.readUInt16LE(central + 8) | 8, central + 8);
+  missingDescriptor.writeUInt16LE(missingDescriptor.readUInt16LE(local + 6) | 8, local + 6);
+  missingDescriptor.writeUInt32LE(0, local + 14);
+  missingDescriptor.writeUInt32LE(0, local + 18);
+  missingDescriptor.writeUInt32LE(0, local + 22);
+  assert.throws(() => inspectHwpxZip(missingDescriptor), /unsupported flags\/compression/);
+
+  const liedAboutSize = Buffer.from(hwpx);
+  liedAboutSize.writeUInt32LE(1, central + 24);
+  liedAboutSize.writeUInt32LE(1, local + 22);
+  assert.throws(() => inspectHwpxZip(liedAboutSize), /invalid\/bounded deflate|inflated size/);
+
+  const corruptPayload = Buffer.from(hwpx);
+  corruptPayload[data + Math.floor(packed / 2)] ^= 0x40;
+  assert.throws(() => inspectHwpxZip(corruptPayload), /invalid\/bounded deflate|CRC-32 mismatch/);
+});
+
+test("downloadDocument enforces host allowlist and byte cap across redirects", async () => {
+  const item = {
+    file: "sample.hwpx",
+    source_url: "https://files.example.test/sample.hwpx",
+    allowed_redirect_hosts: ["cdn.example.test"],
+  };
+  const calls = [];
+  const reviewed = [];
+  const goodFetch = async (url, _init, context) => {
+    calls.push(String(url));
+    reviewed.push(context.reviewedAddresses);
+    if (String(url).includes("files.example.test")) {
+      return new Response(null, {
+        status: 302,
+        headers: { location: "https://cdn.example.test/final.hwpx" },
+      });
+    }
+    return new Response(hwpx, { status: 200, headers: { "content-length": String(hwpx.length) } });
+  };
+  const result = await downloadDocument(item, {
+    fetchImpl: goodFetch,
+    resolver: publicResolver,
+    userAgent: "test",
+  });
+  assert.equal(result.finalUrl, "https://cdn.example.test/final.hwpx");
+  assert.equal(result.envelope.format, "hwpx");
+  assert.equal(calls.length, 2);
+  assert.deepEqual(reviewed, [["93.184.216.34"], ["93.184.216.34"]]);
+
+  const evilFetch = async () =>
+    new Response(null, { status: 302, headers: { location: "https://evil.example/final.hwpx" } });
+  await assert.rejects(
+    downloadDocument(item, { fetchImpl: evilFetch, resolver: publicResolver, userAgent: "test" }),
+    /redirect host evil\.example is not allowlisted/,
+  );
+
+  const oversized = {
+    ...DEFAULT_DOWNLOAD_LIMITS,
+    maxBytes: hwpx.length - 1,
+  };
+  await assert.rejects(
+    downloadDocument(item, {
+      fetchImpl: async () =>
+        new Response(hwpx, { status: 200, headers: { "content-length": String(hwpx.length) } }),
+      resolver: publicResolver,
+      limits: oversized,
+      userAgent: "test",
+    }),
+    /Content-Length .* exceeds policy/,
+  );
+});
+
+test("default HTTPS transport pins lookup to the reviewed address while preserving TLS hostname", async () => {
+  let requestUrl;
+  let requestOptions;
+  const lookupResults = [];
+  const requestImpl = (url, options, callback) => {
+    requestUrl = url;
+    requestOptions = options;
+    options.lookup("ignored.example", { all: false }, (...args) => lookupResults.push(args));
+    options.lookup("ignored.example", { all: true }, (...args) => lookupResults.push(args));
+    const request = new EventEmitter();
+    request.end = () => {
+      const incoming = Readable.from([hwpx]);
+      incoming.statusCode = 200;
+      incoming.statusMessage = "OK";
+      incoming.rawHeaders = ["Content-Length", String(hwpx.length)];
+      callback(incoming);
+    };
+    return request;
+  };
+  const response = await pinnedHttpsGet(
+    new URL("https://files.example.test/sample.hwpx"),
+    { headers: { "User-Agent": "test" } },
+    ["93.184.216.34"],
+    { requestImpl },
+  );
+  assert.equal(String(requestUrl), "https://files.example.test/sample.hwpx");
+  assert.equal(requestOptions.servername, "files.example.test");
+  assert.equal(requestOptions.agent, false);
+  assert.deepEqual(lookupResults, [
+    [null, "93.184.216.34", 4],
+    [null, [{ address: "93.184.216.34", family: 4 }]],
+  ]);
+  assert.deepEqual(Buffer.from(await response.arrayBuffer()), hwpx);
+});
+
+test("downloadDocument rejects terminal-dot and private DNS answers before the affected fetch", async () => {
+  let calls = 0;
+  const fetchImpl = async () => {
+    calls++;
+    return new Response(hwpx, { status: 200 });
+  };
+  await assert.rejects(
+    downloadDocument(
+      { file: "sample.hwpx", source_url: "https://localhost./sample.hwpx" },
+      { fetchImpl, resolver: publicResolver, userAgent: "test" },
+    ),
+    /terminal-dot/,
+  );
+  assert.equal(calls, 0);
+
+  await assert.rejects(
+    downloadDocument(
+      { file: "sample.hwpx", source_url: "https://files.example.test/sample.hwpx" },
+      { fetchImpl, resolver: async () => [{ address: "127.0.0.1", family: 4 }], userAgent: "test" },
+    ),
+    /non-public address 127\.0\.0\.1/,
+  );
+  assert.equal(calls, 0);
+
+  const redirecting = async () => {
+    calls++;
+    return new Response(null, {
+      status: 302,
+      headers: { location: "https://cdn.example.test/final.hwpx" },
+    });
+  };
+  await assert.rejects(
+    downloadDocument(
+      {
+        file: "sample.hwpx",
+        source_url: "https://files.example.test/sample.hwpx",
+        allowed_redirect_hosts: ["cdn.example.test"],
+      },
+      {
+        fetchImpl: redirecting,
+        resolver: async (host) => [
+          { address: host === "cdn.example.test" ? "10.0.0.4" : "93.184.216.34", family: 4 },
+        ],
+        userAgent: "test",
+      },
+    ),
+    /non-public address 10\.0\.0\.4/,
+  );
+  assert.equal(calls, 1, "redirect target DNS must fail before a second fetch");
+});
+
+test("the total download timeout also bounds DNS resolution", async () => {
+  await assert.rejects(
+    downloadDocument(
+      { file: "sample.hwpx", source_url: "https://files.example.test/sample.hwpx" },
+      {
+        fetchImpl: async () => new Response(hwpx),
+        resolver: async () => new Promise(() => {}),
+        limits: { ...DEFAULT_DOWNLOAD_LIMITS, timeoutMs: 20 },
+        userAgent: "test",
+      },
+    ),
+    /DNS resolution aborted/,
+  );
+});

--- a/scripts/verify-local.sh
+++ b/scripts/verify-local.sh
@@ -41,12 +41,15 @@ else
   echo "⚠️  modu-startup 게이트 skipped(corpus/private 부재 — 로컬 전용 실물 벤치, 공개 커밋 금지)"
 fi
 
-echo "═══ 공공문서 후보 카탈로그 계약 (이슈 99 — metadata-only · 다운로드 없음) ═══"
+echo "═══ 공공문서 후보·승격 코퍼스 계약 (이슈 99·100 — CI 다운로드 없음) ═══"
 node --test \
   scripts/tests/gov-sources.test.mjs \
   scripts/tests/fetch-gov-corpus.test.mjs \
-  scripts/tests/gov-source-catalog.test.mjs
+  scripts/tests/gov-source-catalog.test.mjs \
+  scripts/tests/public-corpus-manifest.test.mjs \
+  scripts/tests/safe-document-download.test.mjs
 node scripts/gov-source-catalog.mjs --check
+node scripts/public-corpus-intake.mjs --check
 
 echo "═══ 조판 오라클 스윕 산출물 (이슈 72 — 전수 재실행 아님 · 커밋된 요약만) ═══"
 # 코퍼스 전수 layout-check 는 로컬 `node scripts/oracle-sweep.mjs` (--check 가 회귀).


### PR DESCRIPTION
Closes #100

## Outcome
- promote a metadata-only corpus of 20 HWP5, 20 HWPX, and 10 official PDF pairs
- keep every downloaded binary in gitignored private storage
- record source/license/privacy provenance plus retrieval time, SHA-256, detected container, size, feature tags, and pair id
- reproduce only the approved 50 URLs through a fail-closed network and container boundary

## Safety boundary
- HTTPS without credentials or custom ports
- explicit redirect hosts and public DNS re-check/pinning per hop
- total timeout, compressed/download size, ZIP entry/inflate/ratio caps
- strict HWP5 CFB/FileHeader and HWPX ZIP/OWPML validation; bounded PDF envelope validation
- exclusive no-overwrite publication and revalidation of existing single-link regular files
- logs expose only public artifact ids and pass/policy-failure states

## Evidence
- private admission rerun: 50/50 hash, size, and container match
- production parser/layout tagging: 40/40 HWP/HWPX open
- public contract tests: 72 pass
- `scripts/verify-local.sh`: pass (canonical 8/18/24 pages and 98.9%+ line floor unchanged; PDF visual tests 51/51)

No third-party document binary, document body, local path, or quarantine/rejected metadata is included in this PR.