### PR TITLE
test: calibrate PDF visual oracle on 20 T1 pairs

### DIFF
--- a/corpus/PUBLIC-CORPUS.md
+++ b/corpus/PUBLIC-CORPUS.md
@@ -38,5 +38,8 @@ local/central 불일치·CRC 오류를 거부하고 HWP5는 CFB FAT/디렉터리
 기존 파일은 단일-link regular inode와 SHA/크기/컨테이너를 다시 확인하며, 다른 파일을 덮어쓰지 않는다.
 로그는 공개 artifact id와 통과/정책 실패만 남기고 문서명·본문·SHA를 출력하지 않는다.
 
-공식 PDF는 한/글 자체 렌더의 절대 참값으로 선언하지 않는다. #101에서 페이지 구조를 먼저 맞춘 뒤
-정렬 오차와 시각 지표를 report-only로 보정하고, #88·#93의 pair/oracle 입력으로 사용한다.
+공식 PDF는 한/글 자체 렌더의 절대 참값으로 선언하지 않는다. #101은 HWP5 20건 모두에 대응하는
+공식 PDF를 추가 관측해 `pdf-calibration-manifest.json`에 T1 provenance를 고정했다. 이 중 처음
+10개만 위 intake manifest의 50건에 포함되고, 추가 10개 역시 바이너리는 private에만 둔다.
+`pdf-calibration-baseline.json`은 페이지 구조를 먼저 비교한 report-only 결과이며, #88·#93의
+pair/oracle 입력으로 사용한다.

