### PR TITLE
fix: replay equation and chart SVG in PDF

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,9 @@ jobs:
             libxdo-dev \
             libssl-dev \
             libayatana-appindicator3-dev \
-            librsvg2-dev
+            librsvg2-dev \
+            librsvg2-bin \
+            poppler-utils
       - uses: dtolnay/rust-toolchain@1.95
         with:
           components: rustfmt, clippy
@@ -97,6 +99,8 @@ jobs:
             | node scripts/canonical-layout-gate.mjs
       - name: PDF visual oracle foundation (issue 121)
         run: python3 -m unittest discover -s scripts/tests -p 'test_pdf_visual_check.py'
+      - name: SVG sink to PDF sink vector parity (issue 102)
+        run: python3 scripts/pdf-svg-parity-check.py --output-dir "$RUNNER_TEMP/pdf-svg-parity"
       - name: desktop adapter contract (vitest)
         working-directory: packages/react
         run: npm ci && npx vitest run src/__tests__/desktopParity.contract.test.ts

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2065,11 +2065,16 @@ dependencies = [
 name = "hwp-export"
 version = "0.0.1"
 dependencies = [
+ "hwp-core",
  "hwp-jsx",
  "hwp-model",
  "hwp-render",
  "hwp-typeset",
  "krilla",
+ "kurbo 0.13.1",
+ "quick-xml 0.37.5",
+ "rhwp",
+ "svgtypes 0.16.1",
 ]
 
 [[package]]

--- a/crates/hwp-export/Cargo.toml
+++ b/crates/hwp-export/Cargo.toml
@@ -16,11 +16,22 @@ hwp-jsx = { workspace = true }
 hwp-render = { workspace = true, optional = true }
 hwp-typeset = { workspace = true, optional = true }
 krilla = { version = "0.8", optional = true, default-features = false, features = ["simple-text", "raster-images"] }
+quick-xml = { workspace = true, optional = true }
+svgtypes = { version = "0.16", optional = true }
+kurbo = { version = "0.13", optional = true }
 
 [features]
 default = []
 # High-level PDF export (krilla): own layout → paint IR → PDF with Korean font subsetting. Pairs with
 # the caller's font provider; under `shaper` the real rustybuzz advances drive placement.
-pdf = ["dep:krilla", "dep:hwp-render", "dep:hwp-typeset"]
+pdf = ["dep:krilla", "dep:hwp-render", "dep:hwp-typeset", "dep:quick-xml", "dep:svgtypes", "dep:kurbo"]
 # Drive the PDF export's placement with the real shaper (forwarded to hwp-render/hwp-typeset).
 shaper = ["hwp-render?/shaper", "hwp-typeset?/shaper"]
+
+[dev-dependencies]
+hwp-core = { workspace = true, features = ["rhwp"] }
+rhwp = { path = "../../external/rhwp" }
+
+[[example]]
+name = "svg_pdf_parity"
+required-features = ["pdf"]

--- a/crates/hwp-export/examples/svg_pdf_parity.rs
+++ b/crates/hwp-export/examples/svg_pdf_parity.rs
@@ -1,0 +1,125 @@
+//! Controlled #102 fixture generator used by `scripts/pdf-svg-parity-check.py`.
+
+use std::fs;
+use std::path::PathBuf;
+
+use hwp_export::pdf::{export_pdf, PdfOptions};
+use hwp_model::layout::PaintOp;
+use hwp_model::prelude::*;
+use hwp_typeset::ApproxFontMetrics;
+
+fn main() -> std::result::Result<(), String> {
+    let output = std::env::args_os()
+        .nth(1)
+        .map(PathBuf::from)
+        .ok_or("usage: svg_pdf_parity OUTPUT_DIR")?;
+    fs::create_dir_all(&output).map_err(|error| error.to_string())?;
+
+    let doc = fixture_doc();
+    let svgs = hwp_render::render_doc_svg(&doc, &ApproxFontMetrics);
+    if svgs.len() != 1 {
+        return Err(format!("fixture must stay one page, got {}", svgs.len()));
+    }
+    fs::write(output.join("own.svg"), &svgs[0]).map_err(|error| error.to_string())?;
+
+    let pdf = export_pdf(&doc, &ApproxFontMetrics, &PdfOptions::default())?;
+    if pdf.pages != 1 {
+        return Err(format!("PDF fixture must stay one page, got {}", pdf.pages));
+    }
+    if pdf
+        .diagnostics
+        .iter()
+        .any(|d| d.kind == "equation" || d.kind == "chart")
+    {
+        return Err(format!(
+            "unexpected SVG replay diagnostic: {:?}",
+            pdf.diagnostics
+        ));
+    }
+    fs::write(output.join("own.pdf"), pdf.bytes).map_err(|error| error.to_string())?;
+
+    let trees = hwp_render::render_doc_trees(&doc, &ApproxFontMetrics);
+    let mut boxes = String::from("kind\tx_px\ty_px\tw_px\th_px\n");
+    for op in &trees[0].ops {
+        if let PaintOp::Image {
+            x,
+            y,
+            w,
+            h,
+            svg: Some(svg),
+            ..
+        } = op
+        {
+            let kind = if svg.contains("hwp-gen-chart") || svg.contains("hwp-ooxml-chart") {
+                "chart"
+            } else {
+                "equation"
+            };
+            boxes.push_str(&format!(
+                "{kind}\t{:.4}\t{:.4}\t{:.4}\t{:.4}\n",
+                x / 75.0,
+                y / 75.0,
+                w / 75.0,
+                h / 75.0
+            ));
+        }
+    }
+    if boxes.lines().count() != 3 {
+        return Err("fixture must expose one equation and one chart box".into());
+    }
+    fs::write(output.join("boxes.tsv"), boxes).map_err(|error| error.to_string())?;
+    Ok(())
+}
+
+fn fixture_doc() -> SemanticDoc {
+    let mut doc = SemanticDoc::default();
+    doc.char_shapes.push(CharShape::default());
+    doc.para_shapes.push(ParaShape::default());
+
+    let equation = EquationRef {
+        script: "x over 2".into(),
+        font: "HYhwpEQ".into(),
+        base_unit: 1200,
+        baseline: 0,
+        color: Color {
+            r: 0,
+            g: 0,
+            b: 0,
+            a: 255,
+        },
+        width: 9000,
+        height: 3600,
+        version: "Equation Version 60".into(),
+        rendered_svg: Some(
+            r##"<g class="hwp-equation"><text x="8" y="20" font-size="18" font-style="italic" fill="#111">x</text><line x1="3" y1="25" x2="45" y2="25" stroke="#111" stroke-width="1.5"/><text x="18" y="43" font-size="16" fill="#111">2</text><path d="M58 8 Q70 24 58 42" fill="none" stroke="#0655c9" stroke-width="2" stroke-linecap="round"/></g>"##.into(),
+        ),
+    };
+    let chart = ChartRef {
+        width: 24000,
+        height: 13500,
+        rendered_svg: Some(
+            r##"<g class="hwp-gen-chart" data-chart-type="bar"><rect x="0" y="0" width="320" height="180" fill="#fff" stroke="#ccc" stroke-width="1"/><line x1="35" y1="145" x2="300" y2="145" stroke="#777"/><rect x="60" y="85" width="38" height="60" fill="#4472c4"/><rect x="125" y="52" width="38" height="93" fill="#ed7d31"/><rect x="190" y="105" width="38" height="40" fill="#70ad47"/><polyline points="60,72 144,35 228,82" fill="none" stroke="#a50021" stroke-width="3" stroke-linejoin="round"/><circle cx="144" cy="35" r="4" fill="#a50021"/><text x="160" y="22" font-family="sans-serif" font-size="14" font-weight="700" text-anchor="middle" fill="#222">PDF parity</text></g>"##.into(),
+        ),
+    };
+
+    let mut equation_paragraph = Paragraph::default();
+    equation_paragraph.runs.push(Run {
+        char_shape: 0,
+        content: vec![Inline::Equation(equation)],
+        ..Default::default()
+    });
+    let mut chart_paragraph = Paragraph::default();
+    chart_paragraph.runs.push(Run {
+        char_shape: 0,
+        content: vec![Inline::Chart(chart)],
+        ..Default::default()
+    });
+    doc.sections.push(Section {
+        blocks: vec![
+            Block::Paragraph(equation_paragraph),
+            Block::Paragraph(chart_paragraph),
+        ],
+        ..Default::default()
+    });
+    doc
+}

--- a/crates/hwp-export/src/lib.rs
+++ b/crates/hwp-export/src/lib.rs
@@ -28,6 +28,11 @@ pub mod pdf;
 #[cfg(feature = "pdf")]
 mod bmp;
 
+/// Bounded, no-fetch lowering for the equation/chart SVG fragment carried by `PaintOp::Image.svg`.
+/// Feature `pdf`; private because callers consume it only through the PDF replay diagnostics.
+#[cfg(feature = "pdf")]
+mod svg_fragment;
+
 use hwp_jsx::css::emit_css;
 use hwp_jsx::jsx::{JsxElement, JsxNode, Tag};
 use hwp_jsx::project::{Asset, JsxCssProject};

--- a/crates/hwp-export/src/pdf.rs
+++ b/crates/hwp-export/src/pdf.rs
@@ -28,9 +28,16 @@ use krilla::color::rgb;
 use krilla::geom::{PathBuilder, Point, Rect};
 use krilla::num::NormalizedF32;
 use krilla::page::PageSettings;
-use krilla::paint::{Fill, Stroke, StrokeDash};
+use krilla::paint::{
+    Fill, LineCap as KrillaLineCap, LineJoin as KrillaLineJoin, Stroke, StrokeDash,
+};
 use krilla::text::{Font, TextDirection};
 use krilla::Document;
+
+use crate::svg_fragment::{
+    DominantBaseline, Fragment, LineCap as SvgLineCap, LineJoin as SvgLineJoin, PathCommand,
+    Primitive as SvgPrimitive, Style as SvgStyle, TextAnchor, TextPrimitive,
+};
 
 /// 1 PDF point = 1/72 inch; 1 inch = 7200 HWPUNIT ⇒ 100 HWPUNIT per point.
 const HWPUNIT_PER_PT: f64 = 7200.0 / 72.0;
@@ -240,6 +247,63 @@ pub struct PdfExport {
     pub pages: usize,
     /// Path of the embedded font, or `None` when no Korean face was found (glyphs are stub boxes).
     pub font_path: Option<String>,
+    /// Per-page proof that every produced paint operation was either replayed or explicitly stubbed.
+    pub replay: Vec<PdfPageReplayStats>,
+    /// Bounded capability failures. An unsupported SVG never becomes an unexplained blank object.
+    pub diagnostics: Vec<PdfCapabilityDiagnostic>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct PdfReplayCounts {
+    pub produced: usize,
+    pub replayed: usize,
+    pub stubbed: usize,
+}
+
+impl PdfReplayCounts {
+    fn produced_replayed(&mut self) {
+        self.produced += 1;
+        self.replayed += 1;
+    }
+
+    fn produced_stubbed(&mut self) {
+        self.produced += 1;
+        self.stubbed += 1;
+    }
+
+    fn is_balanced(&self) -> bool {
+        self.produced == self.replayed + self.stubbed
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct PdfPageReplayStats {
+    pub page_index: usize,
+    pub text: PdfReplayCounts,
+    /// Rect/Line paint operations are the table and page-geometry lane in schema v1.
+    pub table_geometry: PdfReplayCounts,
+    pub image: PdfReplayCounts,
+    pub equation: PdfReplayCounts,
+    pub chart: PdfReplayCounts,
+}
+
+impl PdfPageReplayStats {
+    fn is_balanced(&self) -> bool {
+        self.text.is_balanced()
+            && self.table_geometry.is_balanced()
+            && self.image.is_balanced()
+            && self.equation.is_balanced()
+            && self.chart.is_balanced()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PdfCapabilityDiagnostic {
+    pub page_index: usize,
+    pub op_index: usize,
+    pub kind: String,
+    /// Stable machine-readable code; source SVG/content is intentionally never copied here.
+    pub code: String,
 }
 
 /// True iff a real (Korean-capable) font is available to embed — i.e. a future [`export_pdf`] will
@@ -294,8 +358,19 @@ pub fn export_pdf_with_fonts(
         document.set_metadata(meta);
     }
 
-    for tree in &trees {
-        lower_tree_to_page(&mut document, tree, doc, embed.as_ref());
+    let mut replay = Vec::with_capacity(trees.len());
+    let mut diagnostics = Vec::new();
+    for (page_index, tree) in trees.iter().enumerate() {
+        let (stats, mut page_diagnostics) =
+            lower_tree_to_page(&mut document, tree, doc, embed.as_ref(), page_index);
+        if !stats.is_balanced() {
+            return Err(format!(
+                "pdf.replay.unbalanced: page {} produced operations were silently lost",
+                page_index + 1
+            ));
+        }
+        replay.push(stats);
+        diagnostics.append(&mut page_diagnostics);
     }
 
     let bytes = document
@@ -305,6 +380,8 @@ pub fn export_pdf_with_fonts(
         pages: trees.len(),
         bytes,
         font_path: embed.as_ref().map(|f| f.path.clone()),
+        replay,
+        diagnostics,
     })
 }
 
@@ -315,17 +392,24 @@ fn lower_tree_to_page(
     tree: &PageLayerTree,
     doc: &SemanticDoc,
     embed: Option<&EmbedFont>,
-) {
+    page_index: usize,
+) -> (PdfPageReplayStats, Vec<PdfCapabilityDiagnostic>) {
     let w = pt(tree.width).max(1.0);
     let h = pt(tree.height).max(1.0);
     let settings = PageSettings::from_wh(w, h).unwrap_or_else(|| PageSettings::new(default_size()));
     let mut page = document.start_page_with(settings);
     let mut surface = page.surface();
+    let mut stats = PdfPageReplayStats {
+        page_index,
+        ..Default::default()
+    };
+    let mut diagnostics = Vec::new();
 
-    for op in &tree.ops {
+    for (op_index, op) in tree.ops.iter().enumerate() {
         match op {
             PaintOp::Rect { x, y, w, h, fill } => {
                 paint_rect(&mut surface, *x, *y, *w, *h, *fill);
+                stats.table_geometry.produced_replayed();
             }
             PaintOp::Line {
                 x1,
@@ -337,6 +421,7 @@ fn lower_tree_to_page(
                 width,
             } => {
                 paint_line(&mut surface, *x1, *y1, *x2, *y2, *color, *style, *width);
+                stats.table_geometry.produced_replayed();
             }
             PaintOp::Image {
                 x,
@@ -344,11 +429,41 @@ fn lower_tree_to_page(
                 w,
                 h,
                 bin_ref,
-                // Equation SVG (issue 062-5) is ignored by the PDF backend — v1 defers SVG→PDF (no
-                // resvg), so an equation renders as the same stub box `paint_image` draws for it.
-                svg: _,
+                svg,
             } => {
-                paint_image(&mut surface, *x, *y, *w, *h, bin_ref, doc);
+                if let Some(svg) = svg.as_deref() {
+                    let (kind, counts) = if is_chart_svg(svg) {
+                        ("chart", &mut stats.chart)
+                    } else {
+                        ("equation", &mut stats.equation)
+                    };
+                    match crate::svg_fragment::parse(svg) {
+                        Ok(fragment) => {
+                            paint_svg_fragment(&mut surface, *x, *y, &fragment, embed);
+                            counts.produced_replayed();
+                        }
+                        Err(code) => {
+                            paint_image(&mut surface, *x, *y, *w, *h, bin_ref, doc);
+                            counts.produced_stubbed();
+                            diagnostics.push(PdfCapabilityDiagnostic {
+                                page_index,
+                                op_index,
+                                kind: kind.into(),
+                                code,
+                            });
+                        }
+                    }
+                } else if paint_image(&mut surface, *x, *y, *w, *h, bin_ref, doc) {
+                    stats.image.produced_replayed();
+                } else {
+                    stats.image.produced_stubbed();
+                    diagnostics.push(PdfCapabilityDiagnostic {
+                        page_index,
+                        op_index,
+                        kind: "image".into(),
+                        code: "image.unsupported_or_missing".into(),
+                    });
+                }
             }
             PaintOp::Glyph {
                 x,
@@ -380,12 +495,313 @@ fn lower_tree_to_page(
                     cluster.as_deref(),
                     embed,
                 );
+                if embed.is_some() || ch.is_whitespace() {
+                    stats.text.produced_replayed();
+                } else {
+                    stats.text.produced_stubbed();
+                    diagnostics.push(PdfCapabilityDiagnostic {
+                        page_index,
+                        op_index,
+                        kind: "text".into(),
+                        code: "font.unavailable".into(),
+                    });
+                }
             }
         }
     }
 
     surface.finish();
     page.finish();
+    (stats, diagnostics)
+}
+
+fn is_chart_svg(svg: &str) -> bool {
+    svg.contains("hwp-gen-chart") || svg.contains("hwp-ooxml-chart")
+}
+
+/// Replay one already-validated resource-free SVG fragment. Fragment coordinates are CSS px, while
+/// the object origin is paint-IR HWPUNIT; both become PDF points at this boundary.
+fn paint_svg_fragment(
+    surface: &mut krilla::surface::Surface,
+    origin_x: f64,
+    origin_y: f64,
+    fragment: &Fragment,
+    embed: Option<&EmbedFont>,
+) {
+    surface.push_transform(&krilla::geom::Transform::from_translate(
+        pt(origin_x),
+        pt(origin_y),
+    ));
+    for primitive in &fragment.primitives {
+        match primitive {
+            SvgPrimitive::Rect { x, y, w, h, style } => {
+                let Some(rect) = Rect::from_xywh(
+                    px_pt(*x),
+                    px_pt(*y),
+                    px_pt(*w).max(0.001),
+                    px_pt(*h).max(0.001),
+                ) else {
+                    continue;
+                };
+                let mut builder = PathBuilder::new();
+                builder.push_rect(rect);
+                if let Some(path) = builder.finish() {
+                    draw_svg_path(surface, &path, style);
+                }
+            }
+            SvgPrimitive::Line {
+                x1,
+                y1,
+                x2,
+                y2,
+                style,
+            } => {
+                let mut builder = PathBuilder::new();
+                builder.move_to(px_pt(*x1), px_pt(*y1));
+                builder.line_to(px_pt(*x2), px_pt(*y2));
+                if let Some(path) = builder.finish() {
+                    draw_svg_path(surface, &path, style);
+                }
+            }
+            SvgPrimitive::Path { commands, style } => {
+                let mut builder = PathBuilder::new();
+                for command in commands {
+                    match *command {
+                        PathCommand::Move(x, y) => builder.move_to(px_pt(x), px_pt(y)),
+                        PathCommand::Line(x, y) => builder.line_to(px_pt(x), px_pt(y)),
+                        PathCommand::Quad(x1, y1, x, y) => {
+                            builder.quad_to(px_pt(x1), px_pt(y1), px_pt(x), px_pt(y));
+                        }
+                        PathCommand::Cubic(x1, y1, x2, y2, x, y) => builder.cubic_to(
+                            px_pt(x1),
+                            px_pt(y1),
+                            px_pt(x2),
+                            px_pt(y2),
+                            px_pt(x),
+                            px_pt(y),
+                        ),
+                        PathCommand::Close => builder.close(),
+                    }
+                }
+                if let Some(path) = builder.finish() {
+                    draw_svg_path(surface, &path, style);
+                }
+            }
+            SvgPrimitive::Circle {
+                cx,
+                cy,
+                rx,
+                ry,
+                style,
+            } => {
+                let path = ellipse_path(*cx, *cy, *rx, *ry);
+                if let Some(path) = path {
+                    draw_svg_path(surface, &path, style);
+                }
+            }
+            SvgPrimitive::Text(text) => paint_svg_text(surface, text, embed),
+        }
+    }
+    surface.pop();
+}
+
+fn px_pt(value: f64) -> f32 {
+    value as f32 * PT_PER_PX
+}
+
+fn opacity(value: f32) -> NormalizedF32 {
+    NormalizedF32::new(value).unwrap_or(NormalizedF32::ONE)
+}
+
+fn draw_svg_path(
+    surface: &mut krilla::surface::Surface,
+    path: &krilla::geom::Path,
+    style: &SvgStyle,
+) {
+    surface.set_fill(style.fill.map(|color| Fill {
+        paint: rgb_of(color).into(),
+        opacity: opacity(style.opacity),
+        rule: Default::default(),
+    }));
+    surface.set_stroke(style.stroke.map(|color| Stroke {
+        paint: rgb_of(color).into(),
+        width: px_pt(style.stroke_width).max(0.001),
+        line_cap: match style.line_cap {
+            SvgLineCap::Butt => KrillaLineCap::Butt,
+            SvgLineCap::Round => KrillaLineCap::Round,
+            SvgLineCap::Square => KrillaLineCap::Square,
+        },
+        line_join: match style.line_join {
+            SvgLineJoin::Miter => KrillaLineJoin::Miter,
+            SvgLineJoin::Round => KrillaLineJoin::Round,
+            SvgLineJoin::Bevel => KrillaLineJoin::Bevel,
+        },
+        opacity: opacity(style.opacity),
+        dash: style.dash.as_ref().map(|values| StrokeDash {
+            array: values.iter().map(|value| px_pt(*value)).collect(),
+            offset: 0.0,
+        }),
+        ..Default::default()
+    }));
+    surface.draw_path(path);
+}
+
+fn ellipse_path(cx: f64, cy: f64, rx: f64, ry: f64) -> Option<krilla::geom::Path> {
+    if rx <= 0.0 || ry <= 0.0 {
+        return None;
+    }
+    // Four cubic Beziers; kappa is the standard circle approximation constant.
+    const K: f64 = 0.552_284_749_830_793_6;
+    let mut builder = PathBuilder::new();
+    builder.move_to(px_pt(cx + rx), px_pt(cy));
+    builder.cubic_to(
+        px_pt(cx + rx),
+        px_pt(cy + K * ry),
+        px_pt(cx + K * rx),
+        px_pt(cy + ry),
+        px_pt(cx),
+        px_pt(cy + ry),
+    );
+    builder.cubic_to(
+        px_pt(cx - K * rx),
+        px_pt(cy + ry),
+        px_pt(cx - rx),
+        px_pt(cy + K * ry),
+        px_pt(cx - rx),
+        px_pt(cy),
+    );
+    builder.cubic_to(
+        px_pt(cx - rx),
+        px_pt(cy - K * ry),
+        px_pt(cx - K * rx),
+        px_pt(cy - ry),
+        px_pt(cx),
+        px_pt(cy - ry),
+    );
+    builder.cubic_to(
+        px_pt(cx + K * rx),
+        px_pt(cy - ry),
+        px_pt(cx + rx),
+        px_pt(cy - K * ry),
+        px_pt(cx + rx),
+        px_pt(cy),
+    );
+    builder.close();
+    builder.finish()
+}
+
+fn paint_svg_text(
+    surface: &mut krilla::surface::Surface,
+    text: &TextPrimitive,
+    embed: Option<&EmbedFont>,
+) {
+    if text.text.is_empty() {
+        return;
+    }
+    let size = px_pt(text.size);
+    let approx_width = text.text.chars().count() as f32 * size * 0.55;
+    let x = px_pt(text.x)
+        - match text.anchor {
+            TextAnchor::Start => 0.0,
+            TextAnchor::Middle => approx_width / 2.0,
+            TextAnchor::End => approx_width,
+        };
+    let y = px_pt(text.y)
+        + match text.dominant_baseline {
+            DominantBaseline::Auto => 0.0,
+            DominantBaseline::Central => size * 0.35,
+        };
+
+    let Some(embed) = embed else {
+        // Font-less/headless fallback: preserve each character slot individually, not one opaque
+        // whole-object box. The caller's page stats already expose that the font capability is absent.
+        for idx in 0..text.text.chars().count() {
+            let Some(rect) = Rect::from_xywh(
+                x + idx as f32 * size * 0.55,
+                y - size * 0.8,
+                size * 0.5,
+                size,
+            ) else {
+                continue;
+            };
+            let mut builder = PathBuilder::new();
+            builder.push_rect(rect);
+            if let Some(path) = builder.finish() {
+                surface.set_fill(None);
+                surface.set_stroke(Some(Stroke {
+                    paint: rgb::Color::black().into(),
+                    width: 0.25,
+                    ..Default::default()
+                }));
+                surface.draw_path(&path);
+            }
+        }
+        return;
+    };
+
+    let explicit = text.family.as_deref().and_then(|family| {
+        embed
+            .extra
+            .iter()
+            .find(|(candidate, _)| candidate.trim().eq_ignore_ascii_case(family.trim()))
+            .map(|(_, font)| font)
+    });
+    let family_is_serif = text
+        .family
+        .as_deref()
+        .map(|family| {
+            classify(family) == FontCategory::Serif
+                || family.to_ascii_lowercase().contains("serif")
+                || family.to_ascii_lowercase().contains("times")
+        })
+        .unwrap_or(false);
+    let face = if let Some(face) = explicit {
+        face
+    } else if family_is_serif {
+        if text.bold {
+            embed
+                .serif_bold
+                .as_ref()
+                .or(embed.serif.as_ref())
+                .or(embed.bold.as_ref())
+                .unwrap_or(&embed.font)
+        } else {
+            embed.serif.as_ref().unwrap_or(&embed.font)
+        }
+    } else if text.bold {
+        embed.bold.as_ref().unwrap_or(&embed.font)
+    } else {
+        &embed.font
+    };
+
+    surface.set_stroke(None);
+    surface.set_fill(text.style.fill.map(|color| Fill {
+        paint: rgb_of(color).into(),
+        opacity: opacity(text.style.opacity),
+        rule: Default::default(),
+    }));
+    if text.italic {
+        const SLANT: f32 = 0.21;
+        surface.push_transform(&krilla::geom::Transform::from_row(
+            1.0,
+            0.0,
+            -SLANT,
+            1.0,
+            SLANT * y,
+            0.0,
+        ));
+    }
+    surface.draw_text(
+        Point::from_xy(x, y),
+        face.clone(),
+        size,
+        &text.text,
+        false,
+        TextDirection::Auto,
+    );
+    if text.italic {
+        surface.pop();
+    }
 }
 
 /// A minimal A4 size in points as a last-resort page size (only hit if width/height were non-finite).
@@ -503,10 +919,10 @@ fn paint_image(
     h: f64,
     bin_ref: &str,
     doc: &SemanticDoc,
-) {
+) -> bool {
     let size = match krilla::geom::Size::from_wh(pt(w).max(0.01), pt(h).max(0.01)) {
         Some(s) => s,
-        None => return,
+        None => return false,
     };
 
     if let Some(img) = decode_image(bin_ref, doc) {
@@ -515,6 +931,7 @@ fn paint_image(
         surface.push_transform(&krilla::geom::Transform::from_translate(pt(x), pt(y)));
         surface.draw_image(img, size);
         surface.pop();
+        true
     } else {
         // Stub box: light fill + grey outline, same intent as the SVG `#F0F0F0` placeholder.
         paint_rect(
@@ -531,6 +948,7 @@ fn paint_image(
             }),
         );
         paint_rect(surface, x, y, w, h, None);
+        false
     }
 }
 
@@ -749,10 +1167,8 @@ mod tests {
         assert!(out.pages >= 1);
     }
 
-    /// Issue 062-follow (AI-generated charts): a generated chart is an `Inline::Chart` on the
-    /// `PaintOp::Image.svg` channel. The PDF backend ignores the SVG and draws its reserved box (v1 —
-    /// no SVG→PDF vector path yet, exactly like the 062 OOXML chart). Assert the export doesn't panic
-    /// and the chart page is present.
+    /// #102: a generated chart on the `PaintOp::Image.svg` channel is replayed as PDF vectors, never
+    /// silently degraded to the old whole-object placeholder.
     #[test]
     fn exports_a_doc_with_a_generated_chart_without_panicking() {
         let mut chart_para = Paragraph::default();
@@ -775,6 +1191,148 @@ mod tests {
         let out = export_pdf(&doc, &ApproxFontMetrics, &PdfOptions::default()).unwrap();
         assert!(out.bytes.starts_with(b"%PDF-"), "valid PDF header");
         assert!(out.pages >= 1, "the chart box is laid out on a page");
+        let chart = out
+            .replay
+            .iter()
+            .map(|page| &page.chart)
+            .find(|c| c.produced > 0)
+            .unwrap();
+        assert_eq!(chart.produced, chart.replayed);
+        assert_eq!(chart.stubbed, 0);
+        assert!(out.diagnostics.iter().all(|d| d.kind != "chart"));
+    }
+
+    #[test]
+    fn equation_svg_replays_and_unsupported_svg_has_explicit_diagnostic() {
+        let equation_para = |svg: &str| {
+            let mut paragraph = Paragraph::default();
+            paragraph.runs.push(Run {
+                char_shape: 0,
+                content: vec![Inline::Equation(EquationRef {
+                    script: "x over 2".into(),
+                    font: "HYhwpEQ".into(),
+                    base_unit: 1000,
+                    baseline: 0,
+                    color: Color {
+                        r: 0,
+                        g: 0,
+                        b: 0,
+                        a: 255,
+                    },
+                    width: 3000,
+                    height: 1500,
+                    version: "Equation Version 60".into(),
+                    rendered_svg: Some(svg.into()),
+                })],
+                ..Default::default()
+            });
+            paragraph
+        };
+
+        let good = doc_with(vec![Block::Paragraph(equation_para(
+            r##"<g><text x="1" y="12" font-size="12" fill="#000">x</text><line x1="0" y1="14" x2="12" y2="14" stroke="#000"/></g>"##,
+        ))]);
+        let out = export_pdf(&good, &ApproxFontMetrics, &PdfOptions::default()).unwrap();
+        let equation = out
+            .replay
+            .iter()
+            .map(|page| &page.equation)
+            .find(|counts| counts.produced > 0)
+            .expect("equation PaintOp is produced");
+        assert_eq!(equation.produced, equation.replayed);
+        assert_eq!(equation.stubbed, 0);
+
+        let bad = doc_with(vec![Block::Paragraph(equation_para(
+            "<foreignObject><div>network-capable content</div></foreignObject>",
+        ))]);
+        let out = export_pdf(&bad, &ApproxFontMetrics, &PdfOptions::default()).unwrap();
+        let equation = out
+            .replay
+            .iter()
+            .map(|page| &page.equation)
+            .find(|counts| counts.produced > 0)
+            .expect("equation PaintOp is produced");
+        assert_eq!(equation.stubbed, 1, "unsupported SVG gets a visible stub");
+        assert!(out.diagnostics.iter().any(|diagnostic| {
+            diagnostic.kind == "equation"
+                && diagnostic.code == "svg.element.unsupported:foreignobject"
+        }));
+    }
+
+    #[test]
+    fn public_hwpx_equation_fixture_replays_through_the_production_engine() {
+        let bytes = std::fs::read(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../corpus/hwpxlib_corpus/reader_writer/SimpleEquation.hwpx"
+        ))
+        .expect("public HWPX fixture is tracked");
+        let doc =
+            hwp_core::Engine::open(&bytes).expect("production HWPX parser/enrichment opens it");
+        let out = export_pdf(&doc, &ApproxFontMetrics, &PdfOptions::default()).unwrap();
+        let produced: usize = out.replay.iter().map(|page| page.equation.produced).sum();
+        let replayed: usize = out.replay.iter().map(|page| page.equation.replayed).sum();
+        let stubbed: usize = out.replay.iter().map(|page| page.equation.stubbed).sum();
+        assert!(produced > 0, "fixture must exercise the equation SVG lane");
+        assert_eq!(produced, replayed);
+        assert_eq!(stubbed, 0, "public HWPX equations are vectors, not boxes");
+        assert!(out.diagnostics.iter().all(|d| d.kind != "equation"));
+    }
+
+    #[test]
+    fn replay_accounting_covers_text_table_geometry_and_raster_image() {
+        let table = Table {
+            rows: 1,
+            cols: 1,
+            cells: vec![Cell {
+                blocks: vec![Block::Paragraph(para("셀"))],
+                ..Default::default()
+            }],
+            col_widths: vec![8000],
+            ..Default::default()
+        };
+        let mut image_paragraph = Paragraph::default();
+        image_paragraph.runs.push(Run {
+            char_shape: 0,
+            content: vec![Inline::Image(ImageRef {
+                bin_ref: "bmp-accounting".into(),
+                width: 1500,
+                height: 1500,
+                treat_as_char: true,
+            })],
+            ..Default::default()
+        });
+        let mut doc = doc_with(vec![
+            Block::Paragraph(para("본문")),
+            Block::Table(table),
+            Block::Paragraph(image_paragraph),
+        ]);
+        doc.bin_data.push(BinData {
+            bin_ref: "bmp-accounting".into(),
+            bytes: tiny_bmp(),
+            kind: "bmp".into(),
+        });
+
+        let out = export_pdf(&doc, &ApproxFontMetrics, &PdfOptions::default()).unwrap();
+        let sum = |pick: fn(&PdfPageReplayStats) -> &PdfReplayCounts| -> PdfReplayCounts {
+            out.replay
+                .iter()
+                .fold(PdfReplayCounts::default(), |mut acc, page| {
+                    let counts = pick(page);
+                    acc.produced += counts.produced;
+                    acc.replayed += counts.replayed;
+                    acc.stubbed += counts.stubbed;
+                    acc
+                })
+        };
+        for counts in [
+            sum(|page| &page.text),
+            sum(|page| &page.table_geometry),
+            sum(|page| &page.image),
+        ] {
+            assert!(counts.produced > 0, "lane must be exercised");
+            assert_eq!(counts.produced, counts.replayed + counts.stubbed);
+        }
+        assert_eq!(sum(|page| &page.image).stubbed, 0, "BMP is a real replay");
     }
 
     #[test]

--- a/crates/hwp-export/src/svg_fragment.rs
+++ b/crates/hwp-export/src/svg_fragment.rs
@@ -1,0 +1,844 @@
+//! Strict SVG-fragment parser for equation/chart PDF replay.
+//!
+//! This is deliberately not a general SVG implementation. The only accepted input is the bounded,
+//! resource-free primitive subset emitted by auto-hwp/rhwp's equation and chart renderers. Unknown
+//! elements or attributes are rejected instead of being silently ignored.
+
+use std::collections::BTreeMap;
+
+use hwp_model::types::Color;
+use kurbo::{Arc, Point as KurboPoint, SvgArc, Vec2};
+use quick_xml::events::{BytesStart, Event};
+use quick_xml::Reader;
+use svgtypes::{PathParser, PathSegment};
+
+const MAX_BYTES: usize = 1024 * 1024;
+const MAX_ELEMENTS: usize = 10_000;
+const MAX_DEPTH: usize = 32;
+const MAX_ATTRS: usize = 32;
+const MAX_PATH_COMMANDS: usize = 100_000;
+const MAX_TEXT_BYTES: usize = 256 * 1024;
+const MAX_ABS_COORD: f64 = 10_000_000.0;
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct Fragment {
+    pub primitives: Vec<Primitive>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum Primitive {
+    Rect {
+        x: f64,
+        y: f64,
+        w: f64,
+        h: f64,
+        style: Style,
+    },
+    Line {
+        x1: f64,
+        y1: f64,
+        x2: f64,
+        y2: f64,
+        style: Style,
+    },
+    Path {
+        commands: Vec<PathCommand>,
+        style: Style,
+    },
+    Circle {
+        cx: f64,
+        cy: f64,
+        rx: f64,
+        ry: f64,
+        style: Style,
+    },
+    Text(TextPrimitive),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct TextPrimitive {
+    pub x: f64,
+    pub y: f64,
+    pub size: f64,
+    pub text: String,
+    pub anchor: TextAnchor,
+    pub dominant_baseline: DominantBaseline,
+    pub bold: bool,
+    pub italic: bool,
+    pub family: Option<String>,
+    pub style: Style,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum TextAnchor {
+    Start,
+    Middle,
+    End,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum DominantBaseline {
+    Auto,
+    Central,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct Style {
+    pub fill: Option<Color>,
+    pub stroke: Option<Color>,
+    pub stroke_width: f64,
+    pub dash: Option<Vec<f64>>,
+    pub line_cap: LineCap,
+    pub line_join: LineJoin,
+    pub opacity: f32,
+}
+
+impl Default for Style {
+    fn default() -> Self {
+        Self {
+            // SVG's initial fill is black and initial stroke is none.
+            fill: Some(Color {
+                r: 0,
+                g: 0,
+                b: 0,
+                a: 255,
+            }),
+            stroke: None,
+            stroke_width: 1.0,
+            dash: None,
+            line_cap: LineCap::Butt,
+            line_join: LineJoin::Miter,
+            opacity: 1.0,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum LineCap {
+    Butt,
+    Round,
+    Square,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum LineJoin {
+    Miter,
+    Round,
+    Bevel,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) enum PathCommand {
+    Move(f64, f64),
+    Line(f64, f64),
+    Quad(f64, f64, f64, f64),
+    Cubic(f64, f64, f64, f64, f64, f64),
+    Close,
+}
+
+#[derive(Clone, Debug)]
+struct PendingText {
+    primitive: TextPrimitive,
+}
+
+/// Parse the deliberately small SVG subset emitted by our equation/chart renderers.
+pub(crate) fn parse(svg: &str) -> Result<Fragment, String> {
+    if svg.len() > MAX_BYTES {
+        return Err("svg.limit.bytes".into());
+    }
+    if svg.contains("<!") || svg.contains("<?") {
+        return Err("svg.security.declaration".into());
+    }
+
+    // Equation/chart payloads are SVG fragments, so give the XML reader one artificial root.
+    let wrapped = format!("<fragment>{svg}</fragment>");
+    let mut reader = Reader::from_str(&wrapped);
+    reader.config_mut().trim_text(false);
+
+    let mut primitives = Vec::new();
+    let mut styles = vec![Style::default()];
+    let mut elements = 0usize;
+    let mut pending_text: Option<PendingText> = None;
+
+    loop {
+        match reader.read_event() {
+            Ok(Event::Start(e)) => {
+                elements = elements.checked_add(1).ok_or("svg.limit.elements")?;
+                if elements > MAX_ELEMENTS || styles.len() >= MAX_DEPTH {
+                    return Err("svg.limit.elements_or_depth".into());
+                }
+                let name = local_name(e.name().as_ref())?;
+                if name == "fragment" {
+                    continue;
+                }
+                if pending_text.is_some() {
+                    return Err("svg.text.nested_element".into());
+                }
+                let attrs = attrs(&e, &reader)?;
+                let parent = styles.last().cloned().unwrap_or_default();
+                match name.as_str() {
+                    "g" => {
+                        styles.push(parse_style(&attrs, &parent, &["class", "data-chart-type"])?)
+                    }
+                    "text" => {
+                        let style = parse_style(
+                            &attrs,
+                            &parent,
+                            &[
+                                "x",
+                                "y",
+                                "font-family",
+                                "font-size",
+                                "font-weight",
+                                "font-style",
+                                "text-anchor",
+                                "dominant-baseline",
+                                "class",
+                            ],
+                        )?;
+                        let primitive = parse_text_attrs(&attrs, style)?;
+                        styles.push(primitive.style.clone());
+                        pending_text = Some(PendingText { primitive });
+                    }
+                    _ => return Err(format!("svg.element.unsupported:{name}")),
+                }
+            }
+            Ok(Event::Empty(e)) => {
+                elements = elements.checked_add(1).ok_or("svg.limit.elements")?;
+                if elements > MAX_ELEMENTS || styles.len() >= MAX_DEPTH {
+                    return Err("svg.limit.elements_or_depth".into());
+                }
+                if pending_text.is_some() {
+                    return Err("svg.text.nested_element".into());
+                }
+                let name = local_name(e.name().as_ref())?;
+                let attrs = attrs(&e, &reader)?;
+                let parent = styles.last().cloned().unwrap_or_default();
+                parse_empty(&name, &attrs, &parent, &mut primitives)?;
+            }
+            Ok(Event::Text(t)) => {
+                let value = t.unescape().map_err(|_| "svg.xml.text")?;
+                if let Some(pending) = pending_text.as_mut() {
+                    if pending.primitive.text.len() + value.len() > MAX_TEXT_BYTES {
+                        return Err("svg.limit.text".into());
+                    }
+                    pending.primitive.text.push_str(&value);
+                } else if !value.trim().is_empty() {
+                    return Err("svg.text.outside_text".into());
+                }
+            }
+            Ok(Event::End(e)) => {
+                let name = local_name(e.name().as_ref())?;
+                match name.as_str() {
+                    "text" => {
+                        let pending = pending_text.take().ok_or("svg.text.unbalanced")?;
+                        styles.pop().ok_or("svg.depth.unbalanced")?;
+                        primitives.push(Primitive::Text(pending.primitive));
+                    }
+                    "g" => {
+                        styles.pop().ok_or("svg.depth.unbalanced")?;
+                    }
+                    "fragment" => {}
+                    _ => return Err(format!("svg.element.unsupported:{name}")),
+                }
+            }
+            Ok(Event::Comment(_)) => {}
+            Ok(Event::Eof) => break,
+            Ok(Event::Decl(_) | Event::PI(_) | Event::DocType(_) | Event::CData(_)) => {
+                return Err("svg.security.declaration".into());
+            }
+            Err(_) => return Err("svg.xml.malformed".into()),
+        }
+    }
+
+    if pending_text.is_some() || styles.len() != 1 {
+        return Err("svg.depth.unbalanced".into());
+    }
+    if primitives.is_empty() {
+        return Err("svg.fragment.empty".into());
+    }
+    Ok(Fragment { primitives })
+}
+
+fn local_name(raw: &[u8]) -> Result<String, String> {
+    let s = std::str::from_utf8(raw).map_err(|_| "svg.xml.element_name")?;
+    if s.contains(':') {
+        return Err("svg.security.namespace".into());
+    }
+    Ok(s.to_ascii_lowercase())
+}
+
+fn attrs(e: &BytesStart<'_>, reader: &Reader<&[u8]>) -> Result<BTreeMap<String, String>, String> {
+    let mut out = BTreeMap::new();
+    for (idx, attr) in e.attributes().enumerate() {
+        if idx >= MAX_ATTRS {
+            return Err("svg.limit.attributes".into());
+        }
+        let attr = attr.map_err(|_| "svg.xml.attribute")?;
+        let key = std::str::from_utf8(attr.key.as_ref())
+            .map_err(|_| "svg.xml.attribute_name")?
+            .to_ascii_lowercase();
+        if key.contains(':') || key.starts_with("on") || matches!(key.as_str(), "href" | "style") {
+            return Err(format!("svg.security.attribute:{key}"));
+        }
+        let value = attr
+            .decode_and_unescape_value(reader.decoder())
+            .map_err(|_| "svg.xml.attribute_value")?
+            .into_owned();
+        if out.insert(key.clone(), value).is_some() {
+            return Err(format!("svg.attribute.duplicate:{key}"));
+        }
+    }
+    Ok(out)
+}
+
+fn parse_empty(
+    name: &str,
+    attrs: &BTreeMap<String, String>,
+    parent: &Style,
+    out: &mut Vec<Primitive>,
+) -> Result<(), String> {
+    match name {
+        "rect" => {
+            let style = parse_style(attrs, parent, &["x", "y", "width", "height", "class"])?;
+            let (x, y) = (number(attrs, "x", 0.0)?, number(attrs, "y", 0.0)?);
+            let (w, h) = (
+                required_number(attrs, "width")?,
+                required_number(attrs, "height")?,
+            );
+            nonnegative(w, "width")?;
+            nonnegative(h, "height")?;
+            out.push(Primitive::Rect { x, y, w, h, style });
+        }
+        "line" => {
+            let style = parse_style(attrs, parent, &["x1", "y1", "x2", "y2", "class"])?;
+            out.push(Primitive::Line {
+                x1: number(attrs, "x1", 0.0)?,
+                y1: number(attrs, "y1", 0.0)?,
+                x2: number(attrs, "x2", 0.0)?,
+                y2: number(attrs, "y2", 0.0)?,
+                style,
+            });
+        }
+        "circle" | "ellipse" => {
+            let extra = if name == "circle" {
+                vec!["cx", "cy", "r", "class"]
+            } else {
+                vec!["cx", "cy", "rx", "ry", "class"]
+            };
+            let style = parse_style(attrs, parent, &extra)?;
+            let cx = number(attrs, "cx", 0.0)?;
+            let cy = number(attrs, "cy", 0.0)?;
+            let (rx, ry) = if name == "circle" {
+                let r = required_number(attrs, "r")?;
+                (r, r)
+            } else {
+                (required_number(attrs, "rx")?, required_number(attrs, "ry")?)
+            };
+            nonnegative(rx, "radius")?;
+            nonnegative(ry, "radius")?;
+            out.push(Primitive::Circle {
+                cx,
+                cy,
+                rx,
+                ry,
+                style,
+            });
+        }
+        "path" => {
+            let style = parse_style(attrs, parent, &["d", "class"])?;
+            let d = attrs.get("d").ok_or("svg.attribute.missing:d")?;
+            out.push(Primitive::Path {
+                commands: parse_path(d)?,
+                style,
+            });
+        }
+        "polyline" | "polygon" => {
+            let style = parse_style(attrs, parent, &["points", "class"])?;
+            let points = attrs.get("points").ok_or("svg.attribute.missing:points")?;
+            let mut commands = parse_points(points)?;
+            if name == "polygon" {
+                commands.push(PathCommand::Close);
+            }
+            out.push(Primitive::Path { commands, style });
+        }
+        // Empty groups have no visual content; accepting them is harmless and still resource-free.
+        "g" => {
+            parse_style(attrs, parent, &["class", "data-chart-type"])?;
+        }
+        "text" => {
+            let style = parse_style(
+                attrs,
+                parent,
+                &[
+                    "x",
+                    "y",
+                    "font-family",
+                    "font-size",
+                    "font-weight",
+                    "font-style",
+                    "text-anchor",
+                    "dominant-baseline",
+                    "class",
+                ],
+            )?;
+            out.push(Primitive::Text(parse_text_attrs(attrs, style)?));
+        }
+        _ => return Err(format!("svg.element.unsupported:{name}")),
+    }
+    Ok(())
+}
+
+fn parse_style(
+    attrs: &BTreeMap<String, String>,
+    parent: &Style,
+    extras: &[&str],
+) -> Result<Style, String> {
+    const STYLE_ATTRS: &[&str] = &[
+        "fill",
+        "stroke",
+        "stroke-width",
+        "stroke-dasharray",
+        "stroke-linecap",
+        "stroke-linejoin",
+        "opacity",
+    ];
+    for key in attrs.keys() {
+        if !STYLE_ATTRS.contains(&key.as_str()) && !extras.contains(&key.as_str()) {
+            return Err(format!("svg.attribute.unsupported:{key}"));
+        }
+    }
+    let mut out = parent.clone();
+    if let Some(value) = attrs.get("fill") {
+        out.fill = paint(value)?;
+    }
+    if let Some(value) = attrs.get("stroke") {
+        out.stroke = paint(value)?;
+    }
+    if let Some(value) = attrs.get("stroke-width") {
+        out.stroke_width = finite(value, "stroke-width")?;
+        nonnegative(out.stroke_width, "stroke-width")?;
+    }
+    if let Some(value) = attrs.get("stroke-dasharray") {
+        out.dash = if value.trim().eq_ignore_ascii_case("none") {
+            None
+        } else {
+            let values = number_list(value)?;
+            if values.is_empty()
+                || values.len() > 64
+                || values.iter().any(|v| *v < 0.0)
+                || values.iter().all(|v| *v == 0.0)
+            {
+                return Err("svg.attribute.invalid:stroke-dasharray".into());
+            }
+            Some(values)
+        };
+    }
+    if let Some(value) = attrs.get("stroke-linecap") {
+        out.line_cap = match value.as_str() {
+            "butt" => LineCap::Butt,
+            "round" => LineCap::Round,
+            "square" => LineCap::Square,
+            _ => return Err("svg.attribute.invalid:stroke-linecap".into()),
+        };
+    }
+    if let Some(value) = attrs.get("stroke-linejoin") {
+        out.line_join = match value.as_str() {
+            "miter" => LineJoin::Miter,
+            "round" => LineJoin::Round,
+            "bevel" => LineJoin::Bevel,
+            _ => return Err("svg.attribute.invalid:stroke-linejoin".into()),
+        };
+    }
+    if let Some(value) = attrs.get("opacity") {
+        let opacity = finite(value, "opacity")?;
+        if !(0.0..=1.0).contains(&opacity) {
+            return Err("svg.attribute.invalid:opacity".into());
+        }
+        out.opacity *= opacity as f32;
+    }
+    Ok(out)
+}
+
+fn parse_text_attrs(
+    attrs: &BTreeMap<String, String>,
+    style: Style,
+) -> Result<TextPrimitive, String> {
+    if style.stroke.is_some() {
+        return Err("svg.text.stroke_unsupported".into());
+    }
+    let anchor = match attrs
+        .get("text-anchor")
+        .map(String::as_str)
+        .unwrap_or("start")
+    {
+        "start" => TextAnchor::Start,
+        "middle" => TextAnchor::Middle,
+        "end" => TextAnchor::End,
+        _ => return Err("svg.attribute.invalid:text-anchor".into()),
+    };
+    let dominant_baseline = match attrs
+        .get("dominant-baseline")
+        .map(String::as_str)
+        .unwrap_or("auto")
+    {
+        "auto" | "alphabetic" => DominantBaseline::Auto,
+        "central" | "middle" => DominantBaseline::Central,
+        _ => return Err("svg.attribute.invalid:dominant-baseline".into()),
+    };
+    let weight = attrs
+        .get("font-weight")
+        .map(String::as_str)
+        .unwrap_or("400");
+    let bold = match weight {
+        "bold" | "600" | "700" | "800" | "900" => true,
+        "normal" | "100" | "200" | "300" | "400" | "500" => false,
+        _ => return Err("svg.attribute.invalid:font-weight".into()),
+    };
+    let italic = match attrs
+        .get("font-style")
+        .map(String::as_str)
+        .unwrap_or("normal")
+    {
+        "normal" => false,
+        "italic" | "oblique" => true,
+        _ => return Err("svg.attribute.invalid:font-style".into()),
+    };
+    let size = number(attrs, "font-size", 16.0)?;
+    if size <= 0.0 {
+        return Err("svg.attribute.invalid:font-size".into());
+    }
+    Ok(TextPrimitive {
+        x: number(attrs, "x", 0.0)?,
+        y: number(attrs, "y", 0.0)?,
+        size,
+        text: String::new(),
+        anchor,
+        dominant_baseline,
+        bold,
+        italic,
+        family: attrs.get("font-family").cloned(),
+        style,
+    })
+}
+
+fn paint(value: &str) -> Result<Option<Color>, String> {
+    let value = value.trim().to_ascii_lowercase();
+    if value == "none" || value == "transparent" {
+        return Ok(None);
+    }
+    let (r, g, b) = match value.as_str() {
+        "black" => (0, 0, 0),
+        "white" => (255, 255, 255),
+        "red" => (255, 0, 0),
+        "green" => (0, 128, 0),
+        "blue" => (0, 0, 255),
+        "gray" | "grey" => (128, 128, 128),
+        _ if value.starts_with('#') => parse_hex_color(&value)?,
+        _ => return Err("svg.paint.unsupported".into()),
+    };
+    Ok(Some(Color { r, g, b, a: 255 }))
+}
+
+fn parse_hex_color(value: &str) -> Result<(u8, u8, u8), String> {
+    let h = value.trim_start_matches('#');
+    match h.len() {
+        3 => {
+            let mut it = h.chars();
+            let r = hex(it.next().unwrap())?;
+            let g = hex(it.next().unwrap())?;
+            let b = hex(it.next().unwrap())?;
+            Ok((r * 17, g * 17, b * 17))
+        }
+        6 => Ok((
+            u8::from_str_radix(&h[0..2], 16).map_err(|_| "svg.paint.invalid")?,
+            u8::from_str_radix(&h[2..4], 16).map_err(|_| "svg.paint.invalid")?,
+            u8::from_str_radix(&h[4..6], 16).map_err(|_| "svg.paint.invalid")?,
+        )),
+        _ => Err("svg.paint.invalid".into()),
+    }
+}
+
+fn hex(c: char) -> Result<u8, String> {
+    c.to_digit(16)
+        .map(|v| v as u8)
+        .ok_or_else(|| "svg.paint.invalid".into())
+}
+
+fn required_number(attrs: &BTreeMap<String, String>, key: &str) -> Result<f64, String> {
+    let value = attrs
+        .get(key)
+        .ok_or_else(|| format!("svg.attribute.missing:{key}"))?;
+    finite(value, key)
+}
+
+fn number(attrs: &BTreeMap<String, String>, key: &str, default: f64) -> Result<f64, String> {
+    attrs
+        .get(key)
+        .map_or(Ok(default), |value| finite(value, key))
+}
+
+fn finite(value: &str, key: &str) -> Result<f64, String> {
+    let parsed = value
+        .trim()
+        .parse::<f64>()
+        .map_err(|_| format!("svg.attribute.invalid:{key}"))?;
+    if !parsed.is_finite() || parsed.abs() > MAX_ABS_COORD {
+        return Err(format!("svg.attribute.out_of_range:{key}"));
+    }
+    Ok(parsed)
+}
+
+fn nonnegative(value: f64, key: &str) -> Result<(), String> {
+    if value < 0.0 {
+        Err(format!("svg.attribute.negative:{key}"))
+    } else {
+        Ok(())
+    }
+}
+
+fn number_list(value: &str) -> Result<Vec<f64>, String> {
+    value
+        .split(|c: char| c == ',' || c.is_ascii_whitespace())
+        .filter(|s| !s.is_empty())
+        .map(|s| finite(s, "number-list"))
+        .collect()
+}
+
+fn parse_points(value: &str) -> Result<Vec<PathCommand>, String> {
+    let values = number_list(value)?;
+    if values.len() < 2 || values.len() % 2 != 0 || values.len() / 2 > MAX_PATH_COMMANDS {
+        return Err("svg.path.invalid_points".into());
+    }
+    let mut out = Vec::with_capacity(values.len() / 2);
+    for (idx, pair) in values.chunks_exact(2).enumerate() {
+        out.push(if idx == 0 {
+            PathCommand::Move(pair[0], pair[1])
+        } else {
+            PathCommand::Line(pair[0], pair[1])
+        });
+    }
+    Ok(out)
+}
+
+fn parse_path(d: &str) -> Result<Vec<PathCommand>, String> {
+    if d.len() > MAX_BYTES {
+        return Err("svg.limit.path_bytes".into());
+    }
+    let mut out = Vec::new();
+    let (mut x, mut y) = (0.0, 0.0);
+    let (mut sx, mut sy) = (0.0, 0.0);
+    let mut last_cubic: Option<(f64, f64)> = None;
+    let mut last_quad: Option<(f64, f64)> = None;
+
+    for segment in PathParser::from(d) {
+        if out.len() >= MAX_PATH_COMMANDS {
+            return Err("svg.limit.path_commands".into());
+        }
+        let segment = segment.map_err(|_| "svg.path.malformed")?;
+        match segment {
+            PathSegment::MoveTo { abs, x: nx, y: ny } => {
+                (x, y) = absolute(abs, x, y, nx, ny)?;
+                (sx, sy) = (x, y);
+                out.push(PathCommand::Move(x, y));
+                last_cubic = None;
+                last_quad = None;
+            }
+            PathSegment::LineTo { abs, x: nx, y: ny } => {
+                (x, y) = absolute(abs, x, y, nx, ny)?;
+                out.push(PathCommand::Line(x, y));
+                last_cubic = None;
+                last_quad = None;
+            }
+            PathSegment::HorizontalLineTo { abs, x: nx } => {
+                x = checked(if abs { nx } else { x + nx })?;
+                out.push(PathCommand::Line(x, y));
+                last_cubic = None;
+                last_quad = None;
+            }
+            PathSegment::VerticalLineTo { abs, y: ny } => {
+                y = checked(if abs { ny } else { y + ny })?;
+                out.push(PathCommand::Line(x, y));
+                last_cubic = None;
+                last_quad = None;
+            }
+            PathSegment::CurveTo {
+                abs,
+                x1,
+                y1,
+                x2,
+                y2,
+                x: nx,
+                y: ny,
+            } => {
+                let (c1x, c1y) = absolute(abs, x, y, x1, y1)?;
+                let (c2x, c2y) = absolute(abs, x, y, x2, y2)?;
+                let (ex, ey) = absolute(abs, x, y, nx, ny)?;
+                out.push(PathCommand::Cubic(c1x, c1y, c2x, c2y, ex, ey));
+                (x, y) = (ex, ey);
+                last_cubic = Some((c2x, c2y));
+                last_quad = None;
+            }
+            PathSegment::SmoothCurveTo {
+                abs,
+                x2,
+                y2,
+                x: nx,
+                y: ny,
+            } => {
+                let (c1x, c1y) = last_cubic.map_or((x, y), |(cx, cy)| (2.0 * x - cx, 2.0 * y - cy));
+                let (c2x, c2y) = absolute(abs, x, y, x2, y2)?;
+                let (ex, ey) = absolute(abs, x, y, nx, ny)?;
+                out.push(PathCommand::Cubic(c1x, c1y, c2x, c2y, ex, ey));
+                (x, y) = (ex, ey);
+                last_cubic = Some((c2x, c2y));
+                last_quad = None;
+            }
+            PathSegment::Quadratic {
+                abs,
+                x1,
+                y1,
+                x: nx,
+                y: ny,
+            } => {
+                let (cx, cy) = absolute(abs, x, y, x1, y1)?;
+                let (ex, ey) = absolute(abs, x, y, nx, ny)?;
+                out.push(PathCommand::Quad(cx, cy, ex, ey));
+                (x, y) = (ex, ey);
+                last_quad = Some((cx, cy));
+                last_cubic = None;
+            }
+            PathSegment::SmoothQuadratic { abs, x: nx, y: ny } => {
+                let (cx, cy) = last_quad.map_or((x, y), |(qx, qy)| (2.0 * x - qx, 2.0 * y - qy));
+                let (ex, ey) = absolute(abs, x, y, nx, ny)?;
+                out.push(PathCommand::Quad(cx, cy, ex, ey));
+                (x, y) = (ex, ey);
+                last_quad = Some((cx, cy));
+                last_cubic = None;
+            }
+            PathSegment::EllipticalArc {
+                abs,
+                rx,
+                ry,
+                x_axis_rotation,
+                large_arc,
+                sweep,
+                x: nx,
+                y: ny,
+            } => {
+                let (ex, ey) = absolute(abs, x, y, nx, ny)?;
+                let rx = checked(rx.abs())?;
+                let ry = checked(ry.abs())?;
+                if rx == 0.0 || ry == 0.0 || (x == ex && y == ey) {
+                    out.push(PathCommand::Line(ex, ey));
+                } else {
+                    let svg_arc = SvgArc {
+                        from: KurboPoint::new(x, y),
+                        to: KurboPoint::new(ex, ey),
+                        radii: Vec2::new(rx, ry),
+                        x_rotation: x_axis_rotation.to_radians(),
+                        large_arc,
+                        sweep,
+                    };
+                    if let Some(arc) = Arc::from_svg_arc(&svg_arc) {
+                        arc.to_cubic_beziers(0.1, |p1, p2, p3| {
+                            out.push(PathCommand::Cubic(p1.x, p1.y, p2.x, p2.y, p3.x, p3.y));
+                        });
+                        if out.len() > MAX_PATH_COMMANDS {
+                            return Err("svg.limit.path_commands".into());
+                        }
+                    } else {
+                        out.push(PathCommand::Line(ex, ey));
+                    }
+                }
+                (x, y) = (ex, ey);
+                last_cubic = None;
+                last_quad = None;
+            }
+            PathSegment::ClosePath { .. } => {
+                out.push(PathCommand::Close);
+                (x, y) = (sx, sy);
+                last_cubic = None;
+                last_quad = None;
+            }
+        }
+    }
+    if out.is_empty() {
+        return Err("svg.path.empty".into());
+    }
+    Ok(out)
+}
+
+fn absolute(abs: bool, x: f64, y: f64, nx: f64, ny: f64) -> Result<(f64, f64), String> {
+    if abs {
+        Ok((checked(nx)?, checked(ny)?))
+    } else {
+        Ok((checked(x + nx)?, checked(y + ny)?))
+    }
+}
+
+fn checked(value: f64) -> Result<f64, String> {
+    if value.is_finite() && value.abs() <= MAX_ABS_COORD {
+        Ok(value)
+    } else {
+        Err("svg.path.out_of_range".into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_equation_and_chart_primitives() {
+        let equation = r##"<g class="eq"><text x="2" y="12" font-size="12" fill="#123">x</text><line x1="0" y1="15" x2="20" y2="15" stroke="#000" stroke-width="1"/><path d="M0 0 Q5 10 10 0" fill="none" stroke="#000"/><circle cx="3" cy="3" r="2" fill="#f00"/></g>"##;
+        assert_eq!(parse(equation).unwrap().primitives.len(), 4);
+
+        let chart = r##"<g class="hwp-gen-chart" data-chart-type="pie"><rect x="0" y="0" width="20" height="20" fill="#fff"/><polyline points="0,10 5,2 10,8" fill="none" stroke="#00f" stroke-linejoin="round"/><path d="M10,10 L10,1 A9,9 0 0 1 19,10 Z" fill="#0f0"/></g>"##;
+        let parsed = parse(chart).unwrap();
+        assert_eq!(parsed.primitives.len(), 3);
+        assert!(matches!(parsed.primitives[2], Primitive::Path { .. }));
+    }
+
+    #[test]
+    fn accepts_the_actual_vendored_rhwp_ooxml_chart_output() {
+        const BAR_XML: &str = r#"<?xml version="1.0"?>
+<c:chartSpace xmlns:c="x" xmlns:a="y"><c:chart><c:title><c:tx><c:rich><a:p><a:r><a:t>매출</a:t></a:r></a:p></c:rich></c:tx></c:title><c:plotArea><c:barChart><c:barDir val="col"/><c:ser><c:tx><c:strRef><c:strCache><c:pt idx="0"><c:v>2023</c:v></c:pt></c:strCache></c:strRef></c:tx><c:cat><c:strRef><c:strCache><c:pt idx="0"><c:v>1월</c:v></c:pt><c:pt idx="1"><c:v>2월</c:v></c:pt></c:strCache></c:strRef></c:cat><c:val><c:numRef><c:numCache><c:pt idx="0"><c:v>10</c:v></c:pt><c:pt idx="1"><c:v>20</c:v></c:pt></c:numCache></c:numRef></c:val></c:ser></c:barChart></c:plotArea></c:chart></c:chartSpace>"#;
+        let chart =
+            rhwp::ooxml_chart::OoxmlChart::parse(BAR_XML.as_bytes()).expect("rhwp chart parses");
+        let svg = chart.render_svg(0.0, 0.0, 320.0, 180.0);
+        assert!(svg.contains("hwp-ooxml-chart"));
+        let fragment =
+            parse(&svg).expect("every primitive emitted by rhwp belongs to the bounded subset");
+        assert!(!fragment.primitives.is_empty());
+    }
+
+    #[test]
+    fn rejects_active_or_external_svg_features() {
+        for bad in [
+            "<script>alert(1)</script>",
+            "<foreignObject><div>x</div></foreignObject>",
+            "<image href=\"https://example.test/a.png\"/>",
+            "<use href=\"#x\"/>",
+            "<rect onclick=\"x()\" width=\"1\" height=\"1\"/>",
+            "<rect style=\"fill:red\" width=\"1\" height=\"1\"/>",
+            "<g transform=\"translate(1)\"><rect width=\"1\" height=\"1\"/></g>",
+            "<!DOCTYPE svg><rect width=\"1\" height=\"1\"/>",
+        ] {
+            assert!(parse(bad).is_err(), "must reject {bad}");
+        }
+    }
+
+    #[test]
+    fn rejects_limits_nonfinite_and_unknown_attributes() {
+        assert!(parse("<rect x=\"NaN\" width=\"1\" height=\"1\"/>").is_err());
+        assert!(parse("<rect mystery=\"1\" width=\"1\" height=\"1\"/>").is_err());
+        assert!(parse(&"x".repeat(MAX_BYTES + 1)).is_err());
+        let deep = format!(
+            "{}<rect width=\"1\" height=\"1\"/>{}",
+            "<g>".repeat(MAX_DEPTH + 1),
+            "</g>".repeat(MAX_DEPTH + 1)
+        );
+        assert!(parse(&deep).is_err());
+    }
+}

--- a/crates/hwp-model/src/document.rs
+++ b/crates/hwp-model/src/document.rs
@@ -387,7 +387,7 @@ pub struct EquationRef {
     /// never part of the equation's semantic identity: `None` (no rhwp / un-rendered) keeps the old
     /// stub-box behavior byte-for-byte, so this is purely additive. Consumed by the own-render SvgSink
     /// (embedded as a `<g transform=translate(box)>`) and the HTML export (inline `<svg>`); the PDF
-    /// backend ignores it (v1 stub deferred — no SVG→PDF path yet).
+    /// backend replays the same bounded primitive subset as vectors (#102).
     pub rendered_svg: Option<String>,
 }
 
@@ -398,7 +398,7 @@ pub struct EquationRef {
 /// the chart's identity: `None` (no rhwp / legacy OLE VtChart / parse failure) keeps the stub box
 /// byte-for-byte, so this is purely additive. Consumed by the own-render SvgSink (rides the SHARED
 /// `PaintOp::Image.svg` channel — same as an equation) and the HTML export (inline `<svg>`); the PDF
-/// backend ignores it (v1 stub deferred — no SVG→PDF path yet).
+/// backend replays the same bounded primitive subset as vectors (#102).
 #[derive(Clone, Debug)]
 pub struct ChartRef {
     pub width: HwpUnit,

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -23,6 +23,14 @@
   트리를 그대로 보존해 재배치하고 새 CI를 실행 중이다. **다음:** 이 변경을 단일 커밋으로 만든 뒤
   #145 green/병합 → 최신 main 위 rebase → push/PR(`Closes #141`) → 필수 CI, 이어 #142 착수.
 
+- 갱신: 2026-08-23 · Codex(sol) — **#102 PR #138 개설 · 3단 stacked merge 승인 대기**.
+  `eb94323`을 push하고 PR #138(`Closes #102`, base=`codex/issue-101-pdf-calibration`)을
+  개설했으며 MERGEABLE이다. 공개 이슈 #102에도 bounded parser/vector replay, fail-closed stub,
+  계수 불변식, public HWPX·rhwp fragment 회귀와 시각 수치를 기록했다. 현재 #136은 main 기준
+  MERGEABLE이고 필수 CI `issue-link`·`build-test`·`licenses` green, #137과 #138은 각각 부모
+  브랜치 기준 MERGEABLE이라 checks가 없는 정상 stacked 상태다. **다음:** 사용자 승인 후 #136
+  병합 → #137 main retarget·필수 CI·승인 병합 → #138 main retarget·필수 CI·승인 병합.
+
 - 갱신: 2026-08-23 · Codex(sol) — **#102 equation/chart SVG→PDF vector replay 구현·검증 완료**.
   #101 head `92f7a63` 위 `codex/issue-102-pdf-svg-replay`에서 PDF sink가 버리던
   `PaintOp::Image.svg`를 외부 fetch 없는 제한 SVG parser로 해석해 krilla vector로 재생한다.

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -23,6 +23,20 @@
   트리를 그대로 보존해 재배치하고 새 CI를 실행 중이다. **다음:** 이 변경을 단일 커밋으로 만든 뒤
   #145 green/병합 → 최신 main 위 rebase → push/PR(`Closes #141`) → 필수 CI, 이어 #142 착수.
 
+- 갱신: 2026-08-23 · Codex(sol) — **#102 equation/chart SVG→PDF vector replay 구현·검증 완료**.
+  #101 head `92f7a63` 위 `codex/issue-102-pdf-svg-replay`에서 PDF sink가 버리던
+  `PaintOp::Image.svg`를 외부 fetch 없는 제한 SVG parser로 해석해 krilla vector로 재생한다.
+  허용 subset은 group/basic shape/path/text이며 script·event·foreignObject·external URL·namespace와
+  크기/깊이/명령 한도를 위반하면 빈칸 대신 visible stub+stable diagnostic으로 fail-closed한다.
+  페이지별 text/table/image/equation/chart produced=replayed+stubbed 불변식을 export가 강제하며,
+  synthetic 수식·차트, public `SimpleEquation.hwpx`, 실제 vendored rhwp chart fragment 회귀를 잠갔다.
+  own SVG↔PDF 144 DPI 실측은 equation ink 535/505(1.059), chart 18753/19014(0.986),
+  ink F1 0.9759·edge F1 0.9870; placeholder border가 아닌 내부 ink를 CI에서 강제한다.
+  `verify-local --full`은 Rust/wasm/JS·Vitest 269+64+425+247와 별도 Playwright 85 pass/3 skip,
+  최종 quick도 canonical 8/18/24·98.9%+, PDF 51, oracle 82, licenses까지 PASS했다.
+  **다음:** commit·push → #102 stacked PR(base=#101 branch, `Closes #102`) → #136 사용자 승인
+  병합 → #137 main retarget/CI/승인 → #102 main retarget/CI/승인 순서를 지킨다.
+
 - 갱신: 2026-08-23 · Codex(sol) — **PR #136 병합 · 데스크톱 #139 로드맵/#140 구현·실앱 QA**.
   사용자 승인에 따라 #136을 squash 병합(main `0c354cb`, #100 close)했고 #137은 main 위
   `ad55605`로 재배치해 필수 checks 3종 green·MERGEABLE, #138은 그 위 `e18a396`로 정리했다.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -18,6 +18,11 @@
 - 실제 `.app`: 편집→dirty-close 차단→0600 snapshot→강제종료→최신 rev 복원→저장/clean 종료 PASS.
 - #137/#145 green 유지·미병합; 다음은 승인 후 #141 commit/PR, #145 병합 뒤 #142.
 
+## 2026-08-23 (Codex sol) · #102 PR #138 개설
+- `eb94323` push, PR #138(`Closes #102`, base=#137 branch) MERGEABLE; 이슈에 검증 근거 기록.
+- #136은 main 기준 필수 CI 3종 green, #137/#138은 부모 브랜치 기준 checks 없는 정상 stack.
+- 다음: #136 승인 병합 → #137 main retarget/CI/승인 → #138 main retarget/CI/승인.
+
 ## 2026-08-23 (Codex sol) · #102 SVG→PDF parity 구현 완료
 - equation/chart SVG를 제한 parser→krilla vector로 재생; unsupported는 visible stub+진단.
 - page별 produced/replayed/stubbed 균형과 public HWPX·실제 rhwp chart fragment 회귀를 잠금.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -18,6 +18,12 @@
 - 실제 `.app`: 편집→dirty-close 차단→0600 snapshot→강제종료→최신 rev 복원→저장/clean 종료 PASS.
 - #137/#145 green 유지·미병합; 다음은 승인 후 #141 commit/PR, #145 병합 뒤 #142.
 
+## 2026-08-23 (Codex sol) · #102 SVG→PDF parity 구현 완료
+- equation/chart SVG를 제한 parser→krilla vector로 재생; unsupported는 visible stub+진단.
+- page별 produced/replayed/stubbed 균형과 public HWPX·실제 rhwp chart fragment 회귀를 잠금.
+- equation/chart 내부 ink ratio 1.059/0.986, ink F1 0.9759·edge F1 0.9870.
+- full verify+Playwright 85 pass/3 skip와 최종 quick PASS; 다음은 stacked PR 후 #136부터 승인 병합.
+
 ## 2026-08-23 (Codex sol) · #136 병합 · #140 데스크톱 파일 열기 구현
 - #136 squash 병합(main `0c354cb`, #100 close); #137은 green/MERGEABLE, #138 stack 재정렬.
 - #139 우산과 #140~#144를 만들고 #140 single-instance/cold·warm open/교체 확인을 구현.

--- a/scripts/pdf-svg-parity-check.py
+++ b/scripts/pdf-svg-parity-check.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""Bounded #102 SVG-sink ↔ PDF-sink parity integration check.
+
+The comparison stays report-only for visual quality. Its only pass/fail assertion is narrower: the
+known equation/chart object interiors must contain real ink in both the SVG-derived T3 reference and
+the own PDF export. That catches the historical whole-object placeholder without inventing a document
+quality threshold.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+from typing import Dict, Iterable, List, Tuple
+
+
+REPO = Path(__file__).resolve().parents[1]
+DPI = 144
+PX_SCALE = DPI / 96.0
+INK_THRESHOLD = 200
+MIN_INTERIOR_INK = 12
+MAX_OUTPUT_BYTES = 2 * 1024 * 1024
+
+
+class CheckError(RuntimeError):
+    pass
+
+
+def run(args: List[str], *, cwd: Path = REPO, timeout: int = 180) -> str:
+    result = subprocess.run(
+        args,
+        cwd=cwd,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        timeout=timeout,
+        check=False,
+    )
+    output = result.stdout[:MAX_OUTPUT_BYTES].decode("utf-8", "replace")
+    if result.returncode != 0:
+        raise CheckError(f"{' '.join(args[:3])} exited {result.returncode}:\n{output}")
+    return output
+
+
+def require_tools(names: Iterable[str]) -> None:
+    missing = [name for name in names if shutil.which(name) is None]
+    if missing:
+        raise CheckError("required tools unavailable: " + ", ".join(missing))
+
+
+def read_pgm(path: Path) -> Tuple[int, int, bytes]:
+    data = path.read_bytes()
+    if not data.startswith(b"P5"):
+        raise CheckError(f"not a binary PGM: {path}")
+    index = 2
+
+    def token() -> bytes:
+        nonlocal index
+        while index < len(data):
+            if data[index] == ord("#"):
+                end = data.find(b"\n", index)
+                index = len(data) if end < 0 else end + 1
+            elif chr(data[index]).isspace():
+                index += 1
+            else:
+                break
+        start = index
+        while index < len(data) and not chr(data[index]).isspace():
+            index += 1
+        if start == index:
+            raise CheckError(f"truncated PGM header: {path}")
+        return data[start:index]
+
+    width = int(token())
+    height = int(token())
+    maximum = int(token())
+    if maximum != 255 or width <= 0 or height <= 0:
+        raise CheckError(f"unsupported PGM dimensions/range: {path}")
+    if index >= len(data) or not chr(data[index]).isspace():
+        raise CheckError(f"PGM raster separator missing: {path}")
+    # Consume the header separator, not arbitrary whitespace-valued raster bytes.
+    index += 2 if data[index : index + 2] == b"\r\n" else 1
+    pixels = data[index:]
+    if len(pixels) != width * height:
+        raise CheckError(f"PGM byte count mismatch: {path}")
+    return width, height, pixels
+
+
+def raster(pdf: Path, prefix: Path) -> Tuple[int, int, bytes]:
+    run(
+        [
+            "pdftoppm",
+            "-f",
+            "1",
+            "-l",
+            "1",
+            "-singlefile",
+            "-gray",
+            "-r",
+            str(DPI),
+            str(pdf),
+            str(prefix),
+        ],
+        timeout=60,
+    )
+    return read_pgm(prefix.with_suffix(".pgm"))
+
+
+def boxes(path: Path) -> List[Dict[str, float | str]]:
+    with path.open(encoding="utf-8", newline="") as stream:
+        rows = list(csv.DictReader(stream, delimiter="\t"))
+    if sorted(row["kind"] for row in rows) != ["chart", "equation"]:
+        raise CheckError("fixture must contain exactly one equation and one chart box")
+    parsed: List[Dict[str, float | str]] = []
+    for row in rows:
+        values = {key: float(row[key]) for key in ("x_px", "y_px", "w_px", "h_px")}
+        if not all(math.isfinite(value) and value >= 0 for value in values.values()):
+            raise CheckError("box coordinates must be finite and non-negative")
+        parsed.append({"kind": row["kind"], **values})
+    return parsed
+
+
+def interior_ink(
+    image: Tuple[int, int, bytes], box: Dict[str, float | str]
+) -> int:
+    width, height, pixels = image
+    x = int(round(float(box["x_px"]) * PX_SCALE))
+    y = int(round(float(box["y_px"]) * PX_SCALE))
+    w = int(round(float(box["w_px"]) * PX_SCALE))
+    h = int(round(float(box["h_px"]) * PX_SCALE))
+    # Ignore the placeholder's outline. Its #f0f0f0 fill is also above INK_THRESHOLD, whereas actual
+    # equation/chart marks are darker and remain inside this inset.
+    inset = max(3, min(w, h) // 20)
+    x0, y0 = max(0, x + inset), max(0, y + inset)
+    x1, y1 = min(width, x + w - inset), min(height, y + h - inset)
+    if x1 <= x0 or y1 <= y0:
+        raise CheckError(f"degenerate clipped {box['kind']} box")
+    return sum(
+        1
+        for yy in range(y0, y1)
+        for value in pixels[yy * width + x0 : yy * width + x1]
+        if value <= INK_THRESHOLD
+    )
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output-dir", required=True)
+    parsed = parser.parse_args(argv)
+    output = Path(parsed.output_dir).resolve()
+    if output.exists():
+        raise CheckError(f"refusing to overwrite output directory: {output}")
+    output.mkdir(parents=True, mode=0o700)
+
+    require_tools(("cargo", "rsvg-convert", "pdfinfo", "pdftoppm"))
+    run(
+        [
+            "cargo",
+            "run",
+            "-q",
+            "-p",
+            "hwp-export",
+            "--features",
+            "pdf",
+            "--example",
+            "svg_pdf_parity",
+            "--",
+            str(output),
+        ]
+    )
+    reference = output / "svg-reference.pdf"
+    run(
+        [
+            "rsvg-convert",
+            "--format",
+            "pdf",
+            "--output",
+            str(reference),
+            str(output / "own.svg"),
+        ],
+        timeout=60,
+    )
+
+    report_dir = output / "visual-report"
+    run(
+        [
+            sys.executable,
+            str(REPO / "scripts/pdf-visual-check.py"),
+            str(output / "own.pdf"),
+            "--reference",
+            str(reference),
+            "--reference-tier",
+            "T3",
+            "--reference-product",
+            "librsvg",
+            "--reference-note",
+            "Controlled own-SVG debug rendering; not ground truth and no quality threshold.",
+            "--output-dir",
+            str(report_dir),
+        ],
+        timeout=180,
+    )
+    report = json.loads((report_dir / "report.json").read_text(encoding="utf-8"))
+    if report.get("status") != "scored_report" or report.get("policy", {}).get("pass") is not None:
+        raise CheckError("visual oracle must produce one report-only scored page")
+
+    own_image = raster(output / "own.pdf", output / "own-page")
+    reference_image = raster(reference, output / "reference-page")
+    if own_image[:2] != reference_image[:2]:
+        raise CheckError(f"raster dimensions differ: {own_image[:2]} vs {reference_image[:2]}")
+
+    results = []
+    for box in boxes(output / "boxes.tsv"):
+        own_ink = interior_ink(own_image, box)
+        reference_ink = interior_ink(reference_image, box)
+        if own_ink < MIN_INTERIOR_INK or reference_ink < MIN_INTERIOR_INK:
+            raise CheckError(
+                f"{box['kind']} lost interior ink: own={own_ink}, reference={reference_ink}"
+            )
+        ratio = own_ink / reference_ink
+        if not 0.05 <= ratio <= 20.0:
+            raise CheckError(f"{box['kind']} gross ink mismatch: ratio={ratio:.4f}")
+        results.append(
+            {
+                "kind": box["kind"],
+                "own_interior_ink_pixels": own_ink,
+                "reference_interior_ink_pixels": reference_ink,
+                "ratio": round(ratio, 6),
+            }
+        )
+
+    summary = {
+        "schema_version": 1,
+        "policy": "presence-only; visual quality remains report-only",
+        "dpi": DPI,
+        "ink_threshold": INK_THRESHOLD,
+        "objects": results,
+        "visual_report_status": report["status"],
+    }
+    (output / "parity-summary.json").write_text(
+        json.dumps(summary, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    )
+    print(
+        "PDF SVG parity OK: "
+        + ", ".join(
+            f"{item['kind']} own/ref ink={item['own_interior_ink_pixels']}/"
+            f"{item['reference_interior_ink_pixels']}"
+            for item in results
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (CheckError, OSError, ValueError, subprocess.TimeoutExpired) as error:
+        print(f"pdf-svg-parity-check: {error}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/verify-local.sh
+++ b/scripts/verify-local.sh
@@ -52,6 +52,13 @@ node --test \
 node scripts/gov-source-catalog.mjs --check
 node scripts/public-corpus-intake.mjs --check
 node scripts/pdf-visual-calibrate.mjs --check
+if command -v rsvg-convert >/dev/null && command -v pdfinfo >/dev/null && command -v pdftoppm >/dev/null; then
+  parity_tmp=$(mktemp -d "${TMPDIR:-/tmp}/auto-hwp-pdf-svg-parity.XXXXXX")
+  python3 scripts/pdf-svg-parity-check.py --output-dir "$parity_tmp/result"
+  rm -rf "$parity_tmp"
+else
+  echo "⚠️  PDF SVG parity skipped(rsvg-convert/Poppler 부재 — CI에서는 필수 실행)"
+fi
 
 echo "═══ 조판 오라클 스윕 산출물 (이슈 72 — 전수 재실행 아님 · 커밋된 요약만) ═══"
 # 코퍼스 전수 layout-check 는 로컬 `node scripts/oracle-sweep.mjs` (--check 가 회귀).


### PR DESCRIPTION
Closes #102

## Outcome
- replay the bounded equation/chart SVG subset into krilla PDF vectors instead of silently drawing placeholders
- enforce per-page produced = replayed + stubbed accounting for text, table geometry, images, equations, and charts
- reject active/external SVG content and surface unsupported fragments as visible stubs with stable diagnostics
- lock synthetic, public HWPX, and vendored-rhwp chart-fragment regressions
- compare own SVG and PDF at 144 DPI and require real equation/chart interior ink in CI

## Verification
- cargo test -p hwp-export --features pdf: 36 passed
- scripts/verify-local.sh --full: Rust, wasm, JS builds and Vitest passed
- Playwright: 85 passed, 3 intentionally skipped
- final scripts/verify-local.sh quick: passed
- visual integration: equation own/reference ink 535/505; chart 18753/19014; ink F1 0.9759; edge F1 0.9870
- canonical layout remains 8/18/24 pages and 98.9%+ line accuracy; committed 82-document oracle unchanged

## Stack
This PR is intentionally based on codex/issue-101-pdf-calibration. Merge order is #136, #137, then this PR. After its parents land, retarget this PR to main and rerun required checks before merge.