--- a/corpus/pdf-calibration-baseline.json
+++ b/corpus/pdf-calibration-baseline.json
@@ -1,0 +1,636 @@
+{
+  "schema_version": 1,
+  "manifest_sha256": "cece7a9c7eaa21dc8ed7e1ab4bba10b5783f3b3702156e556bf24981fe2e3c2a",
+  "calibration": {
+    "engine_commit": "d803ab1f6540adb7b54ae60959d9923d4e534b2f",
+    "cli_features": [
+      "pdf",
+      "rhwp",
+      "shaper"
+    ],
+    "observed_at": "2026-08-22",
+    "mode": "report-only",
+    "quality_threshold": null
+  },
+  "environment": {
+    "pdfinfo": "pdfinfo version 26.07.0",
+    "pdftoppm": "pdftoppm version 26.07.0",
+    "platform_system": "Darwin",
+    "platform_release": "25.5.0",
+    "platform_machine": "arm64",
+    "python_implementation": "CPython",
+    "python_version": "3.14.6",
+    "dpi": 144,
+    "candidate_font_fingerprint": "sha256:76f45ef4a6bcff344c837c95a7dcc26e017e38b5846d5ae0cdcb5b86be2e2d31",
+    "alignment": {
+      "max_abs_translation_px": 3,
+      "scale": 1,
+      "crop": false,
+      "rotation_degrees": 0
+    }
+  },
+  "counts": {
+    "trusted_pairs": 20,
+    "scored_reports": 18,
+    "structural_mismatches": 2,
+    "scored_pages": 19
+  },
+  "pairs": [
+    {
+      "pair_id": "law-go-271027-17184499",
+      "status": "scored_report",
+      "source_sha256": "39192069329373f80cdd812d7e6a8de9061021c4b0ec4d7caf4be5e42ca1f191",
+      "reference_sha256": "01d013d2dbe59e286fcc5879ab83b3cd4f1be7d82870c3b870ee5a8c6a3a5fc6",
+      "candidate_sha256": "7262779119b75179e39ac0bd348377677e06147bcc269c6d322195552a2fc5ea",
+      "reference_page_count": 2,
+      "candidate_page_count": 2,
+      "structural_mismatches": [],
+      "scored_pages": 2,
+      "worst_page": {
+        "page": 2,
+        "global_ssim_like": 0.095849,
+        "local_ssim_like_mean": 0.308775,
+        "ink_f1": 0.197847,
+        "edge_f1": 0.421567,
+        "worst_tile_recall": 0
+      },
+      "worst_tile": {
+        "page": 1,
+        "recall": 0,
+        "tile": {
+          "height": 128,
+          "left": 512,
+          "matched_ink_pixels": 0,
+          "reference_ink_pixels": 640,
+          "top": 1408,
+          "width": 128
+        }
+      }
+    },
+    {
+      "pair_id": "law-go-271027-17184501",
+      "status": "scored_report",
+      "source_sha256": "811183a397a4fa55f04fd9714879cdb320d90b08597f9bc3579a89458ef30ce5",
+      "reference_sha256": "c0b94f5d13316b92a5c3b81ef54b4c0bfec33a526b9ff25e3f153a1f4f74f65f",
+      "candidate_sha256": "e813faa630ecd4a744309a0ebc6d065503679be30b777a3da10e5bed4a482f7b",
+      "reference_page_count": 1,
+      "candidate_page_count": 1,
+      "structural_mismatches": [],
+      "scored_pages": 1,
+      "worst_page": {
+        "page": 1,
+        "global_ssim_like": 0.196153,
+        "local_ssim_like_mean": 0.381664,
+        "ink_f1": 0.369506,
+        "edge_f1": 0.449762,
+        "worst_tile_recall": 0
+      },
+      "worst_tile": {
+        "page": 1,
+        "recall": 0,
+        "tile": {
+          "height": 128,
+          "left": 0,
+          "matched_ink_pixels": 0,
+          "reference_ink_pixels": 18,
+          "top": 0,
+          "width": 128
+        }
+      }
+    },
+    {
+      "pair_id": "law-go-271027-17184503",
+      "status": "structural_mismatch",
+      "source_sha256": "96885f4e5df7887e5147fd2317b10b376cf9c67f030ee99228c6c6eba4375e92",
+      "reference_sha256": "56d9497a1fab0d0a73046ea6ef34500cee7620b5dfc129de1b8af47563ef11ea",
+      "candidate_sha256": "53472f6ab21a70967323850974a8bfebfd0170164bfd3e197c2079d6560ad02e",
+      "reference_page_count": 1,
+      "candidate_page_count": 2,
+      "structural_mismatches": [
+        {
+          "candidate": 2,
+          "kind": "page_count",
+          "reference": 1
+        }
+      ],
+      "scored_pages": 0,
+      "worst_page": null,
+      "worst_tile": null
+    },
+    {
+      "pair_id": "law-go-271027-17184505",
+      "status": "scored_report",
+      "source_sha256": "682cbf6d11a8bbddc5667e4c7b860a048204f47eabf2df67a6c068a2332e4c23",
+      "reference_sha256": "e069e4184746ce959c6430b2a3c3de48d17735d3d96234006788468ac9bbd5d1",
+      "candidate_sha256": "7641158d954804ccc6af3a6c6f35fed60f3cd4d6880f60f05c4aa2dabf27b66e",
+      "reference_page_count": 1,
+      "candidate_page_count": 1,
+      "structural_mismatches": [],
+      "scored_pages": 1,
+      "worst_page": {
+        "page": 1,
+        "global_ssim_like": 0.296228,
+        "local_ssim_like_mean": 0.456113,
+        "ink_f1": 0.494839,
+        "edge_f1": 0.628057,
+        "worst_tile_recall": 0
+      },
+      "worst_tile": {
+        "page": 1,
+        "recall": 0,
+        "tile": {
+          "height": 128,
+          "left": 640,
+          "matched_ink_pixels": 0,
+          "reference_ink_pixels": 40,
+          "top": 0,
+          "width": 128
+        }
+      }
+    },
+    {
+      "pair_id": "law-go-271027-17184507",
+      "status": "scored_report",
+      "source_sha256": "2239613b8609103bec2a3ee68e02ebfebab6829800756fcc918a8dcc181b6510",
+      "reference_sha256": "04685c76a3eb07a3009c4a2a2160fddcc12d63a5f76b8da4e1e7fd662bdc3c12",
+      "candidate_sha256": "76aa83d125927252144a0c63779e6f47a7cad6fe43c020cbc8b251a2ebaae06d",
+      "reference_page_count": 1,
+      "candidate_page_count": 1,
+      "structural_mismatches": [],
+      "scored_pages": 1,
+      "worst_page": {
+        "page": 1,
+        "global_ssim_like": 0.440048,
+        "local_ssim_like_mean": 0.792568,
+        "ink_f1": 0.355916,
+        "edge_f1": 0.581326,
+        "worst_tile_recall": 0
+      },
+      "worst_tile": {
+        "page": 1,
+        "recall": 0,
+        "tile": {
+          "height": 128,
+          "left": 0,
+          "matched_ink_pixels": 0,
+          "reference_ink_pixels": 72,
+          "top": 0,
+          "width": 128
+        }
+      }
+    },
+    {
+      "pair_id": "law-go-271027-17184509",
+      "status": "scored_report",
+      "source_sha256": "62e0f560a14d5406c7850a8ddf08ee547cc9a7a9ec4e880e38b073c5a8c5a491",
+      "reference_sha256": "280047052c43ab09e092c17a5ff70bd621ca3b9cedd33ac0a4cbbdafc52ca141",
+      "candidate_sha256": "99a8d2a806ca68831e94dbaa89ff923643447668d15290abc4d296face763d80",
+      "reference_page_count": 1,
+      "candidate_page_count": 1,
+      "structural_mismatches": [],
+      "scored_pages": 1,
+      "worst_page": {
+        "page": 1,
+        "global_ssim_like": 0.297274,
+        "local_ssim_like_mean": 0.514518,
+        "ink_f1": 0.478312,
+        "edge_f1": 0.762264,
+        "worst_tile_recall": 0
+      },
+      "worst_tile": {
+        "page": 1,
+        "recall": 0,
+        "tile": {
+          "height": 128,
+          "left": 0,
+          "matched_ink_pixels": 0,
+          "reference_ink_pixels": 36,
+          "top": 0,
+          "width": 128
+        }
+      }
+    },
+    {
+      "pair_id": "law-go-271027-17184511",
+      "status": "scored_report",
+      "source_sha256": "58d4302527076799988dd54279a10de4f2a489fa731e4bad596ca209f160e0b3",
+      "reference_sha256": "9bf747f2dd88b8d844ae0c5c3d7fa998a65591c305690853177cd76f66f90be8",
+      "candidate_sha256": "ef598bbff10dd9cb9f252a174ea7063211ac27955eda38e91f3999c57c2dce5e",
+      "reference_page_count": 1,
+      "candidate_page_count": 1,
+      "structural_mismatches": [],
+      "scored_pages": 1,
+      "worst_page": {
+        "page": 1,
+        "global_ssim_like": 0.167987,
+        "local_ssim_like_mean": 0.395929,
+        "ink_f1": 0.323253,
+        "edge_f1": 0.479558,
+        "worst_tile_recall": 0
+      },
+      "worst_tile": {
+        "page": 1,
+        "recall": 0,
+        "tile": {
+          "height": 128,
+          "left": 896,
+          "matched_ink_pixels": 0,
+          "reference_ink_pixels": 2271,
+          "top": 128,
+          "width": 128
+        }
+      }
+    },
+    {
+      "pair_id": "law-go-271027-17184513",
+      "status": "scored_report",
+      "source_sha256": "32cb80a08144c9e79f27d373f436bc5979030a9b9246f2a0ec566a5008e8b79b",
+      "reference_sha256": "cdbbcd0b5cc7c853354e570caed98d6fc59186691d6c3aa8d855fe819b2cce6b",
+      "candidate_sha256": "5287d5c8a54ec4755636a9a0a564cf022f45acfec136b5a5465231d83f2f4781",
+      "reference_page_count": 1,
+      "candidate_page_count": 1,
+      "structural_mismatches": [],
+      "scored_pages": 1,
+      "worst_page": {
+        "page": 1,
+        "global_ssim_like": 0.342347,
+        "local_ssim_like_mean": 0.484242,
+        "ink_f1": 0.670089,
+        "edge_f1": 0.388469,
+        "worst_tile_recall": 0
+      },
+      "worst_tile": {
+        "page": 1,
+        "recall": 0,
+        "tile": {
+          "height": 128,
+          "left": 640,
+          "matched_ink_pixels": 0,
+          "reference_ink_pixels": 81,
+          "top": 0,
+          "width": 128
+        }
+      }
+    },
+    {
+      "pair_id": "law-go-271027-17184515",
+      "status": "scored_report",
+      "source_sha256": "85e9d52ce12f8e8bd8df812519f7882454521e10448cbef95ed7e4cda8e08c8f",
+      "reference_sha256": "1ed78601b44edfd75a97e97107a3f18e0a29e345615fdce2e23f57f20fb5c0d7",
+      "candidate_sha256": "ad6f3614426fd4a4c5a2292060b85c0788093c15c27944435445fc3eae3efbaf",
+      "reference_page_count": 1,
+      "candidate_page_count": 1,
+      "structural_mismatches": [],
+      "scored_pages": 1,
+      "worst_page": {
+        "page": 1,
+        "global_ssim_like": 0.251399,
+        "local_ssim_like_mean": 0.577226,
+        "ink_f1": 0.235626,
+        "edge_f1": 0.399952,
+        "worst_tile_recall": 0
+      },
+      "worst_tile": {
+        "page": 1,
+        "recall": 0,
+        "tile": {
+          "height": 128,
+          "left": 0,
+          "matched_ink_pixels": 0,
+          "reference_ink_pixels": 24,
+          "top": 0,
+          "width": 128
+        }
+      }
+    },
+    {
+      "pair_id": "law-go-271027-17184517",
+      "status": "scored_report",
+      "source_sha256": "f4b9699c78f9ac63ca271008296b76390226728df084c33d9d7027071d918a18",
+      "reference_sha256": "75e628b1c57bddc931848d5fe6eeb22d0a20a5d5d018530cd5f717c2f186261f",
+      "candidate_sha256": "99bd5cd36ffc2a65c4a0c3df43eabdd4c7360cf87af26cf3c0b7c2e671c8926d",
+      "reference_page_count": 1,
+      "candidate_page_count": 1,
+      "structural_mismatches": [],
+      "scored_pages": 1,
+      "worst_page": {
+        "page": 1,
+        "global_ssim_like": 0.133465,
+        "local_ssim_like_mean": 0.487928,
+        "ink_f1": 0.168603,
+        "edge_f1": 0.457569,
+        "worst_tile_recall": 0
+      },
+      "worst_tile": {
+        "page": 1,
+        "recall": 0,
+        "tile": {
+          "height": 128,
+          "left": 768,
+          "matched_ink_pixels": 0,
+          "reference_ink_pixels": 987,
+          "top": 128,
+          "width": 128
+        }
+      }
+    },
+    {
+      "pair_id": "law-go-271027-17184519",
+      "status": "scored_report",
+      "source_sha256": "2c8d0fcedcb4933a1ac2833f431bf71f1a994b798982569292b48fce047af4df",
+      "reference_sha256": "168f6e81517784f79bd1f55123bb0eef813bafcbd0534906a088e1b9767c2bb6",
+      "candidate_sha256": "9b64bda58a9e5e16ede7ff5a102c4cf79af12e0326b81946688855c6fabe636f",
+      "reference_page_count": 1,
+      "candidate_page_count": 1,
+      "structural_mismatches": [],
+      "scored_pages": 1,
+      "worst_page": {
+        "page": 1,
+        "global_ssim_like": 0.267126,
+        "local_ssim_like_mean": 0.4478,
+        "ink_f1": 0.582663,
+        "edge_f1": 0.469177,
+        "worst_tile_recall": 0
+      },
+      "worst_tile": {
+        "page": 1,
+        "recall": 0,
+        "tile": {
+          "height": 128,
+          "left": 0,
+          "matched_ink_pixels": 0,
+          "reference_ink_pixels": 72,
+          "top": 0,
+          "width": 128
+        }
+      }
+    },
+    {
+      "pair_id": "law-go-271027-17184521",
+      "status": "scored_report",
+      "source_sha256": "5674a44e7fec3d78501c2dbc46a0d63b2241264c15c7488783eaf355bfdb56d9",
+      "reference_sha256": "c012a0e9c8ec4f557c1bdaaf3e2543192737d3174560a72331e9c0c92fcbe68b",
+      "candidate_sha256": "85dab7fadc332db983b8d29df85deb8b4310d12ca97ea61131a37f766d407fc8",
+      "reference_page_count": 1,
+      "candidate_page_count": 1,
+      "structural_mismatches": [],
+      "scored_pages": 1,
+      "worst_page": {
+        "page": 1,
+        "global_ssim_like": 0.320831,
+        "local_ssim_like_mean": 0.411128,
+        "ink_f1": 0.584933,
+        "edge_f1": 0.361312,
+        "worst_tile_recall": 0
+      },
+      "worst_tile": {
+        "page": 1,
+        "recall": 0,
+        "tile": {
+          "height": 128,
+          "left": 640,
+          "matched_ink_pixels": 0,
+          "reference_ink_pixels": 79,
+          "top": 0,
+          "width": 128
+        }
+      }
+    },
+    {
+      "pair_id": "law-go-271027-17184523",
+      "status": "scored_report",
+      "source_sha256": "4c5207a4896acfe8572c6c02b317792933b6b806fa829067346cfe9dcfd99dd3",
+      "reference_sha256": "4f3c7b94c4d147691b8af2716123b6a6ca1a91755f50d1992930203a62799a28",
+      "candidate_sha256": "89697898cc482fada09e62aea2d2812bb5ec7cc58d8c052b9a913a4f2ebd2dfa",
+      "reference_page_count": 1,
+      "candidate_page_count": 1,
+      "structural_mismatches": [],
+      "scored_pages": 1,
+      "worst_page": {
+        "page": 1,
+        "global_ssim_like": 0.25088,
+        "local_ssim_like_mean": 0.398658,
+        "ink_f1": 0.586083,
+        "edge_f1": 0.403216,
+        "worst_tile_recall": 0
+      },
+      "worst_tile": {
+        "page": 1,
+        "recall": 0,
+        "tile": {
+          "height": 128,
+          "left": 0,
+          "matched_ink_pixels": 0,
+          "reference_ink_pixels": 30,
+          "top": 0,
+          "width": 128
+        }
+      }
+    },
+    {
+      "pair_id": "law-go-271027-17184525",
+      "status": "structural_mismatch",
+      "source_sha256": "283d39dcb83a4950d539639d0c60e091429d97602cb40be679266817fc70deb8",
+      "reference_sha256": "82b37ac15fc3b5f22183168fb10ff3416069a79dd6f180f8263fcf5084b0d88e",
+      "candidate_sha256": "706cf567f87838203f4b6b062ff07edfa63128464aa2727647ee99e488c5cf77",
+      "reference_page_count": 1,
+      "candidate_page_count": 2,
+      "structural_mismatches": [
+        {
+          "candidate": 2,
+          "kind": "page_count",
+          "reference": 1
+        }
+      ],
+      "scored_pages": 0,
+      "worst_page": null,
+      "worst_tile": null
+    },
+    {
+      "pair_id": "law-go-271027-17184527",
+      "status": "scored_report",
+      "source_sha256": "bd4b55725c0b3904aac770d5aee3722484458041a4384a27e0a17f60cdcadf76",
+      "reference_sha256": "89752a84db2b617564c87768702f4289fb47e155584bada6cd65de5bdd820b5e",
+      "candidate_sha256": "5fc77d354a144534539ea0ba035b52c40205eb2b1a24b3283b0031140993fd17",
+      "reference_page_count": 1,
+      "candidate_page_count": 1,
+      "structural_mismatches": [],
+      "scored_pages": 1,
+      "worst_page": {
+        "page": 1,
+        "global_ssim_like": 0.269865,
+        "local_ssim_like_mean": 0.689149,
+        "ink_f1": 0.280714,
+        "edge_f1": 0.461814,
+        "worst_tile_recall": 0
+      },
+      "worst_tile": {
+        "page": 1,
+        "recall": 0,
+        "tile": {
+          "height": 128,
+          "left": 0,
+          "matched_ink_pixels": 0,
+          "reference_ink_pixels": 72,
+          "top": 0,
+          "width": 128
+        }
+      }
+    },
+    {
+      "pair_id": "law-go-271027-17184529",
+      "status": "scored_report",
+      "source_sha256": "ffebb654df18e2524ddb28df7d63bb58442aa431cfeb21d8732ccbd57be2a416",
+      "reference_sha256": "c074580f4546560fb69fd571e86fb5b0cf4ebc64f1bd24e02fb239065a2e779c",
+      "candidate_sha256": "ca7178dd7c5e3886fd887fe02226cd491e7f989ca7fbc39baf0e546339a2a637",
+      "reference_page_count": 1,
+      "candidate_page_count": 1,
+      "structural_mismatches": [],
+      "scored_pages": 1,
+      "worst_page": {
+        "page": 1,
+        "global_ssim_like": 0.27096,
+        "local_ssim_like_mean": 0.630525,
+        "ink_f1": 0.27397,
+        "edge_f1": 0.435597,
+        "worst_tile_recall": 0
+      },
+      "worst_tile": {
+        "page": 1,
+        "recall": 0,
+        "tile": {
+          "height": 128,
+          "left": 0,
+          "matched_ink_pixels": 0,
+          "reference_ink_pixels": 72,
+          "top": 0,
+          "width": 128
+        }
+      }
+    },
+    {
+      "pair_id": "law-go-271027-17184531",
+      "status": "scored_report",
+      "source_sha256": "af1bafe1f95778af9ad0c0cddb2240aea67c22ed69dbf2e0f09a83ea22045037",
+      "reference_sha256": "7f8db2f067134375bb2861f0a3c9bc15af4055e8be8ca5a8d0f61372e2ad8e96",
+      "candidate_sha256": "34119b08597f96b1bcac4c634ae11f9ddbc89a4df74edcc9a8172fbdbb918218",
+      "reference_page_count": 1,
+      "candidate_page_count": 1,
+      "structural_mismatches": [],
+      "scored_pages": 1,
+      "worst_page": {
+        "page": 1,
+        "global_ssim_like": 0.352007,
+        "local_ssim_like_mean": 0.50682,
+        "ink_f1": 0.682588,
+        "edge_f1": 0.54998,
+        "worst_tile_recall": 0
+      },
+      "worst_tile": {
+        "page": 1,
+        "recall": 0,
+        "tile": {
+          "height": 128,
+          "left": 0,
+          "matched_ink_pixels": 0,
+          "reference_ink_pixels": 12,
+          "top": 0,
+          "width": 128
+        }
+      }
+    },
+    {
+      "pair_id": "law-go-271027-17184533",
+      "status": "scored_report",
+      "source_sha256": "eb1f9a967a882c062fe17af6d9659fcc3f4e90318863ba43c3fdfebb6c733f48",
+      "reference_sha256": "54c12427c1f75348c9fb1af465f08f055d41d3013f8a6eefeedb91962ff6e4d9",
+      "candidate_sha256": "674a1e454b5d695f6f71f192f903bba984df16966bb88340e54d47e6324bac03",
+      "reference_page_count": 1,
+      "candidate_page_count": 1,
+      "structural_mismatches": [],
+      "scored_pages": 1,
+      "worst_page": {
+        "page": 1,
+        "global_ssim_like": 0.189076,
+        "local_ssim_like_mean": 0.643906,
+        "ink_f1": 0.147587,
+        "edge_f1": 0.378095,
+        "worst_tile_recall": 0
+      },
+      "worst_tile": {
+        "page": 1,
+        "recall": 0,
+        "tile": {
+          "height": 128,
+          "left": 0,
+          "matched_ink_pixels": 0,
+          "reference_ink_pixels": 24,
+          "top": 0,
+          "width": 128
+        }
+      }
+    },
+    {
+      "pair_id": "law-go-271027-17184535",
+      "status": "scored_report",
+      "source_sha256": "470aaacd0079677d3b6387b9d92a2cf25042edce8928080fad1e6a344d1521ec",
+      "reference_sha256": "8c1b19ed6762affe7ea02e09ef684210654a6c17d899366c6f2584f41313fa1d",
+      "candidate_sha256": "8684e11a930c71073b90e08c15047a9393e27f17f46ca1e14233dc3e43fa08f9",
+      "reference_page_count": 1,
+      "candidate_page_count": 1,
+      "structural_mismatches": [],
+      "scored_pages": 1,
+      "worst_page": {
+        "page": 1,
+        "global_ssim_like": 0.395899,
+        "local_ssim_like_mean": 0.631475,
+        "ink_f1": 0.555527,
+        "edge_f1": 0.543138,
+        "worst_tile_recall": 0
+      },
+      "worst_tile": {
+        "page": 1,
+        "recall": 0,
+        "tile": {
+          "height": 128,
+          "left": 384,
+          "matched_ink_pixels": 0,
+          "reference_ink_pixels": 257,
+          "top": 768,
+          "width": 128
+        }
+      }
+    },
+    {
+      "pair_id": "law-go-271027-17184537",
+      "status": "scored_report",
+      "source_sha256": "2a0fc6865d2494b3268954389a6ec958fb44b898a988fb80fd4b32423a48b075",
+      "reference_sha256": "c1d14d6adad73b0f248770187f1622dafd6e6e7b6d6b9e8ecb191d84c5a2a8cb",
+      "candidate_sha256": "559dc045922d9f0e102e7d83599afe28db83bbb98b6cc5168c3ca67c03ba46f1",
+      "reference_page_count": 1,
+      "candidate_page_count": 1,
+      "structural_mismatches": [],
+      "scored_pages": 1,
+      "worst_page": {
+        "page": 1,
+        "global_ssim_like": 0.26767,
+        "local_ssim_like_mean": 0.467534,
+        "ink_f1": 0.532799,
+        "edge_f1": 0.563288,
+        "worst_tile_recall": 0
+      },
+      "worst_tile": {
+        "page": 1,
+        "recall": 0,
+        "tile": {
+          "height": 128,
+          "left": 0,
+          "matched_ink_pixels": 0,
+          "reference_ink_pixels": 54,
+          "top": 0,
+          "width": 128
+        }
+      }
+    }
+  ]
+}

--- a/corpus/pdf-calibration-manifest.json
+++ b/corpus/pdf-calibration-manifest.json
@@ -1,0 +1,581 @@
+{
+  "schema_version": 1,
+  "policy": {
+    "mode": "report-only",
+    "quality_threshold": null,
+    "minimum_trusted_pairs": 20,
+    "candidate_font": {
+      "file": "assets/fonts/NanumGothic-Regular.ttf",
+      "sha256": "76f45ef4a6bcff344c837c95a7dcc26e017e38b5846d5ae0cdcb5b86be2e2d31"
+    },
+    "raster": {
+      "dpi": 144,
+      "max_translation_px": 3,
+      "scale": 1,
+      "crop": false,
+      "rotation_degrees": 0
+    }
+  },
+  "pairs": [
+    {
+      "pair_id": "law-go-271027-17184499",
+      "source": {
+        "artifact_id": "law-go-271027-17184499-hwp5",
+        "file": "law-go-271027-17184499-hwp5.hwp",
+        "format": "hwp5",
+        "sha256": "39192069329373f80cdd812d7e6a8de9061021c4b0ec4d7caf4be5e42ca1f191"
+      },
+      "reference": {
+        "file": "law-go-271027-17184499-pdf.pdf",
+        "tier": "T1",
+        "source_page": "https://www.law.go.kr/LSW/lsInfoP.do?ancYnChk=0&lsiSeq=271027",
+        "source_url": "https://www.law.go.kr/LSW/flDownload.do?flSeq=151361773",
+        "sha256": "01d013d2dbe59e286fcc5879ab83b3cd4f1be7d82870c3b870ee5a8c6a3a5fc6",
+        "size_bytes": 165598,
+        "license": {
+          "code": "Copyright Act Article 7",
+          "evidence_url": "https://www.law.go.kr/lsLinkCommonInfo.do?lsJoLnkSeq=1029423769",
+          "observed_at": "2026-08-22",
+          "scope": "statutory-public-domain"
+        },
+        "product": "Hancom PDF",
+        "build": "Hancom PDF 1.3.0.546 (embedded Producer metadata)",
+        "os": "not disclosed by official publisher",
+        "font_fingerprint": "pdffonts-normalized-sha256:21dc7dfc05bbb66bd74ea5d80fd40f6beb518bf29d4af7737ceb1f47a375d148",
+        "note": "Official law.go.kr HWP/PDF attachment pair; pair_id=law-go-271027-17184499; association self-attested from the same source page"
+      }
+    },
+    {
+      "pair_id": "law-go-271027-17184501",
+      "source": {
+        "artifact_id": "law-go-271027-17184501-hwp5",
+        "file": "law-go-271027-17184501-hwp5.hwp",
+        "format": "hwp5",
+        "sha256": "811183a397a4fa55f04fd9714879cdb320d90b08597f9bc3579a89458ef30ce5"
+      },
+      "reference": {
+        "file": "law-go-271027-17184501-pdf.pdf",
+        "tier": "T1",
+        "source_page": "https://www.law.go.kr/LSW/lsInfoP.do?ancYnChk=0&lsiSeq=271027",
+        "source_url": "https://www.law.go.kr/LSW/flDownload.do?flSeq=151361781",
+        "sha256": "c0b94f5d13316b92a5c3b81ef54b4c0bfec33a526b9ff25e3f153a1f4f74f65f",
+        "size_bytes": 41442,
+        "license": {
+          "code": "Copyright Act Article 7",
+          "evidence_url": "https://www.law.go.kr/lsLinkCommonInfo.do?lsJoLnkSeq=1029423769",
+          "observed_at": "2026-08-22",
+          "scope": "statutory-public-domain"
+        },
+        "product": "Hancom PDF",
+        "build": "Hancom PDF 1.3.0.546 (embedded Producer metadata)",
+        "os": "not disclosed by official publisher",
+        "font_fingerprint": "pdffonts-normalized-sha256:bde31c0ad5e8e99daf2045953079bf502a93cf4abb3a4c2f7c83f51b5ba5308b",
+        "note": "Official law.go.kr HWP/PDF attachment pair; pair_id=law-go-271027-17184501; association self-attested from the same source page"
+      }
+    },
+    {
+      "pair_id": "law-go-271027-17184503",
+      "source": {
+        "artifact_id": "law-go-271027-17184503-hwp5",
+        "file": "law-go-271027-17184503-hwp5.hwp",
+        "format": "hwp5",
+        "sha256": "96885f4e5df7887e5147fd2317b10b376cf9c67f030ee99228c6c6eba4375e92"
+      },
+      "reference": {
+        "file": "law-go-271027-17184503-pdf.pdf",
+        "tier": "T1",
+        "source_page": "https://www.law.go.kr/LSW/lsInfoP.do?ancYnChk=0&lsiSeq=271027",
+        "source_url": "https://www.law.go.kr/LSW/flDownload.do?flSeq=151361787",
+        "sha256": "56d9497a1fab0d0a73046ea6ef34500cee7620b5dfc129de1b8af47563ef11ea",
+        "size_bytes": 51588,
+        "license": {
+          "code": "Copyright Act Article 7",
+          "evidence_url": "https://www.law.go.kr/lsLinkCommonInfo.do?lsJoLnkSeq=1029423769",
+          "observed_at": "2026-08-22",
+          "scope": "statutory-public-domain"
+        },
+        "product": "Hancom PDF",
+        "build": "Hancom PDF 1.3.0.546 (embedded Producer metadata)",
+        "os": "not disclosed by official publisher",
+        "font_fingerprint": "pdffonts-normalized-sha256:a1a753fd040d2004ca3c5740a8dd65963f9a038488d3456f57fadb640e473945",
+        "note": "Official law.go.kr HWP/PDF attachment pair; pair_id=law-go-271027-17184503; association self-attested from the same source page"
+      }
+    },
+    {
+      "pair_id": "law-go-271027-17184505",
+      "source": {
+        "artifact_id": "law-go-271027-17184505-hwp5",
+        "file": "law-go-271027-17184505-hwp5.hwp",
+        "format": "hwp5",
+        "sha256": "682cbf6d11a8bbddc5667e4c7b860a048204f47eabf2df67a6c068a2332e4c23"
+      },
+      "reference": {
+        "file": "law-go-271027-17184505-pdf.pdf",
+        "tier": "T1",
+        "source_page": "https://www.law.go.kr/LSW/lsInfoP.do?ancYnChk=0&lsiSeq=271027",
+        "source_url": "https://www.law.go.kr/LSW/flDownload.do?flSeq=151361801",
+        "sha256": "e069e4184746ce959c6430b2a3c3de48d17735d3d96234006788468ac9bbd5d1",
+        "size_bytes": 51105,
+        "license": {
+          "code": "Copyright Act Article 7",
+          "evidence_url": "https://www.law.go.kr/lsLinkCommonInfo.do?lsJoLnkSeq=1029423769",
+          "observed_at": "2026-08-22",
+          "scope": "statutory-public-domain"
+        },
+        "product": "Hancom PDF",
+        "build": "Hancom PDF 1.3.0.546 (embedded Producer metadata)",
+        "os": "not disclosed by official publisher",
+        "font_fingerprint": "pdffonts-normalized-sha256:e9213c385af85a3b24010e71759afe243d4f6ac4c16b3ac0fc791820ce58e18a",
+        "note": "Official law.go.kr HWP/PDF attachment pair; pair_id=law-go-271027-17184505; association self-attested from the same source page"
+      }
+    },
+    {
+      "pair_id": "law-go-271027-17184507",
+      "source": {
+        "artifact_id": "law-go-271027-17184507-hwp5",
+        "file": "law-go-271027-17184507-hwp5.hwp",
+        "format": "hwp5",
+        "sha256": "2239613b8609103bec2a3ee68e02ebfebab6829800756fcc918a8dcc181b6510"
+      },
+      "reference": {
+        "file": "law-go-271027-17184507-pdf.pdf",
+        "tier": "T1",
+        "source_page": "https://www.law.go.kr/LSW/lsInfoP.do?ancYnChk=0&lsiSeq=271027",
+        "source_url": "https://www.law.go.kr/LSW/flDownload.do?flSeq=151361829",
+        "sha256": "04685c76a3eb07a3009c4a2a2160fddcc12d63a5f76b8da4e1e7fd662bdc3c12",
+        "size_bytes": 32943,
+        "license": {
+          "code": "Copyright Act Article 7",
+          "evidence_url": "https://www.law.go.kr/lsLinkCommonInfo.do?lsJoLnkSeq=1029423769",
+          "observed_at": "2026-08-22",
+          "scope": "statutory-public-domain"
+        },
+        "product": "Hancom PDF",
+        "build": "Hancom PDF 1.3.0.546 (embedded Producer metadata)",
+        "os": "not disclosed by official publisher",
+        "font_fingerprint": "pdffonts-normalized-sha256:2ef5ae76ffc02a3944abb34880db3acc98ee1d7c90236cefc8f59f30de79c9fa",
+        "note": "Official law.go.kr HWP/PDF attachment pair; pair_id=law-go-271027-17184507; association self-attested from the same source page"
+      }
+    },
+    {
+      "pair_id": "law-go-271027-17184509",
+      "source": {
+        "artifact_id": "law-go-271027-17184509-hwp5",
+        "file": "law-go-271027-17184509-hwp5.hwp",
+        "format": "hwp5",
+        "sha256": "62e0f560a14d5406c7850a8ddf08ee547cc9a7a9ec4e880e38b073c5a8c5a491"
+      },
+      "reference": {
+        "file": "law-go-271027-17184509-pdf.pdf",
+        "tier": "T1",
+        "source_page": "https://www.law.go.kr/LSW/lsInfoP.do?ancYnChk=0&lsiSeq=271027",
+        "source_url": "https://www.law.go.kr/LSW/flDownload.do?flSeq=151361837",
+        "sha256": "280047052c43ab09e092c17a5ff70bd621ca3b9cedd33ac0a4cbbdafc52ca141",
+        "size_bytes": 57389,
+        "license": {
+          "code": "Copyright Act Article 7",
+          "evidence_url": "https://www.law.go.kr/lsLinkCommonInfo.do?lsJoLnkSeq=1029423769",
+          "observed_at": "2026-08-22",
+          "scope": "statutory-public-domain"
+        },
+        "product": "Hancom PDF",
+        "build": "Hancom PDF 1.3.0.546 (embedded Producer metadata)",
+        "os": "not disclosed by official publisher",
+        "font_fingerprint": "pdffonts-normalized-sha256:c11e44f10eabff508066a3b60ce5c2a4697584a3a01086715f51e4a7e4fe8cc3",
+        "note": "Official law.go.kr HWP/PDF attachment pair; pair_id=law-go-271027-17184509; association self-attested from the same source page"
+      }
+    },
+    {
+      "pair_id": "law-go-271027-17184511",
+      "source": {
+        "artifact_id": "law-go-271027-17184511-hwp5",
+        "file": "law-go-271027-17184511-hwp5.hwp",
+        "format": "hwp5",
+        "sha256": "58d4302527076799988dd54279a10de4f2a489fa731e4bad596ca209f160e0b3"
+      },
+      "reference": {
+        "file": "law-go-271027-17184511-pdf.pdf",
+        "tier": "T1",
+        "source_page": "https://www.law.go.kr/LSW/lsInfoP.do?ancYnChk=0&lsiSeq=271027",
+        "source_url": "https://www.law.go.kr/LSW/flDownload.do?flSeq=151361843",
+        "sha256": "9bf747f2dd88b8d844ae0c5c3d7fa998a65591c305690853177cd76f66f90be8",
+        "size_bytes": 84728,
+        "license": {
+          "code": "Copyright Act Article 7",
+          "evidence_url": "https://www.law.go.kr/lsLinkCommonInfo.do?lsJoLnkSeq=1029423769",
+          "observed_at": "2026-08-22",
+          "scope": "statutory-public-domain"
+        },
+        "product": "Hancom PDF",
+        "build": "Hancom PDF 1.3.0.546 (embedded Producer metadata)",
+        "os": "not disclosed by official publisher",
+        "font_fingerprint": "pdffonts-normalized-sha256:18d0d893eda7b0aec6b0904d4a5cc7d73925c29d27b2abb7653db48963c495e1",
+        "note": "Official law.go.kr HWP/PDF attachment pair; pair_id=law-go-271027-17184511; association self-attested from the same source page"
+      }
+    },
+    {
+      "pair_id": "law-go-271027-17184513",
+      "source": {
+        "artifact_id": "law-go-271027-17184513-hwp5",
+        "file": "law-go-271027-17184513-hwp5.hwp",
+        "format": "hwp5",
+        "sha256": "32cb80a08144c9e79f27d373f436bc5979030a9b9246f2a0ec566a5008e8b79b"
+      },
+      "reference": {
+        "file": "law-go-271027-17184513-pdf.pdf",
+        "tier": "T1",
+        "source_page": "https://www.law.go.kr/LSW/lsInfoP.do?ancYnChk=0&lsiSeq=271027",
+        "source_url": "https://www.law.go.kr/LSW/flDownload.do?flSeq=151361849",
+        "sha256": "cdbbcd0b5cc7c853354e570caed98d6fc59186691d6c3aa8d855fe819b2cce6b",
+        "size_bytes": 55437,
+        "license": {
+          "code": "Copyright Act Article 7",
+          "evidence_url": "https://www.law.go.kr/lsLinkCommonInfo.do?lsJoLnkSeq=1029423769",
+          "observed_at": "2026-08-22",
+          "scope": "statutory-public-domain"
+        },
+        "product": "Hancom PDF",
+        "build": "Hancom PDF 1.3.0.546 (embedded Producer metadata)",
+        "os": "not disclosed by official publisher",
+        "font_fingerprint": "pdffonts-normalized-sha256:fcb9657077f2fd7a266484385834882a3919511f748c9968606be97836e4867c",
+        "note": "Official law.go.kr HWP/PDF attachment pair; pair_id=law-go-271027-17184513; association self-attested from the same source page"
+      }
+    },
+    {
+      "pair_id": "law-go-271027-17184515",
+      "source": {
+        "artifact_id": "law-go-271027-17184515-hwp5",
+        "file": "law-go-271027-17184515-hwp5.hwp",
+        "format": "hwp5",
+        "sha256": "85e9d52ce12f8e8bd8df812519f7882454521e10448cbef95ed7e4cda8e08c8f"
+      },
+      "reference": {
+        "file": "law-go-271027-17184515-pdf.pdf",
+        "tier": "T1",
+        "source_page": "https://www.law.go.kr/LSW/lsInfoP.do?ancYnChk=0&lsiSeq=271027",
+        "source_url": "https://www.law.go.kr/LSW/flDownload.do?flSeq=151361855",
+        "sha256": "1ed78601b44edfd75a97e97107a3f18e0a29e345615fdce2e23f57f20fb5c0d7",
+        "size_bytes": 35796,
+        "license": {
+          "code": "Copyright Act Article 7",
+          "evidence_url": "https://www.law.go.kr/lsLinkCommonInfo.do?lsJoLnkSeq=1029423769",
+          "observed_at": "2026-08-22",
+          "scope": "statutory-public-domain"
+        },
+        "product": "Hancom PDF",
+        "build": "Hancom PDF 1.3.0.546 (embedded Producer metadata)",
+        "os": "not disclosed by official publisher",
+        "font_fingerprint": "pdffonts-normalized-sha256:aa4950090ac0399bd5aac293702db3546faff73bad961b01f22a9b9fbb091c1b",
+        "note": "Official law.go.kr HWP/PDF attachment pair; pair_id=law-go-271027-17184515; association self-attested from the same source page"
+      }
+    },
+    {
+      "pair_id": "law-go-271027-17184517",
+      "source": {
+        "artifact_id": "law-go-271027-17184517-hwp5",
+        "file": "law-go-271027-17184517-hwp5.hwp",
+        "format": "hwp5",
+        "sha256": "f4b9699c78f9ac63ca271008296b76390226728df084c33d9d7027071d918a18"
+      },
+      "reference": {
+        "file": "law-go-271027-17184517-pdf.pdf",
+        "tier": "T1",
+        "source_page": "https://www.law.go.kr/LSW/lsInfoP.do?ancYnChk=0&lsiSeq=271027",
+        "source_url": "https://www.law.go.kr/LSW/flDownload.do?flSeq=151361863",
+        "sha256": "75e628b1c57bddc931848d5fe6eeb22d0a20a5d5d018530cd5f717c2f186261f",
+        "size_bytes": 39215,
+        "license": {
+          "code": "Copyright Act Article 7",
+          "evidence_url": "https://www.law.go.kr/lsLinkCommonInfo.do?lsJoLnkSeq=1029423769",
+          "observed_at": "2026-08-22",
+          "scope": "statutory-public-domain"
+        },
+        "product": "Hancom PDF",
+        "build": "Hancom PDF 1.3.0.546 (embedded Producer metadata)",
+        "os": "not disclosed by official publisher",
+        "font_fingerprint": "pdffonts-normalized-sha256:d27c4ff3b0b0765d97bc74a4c35450446b6c65d18fbe84e2ee96f23b092f7973",
+        "note": "Official law.go.kr HWP/PDF attachment pair; pair_id=law-go-271027-17184517; association self-attested from the same source page"
+      }
+    },
+    {
+      "pair_id": "law-go-271027-17184519",
+      "source": {
+        "artifact_id": "law-go-271027-17184519-hwp5",
+        "file": "law-go-271027-17184519-hwp5.hwp",
+        "format": "hwp5",
+        "sha256": "2c8d0fcedcb4933a1ac2833f431bf71f1a994b798982569292b48fce047af4df"
+      },
+      "reference": {
+        "file": "law-go-271027-17184519-pdf.pdf",
+        "tier": "T1",
+        "source_page": "https://www.law.go.kr/LSW/lsInfoP.do?ancYnChk=0&lsiSeq=271027",
+        "source_url": "https://www.law.go.kr/LSW/flDownload.do?flSeq=151361869",
+        "sha256": "168f6e81517784f79bd1f55123bb0eef813bafcbd0534906a088e1b9767c2bb6",
+        "size_bytes": 64737,
+        "license": {
+          "code": "Copyright Act Article 7",
+          "evidence_url": "https://www.law.go.kr/lsLinkCommonInfo.do?lsJoLnkSeq=1029423769",
+          "observed_at": "2026-08-22",
+          "scope": "statutory-public-domain"
+        },
+        "product": "Hancom PDF",
+        "build": "Hancom PDF 1.3.0.546 (embedded Producer metadata)",
+        "os": "not disclosed by official publisher",
+        "font_fingerprint": "pdffonts-normalized-sha256:5f9d7cbf2e9a7a60dcf8931a46ccd7d24262ee2822e566897be64854b296b591",
+        "note": "Official law.go.kr HWP/PDF attachment pair; pair_id=law-go-271027-17184519; association self-attested from the same source page"
+      }
+    },
+    {
+      "pair_id": "law-go-271027-17184521",
+      "source": {
+        "artifact_id": "law-go-271027-17184521-hwp5",
+        "file": "law-go-271027-17184521-hwp5.hwp",
+        "format": "hwp5",
+        "sha256": "5674a44e7fec3d78501c2dbc46a0d63b2241264c15c7488783eaf355bfdb56d9"
+      },
+      "reference": {
+        "file": "law-go-271027-17184521-pdf.pdf",
+        "tier": "T1",
+        "source_page": "https://www.law.go.kr/LSW/lsInfoP.do?ancYnChk=0&lsiSeq=271027",
+        "source_url": "https://www.law.go.kr/LSW/flDownload.do?flSeq=151361875",
+        "sha256": "c012a0e9c8ec4f557c1bdaaf3e2543192737d3174560a72331e9c0c92fcbe68b",
+        "size_bytes": 53831,
+        "license": {
+          "code": "Copyright Act Article 7",
+          "evidence_url": "https://www.law.go.kr/lsLinkCommonInfo.do?lsJoLnkSeq=1029423769",
+          "observed_at": "2026-08-22",
+          "scope": "statutory-public-domain"
+        },
+        "product": "Hancom PDF",
+        "build": "Hancom PDF 1.3.0.546 (embedded Producer metadata)",
+        "os": "not disclosed by official publisher",
+        "font_fingerprint": "pdffonts-normalized-sha256:052e4c141ff2f7501046ac6f3b7fbf53c2f904e75e03a06675e33b5778f68a75",
+        "note": "Official law.go.kr HWP/PDF attachment pair; pair_id=law-go-271027-17184521; association self-attested from the same source page"
+      }
+    },
+    {
+      "pair_id": "law-go-271027-17184523",
+      "source": {
+        "artifact_id": "law-go-271027-17184523-hwp5",
+        "file": "law-go-271027-17184523-hwp5.hwp",
+        "format": "hwp5",
+        "sha256": "4c5207a4896acfe8572c6c02b317792933b6b806fa829067346cfe9dcfd99dd3"
+      },
+      "reference": {
+        "file": "law-go-271027-17184523-pdf.pdf",
+        "tier": "T1",
+        "source_page": "https://www.law.go.kr/LSW/lsInfoP.do?ancYnChk=0&lsiSeq=271027",
+        "source_url": "https://www.law.go.kr/LSW/flDownload.do?flSeq=151361883",
+        "sha256": "4f3c7b94c4d147691b8af2716123b6a6ca1a91755f50d1992930203a62799a28",
+        "size_bytes": 66640,
+        "license": {
+          "code": "Copyright Act Article 7",
+          "evidence_url": "https://www.law.go.kr/lsLinkCommonInfo.do?lsJoLnkSeq=1029423769",
+          "observed_at": "2026-08-22",
+          "scope": "statutory-public-domain"
+        },
+        "product": "Hancom PDF",
+        "build": "Hancom PDF 1.3.0.546 (embedded Producer metadata)",
+        "os": "not disclosed by official publisher",
+        "font_fingerprint": "pdffonts-normalized-sha256:e490fcd34e747c1a2236378b21c8ca61639ba18ebdd6f0f91d852e05e83b801d",
+        "note": "Official law.go.kr HWP/PDF attachment pair; pair_id=law-go-271027-17184523; association self-attested from the same source page"
+      }
+    },
+    {
+      "pair_id": "law-go-271027-17184525",
+      "source": {
+        "artifact_id": "law-go-271027-17184525-hwp5",
+        "file": "law-go-271027-17184525-hwp5.hwp",
+        "format": "hwp5",
+        "sha256": "283d39dcb83a4950d539639d0c60e091429d97602cb40be679266817fc70deb8"
+      },
+      "reference": {
+        "file": "law-go-271027-17184525-pdf.pdf",
+        "tier": "T1",
+        "source_page": "https://www.law.go.kr/LSW/lsInfoP.do?ancYnChk=0&lsiSeq=271027",
+        "source_url": "https://www.law.go.kr/LSW/flDownload.do?flSeq=151361889",
+        "sha256": "82b37ac15fc3b5f22183168fb10ff3416069a79dd6f180f8263fcf5084b0d88e",
+        "size_bytes": 62588,
+        "license": {
+          "code": "Copyright Act Article 7",
+          "evidence_url": "https://www.law.go.kr/lsLinkCommonInfo.do?lsJoLnkSeq=1029423769",
+          "observed_at": "2026-08-22",
+          "scope": "statutory-public-domain"
+        },
+        "product": "Hancom PDF",
+        "build": "Hancom PDF 1.3.0.546 (embedded Producer metadata)",
+        "os": "not disclosed by official publisher",
+        "font_fingerprint": "pdffonts-normalized-sha256:959eba4ff77864a5b3a8ca7f6d742646493b1d3ba2f21931dcb73b7b12d34d61",
+        "note": "Official law.go.kr HWP/PDF attachment pair; pair_id=law-go-271027-17184525; association self-attested from the same source page"
+      }
+    },
+    {
+      "pair_id": "law-go-271027-17184527",
+      "source": {
+        "artifact_id": "law-go-271027-17184527-hwp5",
+        "file": "law-go-271027-17184527-hwp5.hwp",
+        "format": "hwp5",
+        "sha256": "bd4b55725c0b3904aac770d5aee3722484458041a4384a27e0a17f60cdcadf76"
+      },
+      "reference": {
+        "file": "law-go-271027-17184527-pdf.pdf",
+        "tier": "T1",
+        "source_page": "https://www.law.go.kr/LSW/lsInfoP.do?ancYnChk=0&lsiSeq=271027",
+        "source_url": "https://www.law.go.kr/LSW/flDownload.do?flSeq=151361895",
+        "sha256": "89752a84db2b617564c87768702f4289fb47e155584bada6cd65de5bdd820b5e",
+        "size_bytes": 32951,
+        "license": {
+          "code": "Copyright Act Article 7",
+          "evidence_url": "https://www.law.go.kr/lsLinkCommonInfo.do?lsJoLnkSeq=1029423769",
+          "observed_at": "2026-08-22",
+          "scope": "statutory-public-domain"
+        },
+        "product": "Hancom PDF",
+        "build": "Hancom PDF 1.3.0.546 (embedded Producer metadata)",
+        "os": "not disclosed by official publisher",
+        "font_fingerprint": "pdffonts-normalized-sha256:d39284072dcc5a39d0482976e82570642708d1cd7c87a2a4f7385e37d4a979bc",
+        "note": "Official law.go.kr HWP/PDF attachment pair; pair_id=law-go-271027-17184527; association self-attested from the same source page"
+      }
+    },
+    {
+      "pair_id": "law-go-271027-17184529",
+      "source": {
+        "artifact_id": "law-go-271027-17184529-hwp5",
+        "file": "law-go-271027-17184529-hwp5.hwp",
+        "format": "hwp5",
+        "sha256": "ffebb654df18e2524ddb28df7d63bb58442aa431cfeb21d8732ccbd57be2a416"
+      },
+      "reference": {
+        "file": "law-go-271027-17184529-pdf.pdf",
+        "tier": "T1",
+        "source_page": "https://www.law.go.kr/LSW/lsInfoP.do?ancYnChk=0&lsiSeq=271027",
+        "source_url": "https://www.law.go.kr/LSW/flDownload.do?flSeq=151361903",
+        "sha256": "c074580f4546560fb69fd571e86fb5b0cf4ebc64f1bd24e02fb239065a2e779c",
+        "size_bytes": 37262,
+        "license": {
+          "code": "Copyright Act Article 7",
+          "evidence_url": "https://www.law.go.kr/lsLinkCommonInfo.do?lsJoLnkSeq=1029423769",
+          "observed_at": "2026-08-22",
+          "scope": "statutory-public-domain"
+        },
+        "product": "Hancom PDF",
+        "build": "Hancom PDF 1.3.0.546 (embedded Producer metadata)",
+        "os": "not disclosed by official publisher",
+        "font_fingerprint": "pdffonts-normalized-sha256:86e177498811327eef77e460e30a94d0acbc79d130b1cbdb9a13a06d048b05e7",
+        "note": "Official law.go.kr HWP/PDF attachment pair; pair_id=law-go-271027-17184529; association self-attested from the same source page"
+      }
+    },
+    {
+      "pair_id": "law-go-271027-17184531",
+      "source": {
+        "artifact_id": "law-go-271027-17184531-hwp5",
+        "file": "law-go-271027-17184531-hwp5.hwp",
+        "format": "hwp5",
+        "sha256": "af1bafe1f95778af9ad0c0cddb2240aea67c22ed69dbf2e0f09a83ea22045037"
+      },
+      "reference": {
+        "file": "law-go-271027-17184531-pdf.pdf",
+        "tier": "T1",
+        "source_page": "https://www.law.go.kr/LSW/lsInfoP.do?ancYnChk=0&lsiSeq=271027",
+        "source_url": "https://www.law.go.kr/LSW/flDownload.do?flSeq=151361909",
+        "sha256": "7f8db2f067134375bb2861f0a3c9bc15af4055e8be8ca5a8d0f61372e2ad8e96",
+        "size_bytes": 58144,
+        "license": {
+          "code": "Copyright Act Article 7",
+          "evidence_url": "https://www.law.go.kr/lsLinkCommonInfo.do?lsJoLnkSeq=1029423769",
+          "observed_at": "2026-08-22",
+          "scope": "statutory-public-domain"
+        },
+        "product": "Hancom PDF",
+        "build": "Hancom PDF 1.3.0.546 (embedded Producer metadata)",
+        "os": "not disclosed by official publisher",
+        "font_fingerprint": "pdffonts-normalized-sha256:2330281f509d4354d8db94aad485092994f98a686688919ee7733adfed3bdbcd",
+        "note": "Official law.go.kr HWP/PDF attachment pair; pair_id=law-go-271027-17184531; association self-attested from the same source page"
+      }
+    },
+    {
+      "pair_id": "law-go-271027-17184533",
+      "source": {
+        "artifact_id": "law-go-271027-17184533-hwp5",
+        "file": "law-go-271027-17184533-hwp5.hwp",
+        "format": "hwp5",
+        "sha256": "eb1f9a967a882c062fe17af6d9659fcc3f4e90318863ba43c3fdfebb6c733f48"
+      },
+      "reference": {
+        "file": "law-go-271027-17184533-pdf.pdf",
+        "tier": "T1",
+        "source_page": "https://www.law.go.kr/LSW/lsInfoP.do?ancYnChk=0&lsiSeq=271027",
+        "source_url": "https://www.law.go.kr/LSW/flDownload.do?flSeq=151361915",
+        "sha256": "54c12427c1f75348c9fb1af465f08f055d41d3013f8a6eefeedb91962ff6e4d9",
+        "size_bytes": 33473,
+        "license": {
+          "code": "Copyright Act Article 7",
+          "evidence_url": "https://www.law.go.kr/lsLinkCommonInfo.do?lsJoLnkSeq=1029423769",
+          "observed_at": "2026-08-22",
+          "scope": "statutory-public-domain"
+        },
+        "product": "Hancom PDF",
+        "build": "Hancom PDF 1.3.0.546 (embedded Producer metadata)",
+        "os": "not disclosed by official publisher",
+        "font_fingerprint": "pdffonts-normalized-sha256:d39284072dcc5a39d0482976e82570642708d1cd7c87a2a4f7385e37d4a979bc",
+        "note": "Official law.go.kr HWP/PDF attachment pair; pair_id=law-go-271027-17184533; association self-attested from the same source page"
+      }
+    },
+    {
+      "pair_id": "law-go-271027-17184535",
+      "source": {
+        "artifact_id": "law-go-271027-17184535-hwp5",
+        "file": "law-go-271027-17184535-hwp5.hwp",
+        "format": "hwp5",
+        "sha256": "470aaacd0079677d3b6387b9d92a2cf25042edce8928080fad1e6a344d1521ec"
+      },
+      "reference": {
+        "file": "law-go-271027-17184535-pdf.pdf",
+        "tier": "T1",
+        "source_page": "https://www.law.go.kr/LSW/lsInfoP.do?ancYnChk=0&lsiSeq=271027",
+        "source_url": "https://www.law.go.kr/LSW/flDownload.do?flSeq=151361921",
+        "sha256": "8c1b19ed6762affe7ea02e09ef684210654a6c17d899366c6f2584f41313fa1d",
+        "size_bytes": 45192,
+        "license": {
+          "code": "Copyright Act Article 7",
+          "evidence_url": "https://www.law.go.kr/lsLinkCommonInfo.do?lsJoLnkSeq=1029423769",
+          "observed_at": "2026-08-22",
+          "scope": "statutory-public-domain"
+        },
+        "product": "Hancom PDF",
+        "build": "Hancom PDF 1.3.0.546 (embedded Producer metadata)",
+        "os": "not disclosed by official publisher",
+        "font_fingerprint": "pdffonts-normalized-sha256:527eccb3bd34fc3e65fc129ffb1b295f8b81236a0766f3abe254902b4d090e0e",
+        "note": "Official law.go.kr HWP/PDF attachment pair; pair_id=law-go-271027-17184535; association self-attested from the same source page"
+      }
+    },
+    {
+      "pair_id": "law-go-271027-17184537",
+      "source": {
+        "artifact_id": "law-go-271027-17184537-hwp5",
+        "file": "law-go-271027-17184537-hwp5.hwp",
+        "format": "hwp5",
+        "sha256": "2a0fc6865d2494b3268954389a6ec958fb44b898a988fb80fd4b32423a48b075"
+      },
+      "reference": {
+        "file": "law-go-271027-17184537-pdf.pdf",
+        "tier": "T1",
+        "source_page": "https://www.law.go.kr/LSW/lsInfoP.do?ancYnChk=0&lsiSeq=271027",
+        "source_url": "https://www.law.go.kr/LSW/flDownload.do?flSeq=151361927",
+        "sha256": "c1d14d6adad73b0f248770187f1622dafd6e6e7b6d6b9e8ecb191d84c5a2a8cb",
+        "size_bytes": 49389,
+        "license": {
+          "code": "Copyright Act Article 7",
+          "evidence_url": "https://www.law.go.kr/lsLinkCommonInfo.do?lsJoLnkSeq=1029423769",
+          "observed_at": "2026-08-22",
+          "scope": "statutory-public-domain"
+        },
+        "product": "Hancom PDF",
+        "build": "Hancom PDF 1.3.0.546 (embedded Producer metadata)",
+        "os": "not disclosed by official publisher",
+        "font_fingerprint": "pdffonts-normalized-sha256:001deb3ce9d3b3acb49c7f81d09f39c4a9dedd35fcb3d868598a01d58ec3f8c4",
+        "note": "Official law.go.kr HWP/PDF attachment pair; pair_id=law-go-271027-17184537; association self-attested from the same source page"
+      }
+    }
+  ]
+}

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,6 +3,18 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
+- 갱신: 2026-08-23 · Codex(sol) — **#101 T1 PDF calibration 구현·재현 완료 · stacked PR 준비**.
+  #100 PR #136(`d803ab1`)은 MERGEABLE이고 필수 CI 3종 green이나 비사소 PR이라 사용자 병합
+  승인 대기다. 그 헤드 위 `codex/issue-101-pdf-calibration`에서 국가법령정보센터 공식 HWP5/PDF
+  20쌍을 T1 provenance·권리·SHA·Hancom PDF producer·OS disclosure·`pdffonts` 지문과 함께
+  metadata-only manifest로 고정했다. 자체 `export-pdf`→구조→144 DPI 비교 full run은 20/20
+  재현됐고 committed baseline과 byte-identical: scored 18건/19쪽, page-count structural mismatch
+  2건(`17184503`, `17184525`)은 pixel score 0건. HTML/PNG/바이너리는 private/ignored다.
+  새 validator/runner/4 tests, 기존 PDF 51 tests, `verify-local` quick가 PASS했고 canonical
+  8/18/24·98.9%+, 오라클 82건 무변경. **다음:** commit·push → #101 stacked PR(Closes #101,
+  base=#100 branch) → #136 사용자 승인 병합 → #101 base를 main으로 전환·CI → 사용자 병합 승인
+  → #102 PaintOp/SVG↔PDF parity.
+
 - 갱신: 2026-08-23 · Codex(sol) — **#100 구현·실수집 완료 · 커밋/PR 전 최종 diff 검수**.
   `codex/issue-100-public-corpus`에서 공식 HWP5 20건·HWPX 20건·같은 서식의 PDF pair
   10쌍(총 50)을 권리·privacy·접근성 재검토 후 `corpus/private/`에 수집했고, 재실행 50/50

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,12 @@
 
 ---
 
+## 2026-08-23 (Codex sol) · #101 T1 PDF calibration 구현 완료
+- 공식 HWP5/PDF 20쌍 manifest+baseline; 자체 PDF full run 20/20·baseline byte-identical.
+- 18건/19쪽 pixel report, page-count mismatch 2건은 score 없이 구조 단계에서 차단.
+- validator/runner/4 tests + PDF 51 tests + quick verify PASS; HTML/PNG/binary는 private.
+- 다음: stacked PR → #136 승인 병합 → #101 main retarget/CI/승인 → #102.
+
 ## 2026-08-23 (Codex sol) · #100 public corpus intake 구현 완료
 - HWP5 20·HWPX 20·공식 PDF pair 10쌍을 private 수집; SHA/구조 50/50·production open 40/40.
 - 공개에는 provenance·권리·privacy·SHA·magic·size·feature/pair만, 바이너리·본문·격리정보 0.

--- a/docs/PDF-VISUAL-ORACLE.md
+++ b/docs/PDF-VISUAL-ORACLE.md
@@ -10,6 +10,46 @@ non-standard JSON `NaN`/`Infinity` tokens.
 The existing stored-lineseg `layout-check` remains the fast layout regression gate. This visual report
 is additive and does not replace or relax it.
 
+## First T1 calibration (issue #101)
+
+The first committed calibration contract is split into two metadata-only files:
+
+- `corpus/pdf-calibration-manifest.json` pins 20 official law.go.kr HWP5/PDF attachment pairs,
+  their rights/provenance records, source/reference hashes, Hancom PDF producer metadata, normalized
+  `pdffonts` fingerprints, the own-engine font hash, 144 DPI, and the no-normalization policy.
+- `corpus/pdf-calibration-baseline.json` is the redacted machine-readable result produced at engine
+  commit `d803ab1f6540adb7b54ae60959d9923d4e534b2f`. It records 18 scored reports (19 pages) and two
+  page-count structural mismatches. It contains no pass field or aggregate quality threshold.
+
+The two structural mismatches are `law-go-271027-17184503` and
+`law-go-271027-17184525`: the official PDF has one page while the own engine exports two. Their
+pixel comparison is deliberately absent rather than represented as a low or zero score. Among the
+18 structurally comparable pairs, the results remain diagnostics: several worst tiles have zero
+recall and the worst-page ink/edge metrics show substantial fidelity work remains. Calibration does
+not turn those observations into a gate.
+
+The full side-by-side, overlay, and heatmap HTML/PNG reports stay under `corpus/private/` and are
+gitignored. Given a private flat directory containing the 20 HWP5 files and another containing the
+20 matching official PDFs, reproduce the whole HWP5 → own PDF → structural check → pixel report
+pipeline with:
+
+```bash
+cargo build -p auto-hwp-cli --features "pdf shaper rhwp"
+node scripts/pdf-visual-calibrate.mjs --run \
+  --source-root corpus/private/pdf-calibration/sources \
+  --reference-root corpus/private/pdf-calibration/references \
+  --output-dir corpus/private/pdf-calibration/run-001 \
+  --cli target/debug/auto-hwp
+```
+
+The output directory must not exist. The runner verifies every source/reference hash and byte count,
+recomputes each reference font fingerprint, exports candidates through `export-pdf`, and builds the
+entire result in a private staging directory before an atomic rename. A tool/input error removes only
+that unique staging directory. A structural mismatch remains a successful report-only observation.
+`node scripts/pdf-visual-calibrate.mjs --check` validates the committed manifest and baseline without
+network access or private binaries; CI runs this check alongside the existing Python resource-limit
+and self-compare determinism suite.
+
 ## Scope
 
 `scripts/pdf-visual-check.py` currently provides:

--- a/scripts/lib/pdf-calibration-manifest.mjs
+++ b/scripts/lib/pdf-calibration-manifest.mjs
@@ -1,0 +1,247 @@
+import { createHash } from "node:crypto";
+import { basename, isAbsolute, normalize, sep } from "node:path";
+
+const ROOT_KEYS = new Set(["schema_version", "policy", "pairs"]);
+const POLICY_KEYS = new Set(["mode", "quality_threshold", "minimum_trusted_pairs", "candidate_font", "raster"]);
+const CANDIDATE_FONT_KEYS = new Set(["file", "sha256"]);
+const RASTER_KEYS = new Set(["dpi", "max_translation_px", "scale", "crop", "rotation_degrees"]);
+const PAIR_KEYS = new Set(["pair_id", "source", "reference"]);
+const SOURCE_KEYS = new Set(["artifact_id", "file", "format", "sha256"]);
+const REFERENCE_KEYS = new Set([
+  "file", "tier", "source_page", "source_url", "sha256", "size_bytes", "license",
+  "product", "build", "os", "font_fingerprint", "note",
+]);
+const LICENSE_KEYS = new Set(["code", "evidence_url", "observed_at", "scope"]);
+const SHA256 = /^[0-9a-f]{64}$/;
+const SLUG = /^[a-z0-9]+(?:[-_][a-z0-9]+)*$/;
+
+function exactKeys(value, expected, path, errors) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    errors.push(`${path}: object required`);
+    return false;
+  }
+  for (const key of Object.keys(value)) if (!expected.has(key)) errors.push(`${path}: unknown field ${key}`);
+  for (const key of expected) if (!(key in value)) errors.push(`${path}: missing field ${key}`);
+  return true;
+}
+
+function nonempty(value) {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function safeRelativeFile(value, extension, path, errors) {
+  if (!nonempty(value) || isAbsolute(value) || basename(value) !== value || normalize(value).split(sep).includes("..") || !value.endsWith(extension)) {
+    errors.push(`${path}: safe ${extension} basename required`);
+  }
+}
+
+function officialHttps(value, path, errors) {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "https:" || url.username || url.password || url.hostname !== "www.law.go.kr") {
+      errors.push(`${path}: reviewed https://www.law.go.kr URL required`);
+    }
+  } catch {
+    errors.push(`${path}: valid URL required`);
+  }
+}
+
+function realDate(value) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(String(value ?? ""))) return false;
+  const [year, month, day] = value.split("-").map(Number);
+  const date = new Date(Date.UTC(year, month - 1, day));
+  return date.getUTCFullYear() === year && date.getUTCMonth() === month - 1 && date.getUTCDate() === day;
+}
+
+export function validatePdfCalibrationManifest(doc, publicCorpus = null) {
+  const errors = [];
+  if (!exactKeys(doc, ROOT_KEYS, "manifest", errors)) return errors;
+  if (doc.schema_version !== 1) errors.push("manifest.schema_version must be 1");
+
+  if (exactKeys(doc.policy, POLICY_KEYS, "manifest.policy", errors)) {
+    if (doc.policy.mode !== "report-only") errors.push("manifest.policy.mode must be report-only");
+    if (doc.policy.quality_threshold !== null) errors.push("manifest.policy.quality_threshold must remain null during calibration");
+    if (doc.policy.minimum_trusted_pairs !== 20) errors.push("manifest.policy.minimum_trusted_pairs must be 20");
+    if (exactKeys(doc.policy.candidate_font, CANDIDATE_FONT_KEYS, "manifest.policy.candidate_font", errors)) {
+      const font = doc.policy.candidate_font;
+      if (!nonempty(font.file) || isAbsolute(font.file) || normalize(font.file).split(sep).includes("..")) errors.push("manifest.policy.candidate_font.file: safe repository-relative path required");
+      if (!SHA256.test(String(font.sha256 ?? ""))) errors.push("manifest.policy.candidate_font.sha256: lowercase SHA-256 required");
+    }
+    if (exactKeys(doc.policy.raster, RASTER_KEYS, "manifest.policy.raster", errors)) {
+      const raster = doc.policy.raster;
+      if (raster.dpi !== 144 || raster.max_translation_px !== 3 || raster.scale !== 1 || raster.crop !== false || raster.rotation_degrees !== 0) {
+        errors.push("manifest.policy.raster must pin 144 DPI, ±3px translation, scale=1, crop=false, rotation=0");
+      }
+    }
+  }
+
+  if (!Array.isArray(doc.pairs)) {
+    errors.push("manifest.pairs must be an array");
+    return errors;
+  }
+  if (doc.pairs.length !== 20) errors.push(`manifest.pairs must contain exactly 20 trusted pairs (got ${doc.pairs.length})`);
+
+  const publicArtifacts = new Map(publicCorpus?.artifacts?.map((artifact) => [artifact.id, artifact]) ?? []);
+  const ids = new Set();
+  const sourceHashes = new Set();
+  const referenceHashes = new Set();
+  const referenceUrls = new Set();
+  let previousPairId = "";
+
+  for (const [index, pair] of doc.pairs.entries()) {
+    const path = `manifest.pairs[${index}]`;
+    if (!exactKeys(pair, PAIR_KEYS, path, errors)) continue;
+    if (!SLUG.test(String(pair.pair_id ?? ""))) errors.push(`${path}.pair_id: lowercase slug required`);
+    if (pair.pair_id <= previousPairId) errors.push(`${path}.pair_id: pairs must be strictly sorted`);
+    previousPairId = pair.pair_id;
+    if (ids.has(pair.pair_id)) errors.push(`${path}.pair_id: duplicate`);
+    ids.add(pair.pair_id);
+
+    if (exactKeys(pair.source, SOURCE_KEYS, `${path}.source`, errors)) {
+      if (pair.source.artifact_id !== `${pair.pair_id}-hwp5`) errors.push(`${path}.source.artifact_id: must match pair_id`);
+      safeRelativeFile(pair.source.file, ".hwp", `${path}.source.file`, errors);
+      if (pair.source.format !== "hwp5") errors.push(`${path}.source.format must be hwp5`);
+      if (!SHA256.test(String(pair.source.sha256 ?? ""))) errors.push(`${path}.source.sha256: lowercase SHA-256 required`);
+      if (sourceHashes.has(pair.source.sha256)) errors.push(`${path}.source.sha256: duplicate`);
+      sourceHashes.add(pair.source.sha256);
+
+      const artifact = publicArtifacts.get(pair.source.artifact_id);
+      if (publicCorpus && !artifact) errors.push(`${path}.source.artifact_id: missing from public corpus manifest`);
+      if (artifact && (artifact.file !== pair.source.file || artifact.format !== pair.source.format || artifact.sha256 !== pair.source.sha256 || artifact.pair_id !== pair.pair_id)) {
+        errors.push(`${path}.source: does not match public corpus artifact`);
+      }
+    }
+
+    if (exactKeys(pair.reference, REFERENCE_KEYS, `${path}.reference`, errors)) {
+      const reference = pair.reference;
+      if (reference.file !== `${pair.pair_id}-pdf.pdf`) errors.push(`${path}.reference.file: must match pair_id`);
+      safeRelativeFile(reference.file, ".pdf", `${path}.reference.file`, errors);
+      if (!new Set(["T0", "T1"]).has(reference.tier)) errors.push(`${path}.reference.tier: T0 or T1 required`);
+      officialHttps(reference.source_page, `${path}.reference.source_page`, errors);
+      officialHttps(reference.source_url, `${path}.reference.source_url`, errors);
+      if (referenceUrls.has(reference.source_url)) errors.push(`${path}.reference.source_url: duplicate`);
+      referenceUrls.add(reference.source_url);
+      if (!SHA256.test(String(reference.sha256 ?? ""))) errors.push(`${path}.reference.sha256: lowercase SHA-256 required`);
+      if (referenceHashes.has(reference.sha256)) errors.push(`${path}.reference.sha256: duplicate`);
+      referenceHashes.add(reference.sha256);
+      if (!Number.isSafeInteger(reference.size_bytes) || reference.size_bytes < 1 || reference.size_bytes > 64 * 1024 * 1024) errors.push(`${path}.reference.size_bytes: 1..67108864 required`);
+      for (const field of ["product", "build", "os", "font_fingerprint", "note"]) {
+        if (!nonempty(reference[field])) errors.push(`${path}.reference.${field}: explicit provenance required`);
+      }
+      if (!/^pdffonts-normalized-sha256:[0-9a-f]{64}$/.test(String(reference.font_fingerprint ?? ""))) errors.push(`${path}.reference.font_fingerprint: normalized pdffonts SHA-256 required`);
+      if (!reference.note.includes(pair.pair_id) || !reference.note.includes("self-attested")) errors.push(`${path}.reference.note: pair_id and self-attested association required`);
+      if (exactKeys(reference.license, LICENSE_KEYS, `${path}.reference.license`, errors)) {
+        if (!nonempty(reference.license.code)) errors.push(`${path}.reference.license.code required`);
+        officialHttps(reference.license.evidence_url, `${path}.reference.license.evidence_url`, errors);
+        if (!realDate(reference.license.observed_at)) errors.push(`${path}.reference.license.observed_at: real date required`);
+        if (reference.license.scope !== "statutory-public-domain") errors.push(`${path}.reference.license.scope must be statutory-public-domain`);
+      }
+
+      const artifact = publicArtifacts.get(pair.source?.artifact_id);
+      if (artifact && artifact.source_page !== reference.source_page) errors.push(`${path}: HWP and PDF source_page must match`);
+    }
+  }
+  return errors;
+}
+
+export function loadPdfCalibrationManifest(jsonText, publicCorpus = null) {
+  const doc = JSON.parse(jsonText);
+  const errors = validatePdfCalibrationManifest(doc, publicCorpus);
+  if (errors.length) throw new Error(`PDF calibration manifest invalid:\n- ${errors.join("\n- ")}`);
+  return doc;
+}
+
+export function sha256Bytes(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+const BASELINE_ROOT_KEYS = new Set(["schema_version", "manifest_sha256", "calibration", "environment", "counts", "pairs"]);
+const BASELINE_CALIBRATION_KEYS = new Set(["engine_commit", "cli_features", "observed_at", "mode", "quality_threshold"]);
+const BASELINE_ENVIRONMENT_KEYS = new Set([
+  "pdfinfo", "pdftoppm", "platform_system", "platform_release", "platform_machine",
+  "python_implementation", "python_version", "dpi", "candidate_font_fingerprint", "alignment",
+]);
+const BASELINE_ALIGNMENT_KEYS = new Set(["max_abs_translation_px", "scale", "crop", "rotation_degrees"]);
+const BASELINE_COUNT_KEYS = new Set(["trusted_pairs", "scored_reports", "structural_mismatches", "scored_pages"]);
+const BASELINE_PAIR_KEYS = new Set([
+  "pair_id", "status", "source_sha256", "reference_sha256", "candidate_sha256",
+  "reference_page_count", "candidate_page_count", "structural_mismatches", "scored_pages",
+  "worst_page", "worst_tile",
+]);
+const WORST_PAGE_KEYS = new Set([
+  "page", "global_ssim_like", "local_ssim_like_mean", "ink_f1", "edge_f1", "worst_tile_recall",
+]);
+
+function finiteUnitInterval(value) {
+  return typeof value === "number" && Number.isFinite(value) && value >= -1 && value <= 1;
+}
+
+export function validatePdfCalibrationBaseline(doc, manifest, manifestSha256) {
+  const errors = [];
+  if (!exactKeys(doc, BASELINE_ROOT_KEYS, "baseline", errors)) return errors;
+  if (doc.schema_version !== 1) errors.push("baseline.schema_version must be 1");
+  if (doc.manifest_sha256 !== manifestSha256) errors.push("baseline.manifest_sha256 does not match the committed manifest bytes");
+  if (exactKeys(doc.calibration, BASELINE_CALIBRATION_KEYS, "baseline.calibration", errors)) {
+    if (!/^[0-9a-f]{7,40}$/.test(String(doc.calibration.engine_commit ?? ""))) errors.push("baseline.calibration.engine_commit: git SHA required");
+    if (JSON.stringify(doc.calibration.cli_features) !== JSON.stringify(["pdf", "rhwp", "shaper"])) errors.push("baseline.calibration.cli_features must pin pdf/rhwp/shaper");
+    if (!realDate(doc.calibration.observed_at)) errors.push("baseline.calibration.observed_at: real date required");
+    if (doc.calibration.mode !== "report-only" || doc.calibration.quality_threshold !== null) errors.push("baseline.calibration must remain report-only with null threshold");
+  }
+  if (exactKeys(doc.environment, BASELINE_ENVIRONMENT_KEYS, "baseline.environment", errors)) {
+    for (const field of ["pdfinfo", "pdftoppm", "platform_system", "platform_release", "platform_machine", "python_implementation", "python_version"]) {
+      if (!nonempty(doc.environment[field])) errors.push(`baseline.environment.${field} required`);
+    }
+    if (doc.environment.dpi !== manifest.policy.raster.dpi) errors.push("baseline.environment.dpi: manifest mismatch");
+    if (doc.environment.candidate_font_fingerprint !== `sha256:${manifest.policy.candidate_font.sha256}`) errors.push("baseline.environment.candidate_font_fingerprint: manifest mismatch");
+    if (exactKeys(doc.environment.alignment, BASELINE_ALIGNMENT_KEYS, "baseline.environment.alignment", errors)) {
+      const alignment = doc.environment.alignment;
+      if (alignment.max_abs_translation_px !== 3 || alignment.scale !== 1 || alignment.crop !== false || alignment.rotation_degrees !== 0) errors.push("baseline.environment.alignment: forbidden normalization or unbounded translation");
+    }
+  }
+  if (exactKeys(doc.counts, BASELINE_COUNT_KEYS, "baseline.counts", errors)) {
+    for (const key of BASELINE_COUNT_KEYS) if (!Number.isSafeInteger(doc.counts[key]) || doc.counts[key] < 0) errors.push(`baseline.counts.${key}: nonnegative integer required`);
+  }
+  if (!Array.isArray(doc.pairs) || doc.pairs.length !== 20) {
+    errors.push("baseline.pairs must contain exactly 20 entries");
+    return errors;
+  }
+  const manifestPairs = new Map(manifest.pairs.map((pair) => [pair.pair_id, pair]));
+  let scoredReports = 0;
+  let structuralMismatches = 0;
+  let scoredPages = 0;
+  let previousPairId = "";
+  for (const [index, pair] of doc.pairs.entries()) {
+    const path = `baseline.pairs[${index}]`;
+    if (!exactKeys(pair, BASELINE_PAIR_KEYS, path, errors)) continue;
+    if (pair.pair_id <= previousPairId) errors.push(`${path}.pair_id: pairs must be strictly sorted`);
+    previousPairId = pair.pair_id;
+    const contract = manifestPairs.get(pair.pair_id);
+    if (!contract) errors.push(`${path}.pair_id: absent from manifest`);
+    else if (pair.source_sha256 !== contract.source.sha256 || pair.reference_sha256 !== contract.reference.sha256) errors.push(`${path}: source/reference hash mismatch`);
+    if (!SHA256.test(String(pair.candidate_sha256 ?? ""))) errors.push(`${path}.candidate_sha256: lowercase SHA-256 required`);
+    if (!new Set(["scored_report", "structural_mismatch"]).has(pair.status)) errors.push(`${path}.status: scored_report or structural_mismatch required`);
+    for (const field of ["reference_page_count", "candidate_page_count", "scored_pages"]) if (!Number.isSafeInteger(pair[field]) || pair[field] < 0) errors.push(`${path}.${field}: nonnegative integer required`);
+    if (!Array.isArray(pair.structural_mismatches)) errors.push(`${path}.structural_mismatches: array required`);
+    if (pair.status === "structural_mismatch") {
+      structuralMismatches++;
+      if (pair.scored_pages !== 0 || pair.worst_page !== null || pair.worst_tile !== null || pair.structural_mismatches.length === 0) errors.push(`${path}: structural mismatch must not carry pixel scores`);
+    } else {
+      scoredReports++;
+      if (pair.structural_mismatches.length !== 0 || pair.scored_pages < 1 || !pair.worst_page || !pair.worst_tile) errors.push(`${path}: scored report requires pixel diagnostics and no structural mismatch`);
+      if (pair.worst_page && exactKeys(pair.worst_page, WORST_PAGE_KEYS, `${path}.worst_page`, errors)) {
+        for (const metric of ["global_ssim_like", "local_ssim_like_mean", "ink_f1", "edge_f1"]) if (!finiteUnitInterval(pair.worst_page[metric])) errors.push(`${path}.worst_page.${metric}: finite normalized metric required`);
+        if (pair.worst_page.worst_tile_recall !== null && !finiteUnitInterval(pair.worst_page.worst_tile_recall)) errors.push(`${path}.worst_page.worst_tile_recall: null or finite normalized metric required`);
+      }
+    }
+    scoredPages += pair.scored_pages;
+  }
+  if (doc.counts?.trusted_pairs !== doc.pairs.length || doc.counts?.scored_reports !== scoredReports || doc.counts?.structural_mismatches !== structuralMismatches || doc.counts?.scored_pages !== scoredPages) errors.push("baseline.counts do not match pair records");
+  return errors;
+}
+
+export function loadPdfCalibrationBaseline(jsonText, manifest, manifestSha256) {
+  const doc = JSON.parse(jsonText);
+  const errors = validatePdfCalibrationBaseline(doc, manifest, manifestSha256);
+  if (errors.length) throw new Error(`PDF calibration baseline invalid:\n- ${errors.join("\n- ")}`);
+  return doc;
+}

--- a/scripts/pdf-visual-calibrate.mjs
+++ b/scripts/pdf-visual-calibrate.mjs
@@ -1,0 +1,254 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import {
+  chmodSync, existsSync, lstatSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync,
+} from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  loadPdfCalibrationBaseline, loadPdfCalibrationManifest, sha256Bytes,
+} from "./lib/pdf-calibration-manifest.mjs";
+import { loadPublicCorpusManifest } from "./lib/public-corpus-manifest.mjs";
+
+const repo = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const defaultManifestPath = join(repo, "corpus/pdf-calibration-manifest.json");
+const defaultPublicManifestPath = join(repo, "corpus/public-corpus-manifest.json");
+const defaultBaselinePath = join(repo, "corpus/pdf-calibration-baseline.json");
+
+function usage() {
+  return `Usage:
+  node scripts/pdf-visual-calibrate.mjs --check
+  node scripts/pdf-visual-calibrate.mjs --summarize-reports DIR --output FILE --engine-commit SHA
+  node scripts/pdf-visual-calibrate.mjs --run --source-root DIR --reference-root DIR --output-dir DIR --cli FILE [--python FILE]
+
+The run mode exports every HWP5 candidate through auto-hwp's own PDF path, then invokes the
+report-only visual oracle. Inputs and full HTML/PNG reports stay in gitignored private directories.`;
+}
+
+function parseArgs(argv) {
+  const args = { python: "python3", manifest: defaultManifestPath, publicManifest: defaultPublicManifestPath };
+  for (let index = 0; index < argv.length; index++) {
+    const arg = argv[index];
+    if (["--check", "--run"].includes(arg)) args[arg.slice(2).replaceAll("-", "_")] = true;
+    else if (arg === "--help" || arg === "-h") args.help = true;
+    else if (arg.startsWith("--")) {
+      const value = argv[++index];
+      if (!value || value.startsWith("--")) throw new Error(`${arg} requires a value`);
+      args[arg.slice(2).replaceAll("-", "_")] = value;
+    } else throw new Error(`unexpected argument: ${arg}`);
+  }
+  return args;
+}
+
+function loadManifests(args) {
+  const publicCorpus = loadPublicCorpusManifest(readFileSync(args.publicManifest, "utf8"));
+  const manifestBytes = readFileSync(args.manifest);
+  return {
+    manifest: loadPdfCalibrationManifest(manifestBytes.toString("utf8"), publicCorpus),
+    manifestSha256: sha256Bytes(manifestBytes),
+  };
+}
+
+function regularFile(path, label) {
+  const stat = lstatSync(path);
+  if (!stat.isFile() || stat.isSymbolicLink()) throw new Error(`${label}: regular non-symlink file required: ${path}`);
+  return stat;
+}
+
+function verifyFile(path, expectedSha256, expectedBytes, label) {
+  const stat = regularFile(path, label);
+  if (expectedBytes !== undefined && stat.size !== expectedBytes) throw new Error(`${label}: byte-size mismatch`);
+  const actual = sha256Bytes(readFileSync(path));
+  if (actual !== expectedSha256) throw new Error(`${label}: SHA-256 mismatch`);
+}
+
+function command(command, args, { cwd = repo, timeout = 120_000 } = {}) {
+  const result = spawnSync(command, args, { cwd, encoding: "utf8", maxBuffer: 2 * 1024 * 1024, timeout });
+  if (result.error) throw new Error(`${command}: ${result.error.message}`);
+  if (result.status !== 0) {
+    const detail = `${result.stdout ?? ""}\n${result.stderr ?? ""}`.trim().slice(0, 8_000);
+    throw new Error(`${command} exited ${result.status}${detail ? `:\n${detail}` : ""}`);
+  }
+  return { stdout: result.stdout ?? "", stderr: result.stderr ?? "" };
+}
+
+function normalizedPdffontsFingerprint(path) {
+  const { stdout } = command("pdffonts", [path], { timeout: 30_000 });
+  const normalized = stdout.split(/\r?\n/u).slice(2).filter((line) => line.trim()).sort().join("\n");
+  return `pdffonts-normalized-sha256:${sha256Bytes(Buffer.from(`${normalized}\n`))}`;
+}
+
+function reportPairSummary(pair, report) {
+  const worst = report.summary.worst_pages[0] ?? null;
+  const worstPage = worst ? report.pages.find((page) => page.page === worst.page) : null;
+  return {
+    pair_id: pair.pair_id,
+    status: report.status,
+    source_sha256: pair.source.sha256,
+    reference_sha256: report.inputs.reference.sha256,
+    candidate_sha256: report.inputs.candidate.sha256,
+    reference_page_count: report.structural.reference.page_count,
+    candidate_page_count: report.structural.candidate.page_count,
+    structural_mismatches: report.structural.mismatches,
+    scored_pages: report.summary.scored_pages,
+    worst_page: worstPage ? {
+      page: worstPage.page,
+      global_ssim_like: worstPage.metrics.ssim_like.global,
+      local_ssim_like_mean: worstPage.metrics.ssim_like.local.mean,
+      ink_f1: worstPage.metrics.ink.f1,
+      edge_f1: worstPage.metrics.edge.f1,
+      worst_tile_recall: worstPage.metrics.worst_tile_recall?.recall ?? null,
+    } : null,
+    worst_tile: report.summary.worst_tiles[0] ?? null,
+  };
+}
+
+export function buildCalibrationSummary(manifest, manifestSha256, reports, engineCommit) {
+  if (!/^[0-9a-f]{7,40}$/.test(engineCommit)) throw new Error("engine commit must be a 7..40 character lowercase git SHA");
+  if (reports.length !== manifest.pairs.length) throw new Error("one report per manifest pair required");
+  const first = reports[0]?.report;
+  const pairs = reports.map(({ pair, report }) => reportPairSummary(pair, report));
+  const counts = {
+    trusted_pairs: pairs.length,
+    scored_reports: pairs.filter((pair) => pair.status === "scored_report").length,
+    structural_mismatches: pairs.filter((pair) => pair.status === "structural_mismatch").length,
+    scored_pages: pairs.reduce((sum, pair) => sum + pair.scored_pages, 0),
+  };
+  return {
+    schema_version: 1,
+    manifest_sha256: manifestSha256,
+    calibration: {
+      engine_commit: engineCommit,
+      cli_features: ["pdf", "rhwp", "shaper"],
+      observed_at: "2026-08-22",
+      mode: "report-only",
+      quality_threshold: null,
+    },
+    environment: {
+      pdfinfo: first.environment.pdfinfo,
+      pdftoppm: first.environment.pdftoppm,
+      platform_system: first.environment.platform_system,
+      platform_release: first.environment.platform_release,
+      platform_machine: first.environment.platform_machine,
+      python_implementation: first.environment.python_implementation,
+      python_version: first.environment.python_version,
+      dpi: first.environment.dpi,
+      candidate_font_fingerprint: first.environment.candidate_font_fingerprint,
+      alignment: {
+        max_abs_translation_px: first.alignment_policy.max_abs_translation_px,
+        scale: first.alignment_policy.scale,
+        crop: first.alignment_policy.crop,
+        rotation_degrees: first.alignment_policy.rotation_degrees,
+      },
+    },
+    counts,
+    pairs,
+  };
+}
+
+function loadReports(manifest, reportsRoot) {
+  return manifest.pairs.map((pair) => {
+    const report = JSON.parse(readFileSync(join(reportsRoot, pair.pair_id, "report.json"), "utf8"));
+    if (report.policy?.mode !== "report-only" || report.policy?.pass !== null) throw new Error(`${pair.pair_id}: report-only contract violated`);
+    if (report.inputs?.reference?.tier !== pair.reference.tier) throw new Error(`${pair.pair_id}: reference tier mismatch`);
+    if (report.inputs?.reference?.sha256 !== pair.reference.sha256) throw new Error(`${pair.pair_id}: reference hash mismatch`);
+    if (report.inputs?.reference?.font_fingerprint !== pair.reference.font_fingerprint) throw new Error(`${pair.pair_id}: reference font fingerprint mismatch`);
+    return { pair, report };
+  });
+}
+
+function summaryHtml(summary) {
+  const rows = summary.pairs.map((pair) => {
+    const worst = pair.worst_page;
+    const metrics = worst ? `ink F1 ${worst.ink_f1 ?? "—"}; edge/local details in report` : "pixel comparison blocked";
+    return `<tr><td><a href="reports/${pair.pair_id}/index.html">${pair.pair_id}</a></td><td>${pair.status}</td><td>${pair.reference_page_count}</td><td>${pair.candidate_page_count}</td><td>${metrics}</td></tr>`;
+  }).join("\n");
+  return `<!doctype html><html lang="en"><meta charset="utf-8"><title>auto-hwp PDF calibration</title><style>body{font:14px system-ui;margin:2rem}table{border-collapse:collapse}th,td{border:1px solid #bbb;padding:.45rem;text-align:left}code{font-size:12px}</style><h1>PDF visual calibration — report only</h1><p>No pass/fail threshold is defined. Structural mismatches never receive pixel scores.</p><p><code>${summary.calibration.engine_commit}</code> · ${summary.counts.trusted_pairs} T0/T1 pairs · ${summary.counts.scored_reports} scored · ${summary.counts.structural_mismatches} structural mismatches</p><table><thead><tr><th>pair</th><th>status</th><th>reference pages</th><th>candidate pages</th><th>diagnostic</th></tr></thead><tbody>${rows}</tbody></table></html>\n`;
+}
+
+function summarizeExisting(args, manifest, manifestSha256) {
+  if (!args.output || !args.engine_commit) throw new Error("--summarize-reports requires --output and --engine-commit");
+  if (existsSync(args.output)) throw new Error(`refusing to overwrite ${args.output}`);
+  const summary = buildCalibrationSummary(manifest, manifestSha256, loadReports(manifest, resolve(args.summarize_reports)), args.engine_commit);
+  writeFileSync(args.output, `${JSON.stringify(summary, null, 2)}\n`, { mode: 0o600, flag: "wx" });
+  console.log(`wrote ${args.output}: ${summary.counts.trusted_pairs} trusted pairs, ${summary.counts.structural_mismatches} structural mismatches`);
+}
+
+function runCalibration(args, manifest, manifestSha256) {
+  for (const required of ["source_root", "reference_root", "output_dir", "cli"]) if (!args[required]) throw new Error(`--run requires --${required.replaceAll("_", "-")}`);
+  const sourceRoot = resolve(args.source_root);
+  const referenceRoot = resolve(args.reference_root);
+  const outputDir = resolve(args.output_dir);
+  const cli = resolve(args.cli);
+  regularFile(cli, "auto-hwp CLI");
+  verifyFile(join(repo, manifest.policy.candidate_font.file), manifest.policy.candidate_font.sha256, undefined, "candidate font");
+  if (existsSync(outputDir)) throw new Error(`refusing to overwrite output directory: ${outputDir}`);
+  mkdirSync(dirname(outputDir), { recursive: true, mode: 0o700 });
+  const stage = `${outputDir}.stage-${process.pid}-${randomBytes(5).toString("hex")}`;
+  mkdirSync(stage, { mode: 0o700 });
+  mkdirSync(join(stage, "candidates"), { mode: 0o700 });
+  mkdirSync(join(stage, "reports"), { mode: 0o700 });
+  try {
+    for (const [index, pair] of manifest.pairs.entries()) {
+      const source = join(sourceRoot, pair.source.file);
+      const reference = join(referenceRoot, pair.reference.file);
+      verifyFile(source, pair.source.sha256, undefined, `${pair.pair_id} source`);
+      verifyFile(reference, pair.reference.sha256, pair.reference.size_bytes, `${pair.pair_id} reference`);
+      const fingerprint = normalizedPdffontsFingerprint(reference);
+      if (fingerprint !== pair.reference.font_fingerprint) throw new Error(`${pair.pair_id}: pdffonts fingerprint mismatch`);
+      const candidate = join(stage, "candidates", `${pair.pair_id}-own.pdf`);
+      command(cli, ["export-pdf", source, "-o", candidate], { timeout: 180_000 });
+      command(args.python, [
+        join(repo, "scripts/pdf-visual-check.py"), candidate,
+        "--reference", reference,
+        "--reference-tier", pair.reference.tier,
+        "--reference-product", pair.reference.product,
+        "--reference-build", pair.reference.build,
+        "--reference-os", pair.reference.os,
+        "--font-fingerprint", pair.reference.font_fingerprint,
+        "--candidate-font-fingerprint", `sha256:${manifest.policy.candidate_font.sha256}`,
+        "--reference-note", pair.reference.note,
+        "--max-translation-px", String(manifest.policy.raster.max_translation_px),
+        "--output-dir", join(stage, "reports", pair.pair_id),
+      ], { timeout: 180_000 });
+      console.log(`[${index + 1}/${manifest.pairs.length}] ${pair.pair_id}`);
+    }
+    const reports = loadReports(manifest, join(stage, "reports"));
+    const engineCommit = command("git", ["rev-parse", "HEAD"]).stdout.trim();
+    const summary = buildCalibrationSummary(manifest, manifestSha256, reports, engineCommit);
+    writeFileSync(join(stage, "summary.json"), `${JSON.stringify(summary, null, 2)}\n`, { mode: 0o600 });
+    writeFileSync(join(stage, "index.html"), summaryHtml(summary), { mode: 0o600 });
+    chmodSync(stage, 0o700);
+    renameSync(stage, outputDir);
+    console.log(`report-only calibration: ${summary.counts.scored_reports} scored, ${summary.counts.structural_mismatches} structural mismatches`);
+    console.log(`HTML: ${join(outputDir, "index.html")}`);
+  } catch (error) {
+    rmSync(stage, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+if (resolve(process.argv[1] ?? "") === fileURLToPath(import.meta.url)) {
+  try {
+    const args = parseArgs(process.argv.slice(2));
+    if (args.help) {
+      console.log(usage());
+      process.exit(0);
+    }
+    const { manifest, manifestSha256 } = loadManifests(args);
+    if (args.check) {
+      const baseline = loadPdfCalibrationBaseline(readFileSync(defaultBaselinePath, "utf8"), manifest, manifestSha256);
+      console.log(`PDF calibration baseline OK: ${manifest.pairs.length} T0/T1 pairs; ${baseline.counts.scored_reports} scored; ${baseline.counts.structural_mismatches} structural mismatches; report-only; threshold=null`);
+    } else if (args.summarize_reports) {
+      summarizeExisting(args, manifest, manifestSha256);
+    } else if (args.run) {
+      runCalibration(args, manifest, manifestSha256);
+    } else {
+      throw new Error(usage());
+    }
+  } catch (error) {
+    console.error(`pdf-visual-calibrate: ${error.message}`);
+    process.exit(1);
+  }
+}

--- a/scripts/tests/pdf-calibration.test.mjs
+++ b/scripts/tests/pdf-calibration.test.mjs
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  loadPdfCalibrationBaseline, loadPdfCalibrationManifest, sha256Bytes,
+  validatePdfCalibrationBaseline, validatePdfCalibrationManifest,
+} from "../lib/pdf-calibration-manifest.mjs";
+
+const repo = join(dirname(fileURLToPath(import.meta.url)), "../..");
+const publicCorpus = JSON.parse(readFileSync(join(repo, "corpus/public-corpus-manifest.json"), "utf8"));
+const manifestBytes = readFileSync(join(repo, "corpus/pdf-calibration-manifest.json"));
+const manifestSha256 = sha256Bytes(manifestBytes);
+const manifest = loadPdfCalibrationManifest(manifestBytes.toString("utf8"), publicCorpus);
+const baselineText = readFileSync(join(repo, "corpus/pdf-calibration-baseline.json"), "utf8");
+
+test("committed PDF calibration has 20 explicit T1 pairs and remains report-only", () => {
+  assert.equal(manifest.pairs.length, 20);
+  assert.ok(manifest.pairs.every((pair) => pair.reference.tier === "T1"));
+  assert.equal(manifest.policy.quality_threshold, null);
+  assert.deepEqual(manifest.policy.raster, {
+    dpi: 144,
+    max_translation_px: 3,
+    scale: 1,
+    crop: false,
+    rotation_degrees: 0,
+  });
+});
+
+test("committed baseline records 18 pixel reports and blocks 2 structural mismatches", () => {
+  const baseline = loadPdfCalibrationBaseline(baselineText, manifest, manifestSha256);
+  assert.deepEqual(baseline.counts, {
+    trusted_pairs: 20,
+    scored_reports: 18,
+    structural_mismatches: 2,
+    scored_pages: 19,
+  });
+  for (const pair of baseline.pairs) {
+    if (pair.status === "structural_mismatch") {
+      assert.equal(pair.scored_pages, 0);
+      assert.equal(pair.worst_page, null);
+      assert.equal(pair.worst_tile, null);
+    } else {
+      assert.deepEqual(Object.keys(pair.worst_page).sort(), [
+        "edge_f1", "global_ssim_like", "ink_f1", "local_ssim_like_mean", "page", "worst_tile_recall",
+      ]);
+    }
+  }
+});
+
+test("calibration manifest rejects authority, normalization, path, hash, and schema downgrades", () => {
+  const mutations = [
+    (doc) => { doc.policy.quality_threshold = 0.8; },
+    (doc) => { doc.policy.raster.scale = 0.95; },
+    (doc) => { doc.pairs[0].reference.tier = "T3"; },
+    (doc) => { doc.pairs[0].reference.file = "../private.pdf"; },
+    (doc) => { doc.pairs[0].reference.font_fingerprint = "unknown"; },
+    (doc) => { doc.pairs[0].source.sha256 = "A".repeat(64); },
+    (doc) => { doc.pairs[0].private_path = "/tmp/leak"; },
+  ];
+  for (const mutate of mutations) {
+    const doc = structuredClone(manifest);
+    mutate(doc);
+    assert.notEqual(validatePdfCalibrationManifest(doc, publicCorpus).length, 0);
+  }
+});
+
+test("calibration baseline rejects thresholds, fabricated scores, count drift, and hash drift", () => {
+  const source = JSON.parse(baselineText);
+  const structuralIndex = source.pairs.findIndex((pair) => pair.status === "structural_mismatch");
+  const mutations = [
+    (doc) => { doc.calibration.quality_threshold = 0.5; },
+    (doc) => { doc.manifest_sha256 = "0".repeat(64); },
+    (doc) => { doc.counts.scored_reports++; },
+    (doc) => { doc.pairs[0].candidate_sha256 = "A".repeat(64); },
+    (doc) => { doc.pairs[structuralIndex].worst_page = { page: 1 }; },
+    (doc) => { doc.pass = true; },
+  ];
+  for (const mutate of mutations) {
+    const doc = structuredClone(source);
+    mutate(doc);
+    assert.notEqual(validatePdfCalibrationBaseline(doc, manifest, manifestSha256).length, 0);
+  }
+});

--- a/scripts/verify-local.sh
+++ b/scripts/verify-local.sh
@@ -47,9 +47,11 @@ node --test \
   scripts/tests/fetch-gov-corpus.test.mjs \
   scripts/tests/gov-source-catalog.test.mjs \
   scripts/tests/public-corpus-manifest.test.mjs \
+  scripts/tests/pdf-calibration.test.mjs \
   scripts/tests/safe-document-download.test.mjs
 node scripts/gov-source-catalog.mjs --check
 node scripts/public-corpus-intake.mjs --check
+node scripts/pdf-visual-calibrate.mjs --check
 
 echo "═══ 조판 오라클 스윕 산출물 (이슈 72 — 전수 재실행 아님 · 커밋된 요약만) ═══"
 # 코퍼스 전수 layout-check 는 로컬 `node scripts/oracle-sweep.mjs` (--check 가 회귀).


### PR DESCRIPTION
Closes #101

Depends on #136. Merge #136 first, then retarget this PR to main and rerun required CI.

Summary:
- pin metadata-only provenance for 20 official law.go.kr HWP5/PDF T1 pairs
- reproduce own export-pdf to structure-first 144 DPI reports with no scale/crop normalization
- commit a redacted report-only baseline: 18 scored reports / 19 pages and 2 page-count structural mismatches with no pixel score
- keep HWP/PDF binaries and full HTML/PNG diagnostics under ignored private storage
- add strict manifest/baseline validators, deterministic runner, CI contract tests, and documentation

Verification:
- end-to-end private run 20/20; generated summary byte-identical to committed baseline
- node contract tests 76/76
- PDF visual oracle Python tests 51/51
- scripts/verify-local.sh quick PASS
- canonical layout gate unchanged: 8/18/24 pages and 98.9%+ line accuracy
- committed 82-document lineseg oracle unchanged