### PR TITLE
feat: add lossless desktop recovery lifecycle

### DIFF
--- a/crates/hwp-viewer/src/desktop_state.rs
+++ b/crates/hwp-viewer/src/desktop_state.rs
@@ -1,0 +1,252 @@
+//! Desktop document lifecycle state for issue #141.
+//!
+//! This state deliberately separates the in-memory source identity (needed to detect an external
+//! overwrite race) from recovery metadata persisted under app-data. Source paths never leave this
+//! process through the recovery store, events, logs, or telemetry.
+
+use serde::Serialize;
+use std::path::{Path, PathBuf};
+use std::time::UNIX_EPOCH;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct SourceIdentity {
+    canonical_path: PathBuf,
+    len: u64,
+    modified_ns: u128,
+    #[cfg(unix)]
+    device: u64,
+    #[cfg(unix)]
+    inode: u64,
+}
+
+impl SourceIdentity {
+    fn read(path: &Path) -> Result<Self, String> {
+        let canonical_path =
+            std::fs::canonicalize(path).map_err(|e| format!("source identity unavailable: {e}"))?;
+        let metadata = std::fs::metadata(&canonical_path)
+            .map_err(|e| format!("source identity unavailable: {e}"))?;
+        if !metadata.is_file() {
+            return Err("source identity unavailable: not a regular file".into());
+        }
+        let modified_ns = metadata
+            .modified()
+            .ok()
+            .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
+            .map(|duration| duration.as_nanos())
+            .unwrap_or(0);
+        #[cfg(unix)]
+        use std::os::unix::fs::MetadataExt;
+        Ok(Self {
+            canonical_path,
+            len: metadata.len(),
+            modified_ns,
+            #[cfg(unix)]
+            device: metadata.dev(),
+            #[cfg(unix)]
+            inode: metadata.ino(),
+        })
+    }
+
+    fn same_target(&self, path: &Path) -> bool {
+        std::fs::canonicalize(path).is_ok_and(|candidate| candidate == self.canonical_path)
+    }
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct DesktopSessionStatus {
+    pub(crate) document_id: Option<String>,
+    pub(crate) revision: u64,
+    pub(crate) saved_revision: u64,
+    pub(crate) dirty: bool,
+    pub(crate) has_source: bool,
+}
+
+#[derive(Default)]
+pub(crate) struct DesktopDocumentState {
+    document_id: Option<String>,
+    saved_revision: u64,
+    source: Option<SourceIdentity>,
+    unsaved: bool,
+    recovery_suppressed: bool,
+    allow_close_once: bool,
+}
+
+impl DesktopDocumentState {
+    pub(crate) fn opened_path(&mut self, path: &Path, revision: u64) -> Result<(), String> {
+        self.document_id = Some(new_document_id()?);
+        self.saved_revision = revision;
+        self.source = Some(SourceIdentity::read(path)?);
+        self.unsaved = false;
+        self.recovery_suppressed = false;
+        self.allow_close_once = false;
+        Ok(())
+    }
+
+    pub(crate) fn opened_recovery(&mut self, revision: u64) -> Result<(), String> {
+        self.document_id = Some(new_document_id()?);
+        self.saved_revision = revision;
+        self.source = None;
+        self.unsaved = true;
+        self.recovery_suppressed = false;
+        self.allow_close_once = false;
+        Ok(())
+    }
+
+    pub(crate) fn status(&self, revision: u64) -> DesktopSessionStatus {
+        DesktopSessionStatus {
+            document_id: self.document_id.clone(),
+            revision,
+            saved_revision: self.saved_revision,
+            dirty: self.document_id.is_some() && (self.unsaved || revision != self.saved_revision),
+            has_source: self.source.is_some(),
+        }
+    }
+
+    /// Return `true` only when the user is saving back over the originally-opened path and its
+    /// identity changed since open/last successful save. A Save As destination is not an external
+    /// conflict; after it succeeds, `mark_saved` adopts it as the new source identity.
+    pub(crate) fn external_conflict(&self, destination: &Path) -> Result<bool, String> {
+        let Some(opened) = &self.source else {
+            return Ok(false);
+        };
+        if !destination.exists() || !opened.same_target(destination) {
+            return Ok(false);
+        }
+        Ok(SourceIdentity::read(destination)? != *opened)
+    }
+
+    pub(crate) fn mark_saved(&mut self, destination: &Path, revision: u64) -> Result<(), String> {
+        self.source = Some(SourceIdentity::read(destination)?);
+        self.saved_revision = revision;
+        self.unsaved = false;
+        self.recovery_suppressed = false;
+        Ok(())
+    }
+
+    pub(crate) fn should_write_recovery(&self, revision: u64) -> bool {
+        !self.recovery_suppressed && self.status(revision).dirty
+    }
+
+    pub(crate) fn suppress_recovery_for(&mut self, document_id: &str) {
+        if self.document_id.as_deref() == Some(document_id) {
+            self.recovery_suppressed = true;
+        }
+    }
+
+    pub(crate) fn document_id(&self) -> Option<&str> {
+        self.document_id.as_deref()
+    }
+
+    pub(crate) fn should_prevent_close(&mut self, revision: u64) -> bool {
+        if self.allow_close_once {
+            self.allow_close_once = false;
+            return false;
+        }
+        self.status(revision).dirty
+    }
+
+    pub(crate) fn allow_close_once(&mut self) {
+        self.allow_close_once = true;
+    }
+}
+
+fn new_document_id() -> Result<String, String> {
+    let mut random = [0_u8; 16];
+    getrandom::fill(&mut random).map_err(|e| format!("document id generation failed: {e}"))?;
+    Ok(random.iter().map(|byte| format!("{byte:02x}")).collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static FIXTURE_ID: AtomicU64 = AtomicU64::new(0);
+
+    struct Fixture(PathBuf);
+
+    impl Fixture {
+        fn new() -> Self {
+            let id = FIXTURE_ID.fetch_add(1, Ordering::Relaxed);
+            let path = std::env::temp_dir().join(format!(
+                "auto-hwp-desktop-state-{}-{id}",
+                std::process::id()
+            ));
+            std::fs::create_dir(&path).unwrap();
+            Self(path)
+        }
+    }
+
+    impl Drop for Fixture {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn revision_dirty_signal_tracks_successful_save() {
+        let fixture = Fixture::new();
+        let source = fixture.0.join("source.hwpx");
+        std::fs::write(&source, b"first").unwrap();
+        let mut state = DesktopDocumentState::default();
+        state.opened_path(&source, 0).unwrap();
+        assert!(!state.status(0).dirty);
+        assert!(state.status(1).dirty);
+        state.mark_saved(&source, 1).unwrap();
+        assert!(!state.status(1).dirty);
+        assert!(state.status(2).dirty);
+    }
+
+    #[test]
+    fn external_source_change_blocks_only_same_destination() {
+        let fixture = Fixture::new();
+        let source = fixture.0.join("source.hwpx");
+        let save_as = fixture.0.join("copy.hwpx");
+        std::fs::write(&source, b"first").unwrap();
+        std::fs::write(&save_as, b"copy").unwrap();
+        let mut state = DesktopDocumentState::default();
+        state.opened_path(&source, 0).unwrap();
+        assert!(!state.external_conflict(&source).unwrap());
+
+        // A size change is deterministic even on filesystems with coarse mtime resolution.
+        std::fs::write(&source, b"externally changed").unwrap();
+        assert!(state.external_conflict(&source).unwrap());
+        assert!(!state.external_conflict(&save_as).unwrap());
+    }
+
+    #[test]
+    fn restored_session_is_unsaved_and_path_free() {
+        let mut state = DesktopDocumentState::default();
+        state.opened_recovery(0).unwrap();
+        let status = state.status(0);
+        assert!(!status.has_source);
+        assert!(status.dirty, "a restored session has no source save point");
+        assert!(status.document_id.is_some());
+    }
+
+    #[test]
+    fn dirty_close_is_prevented_until_one_explicit_bypass() {
+        let mut state = DesktopDocumentState::default();
+        state.opened_recovery(0).unwrap();
+        assert!(state.should_prevent_close(1));
+        state.allow_close_once();
+        assert!(!state.should_prevent_close(1));
+        assert!(state.should_prevent_close(1));
+    }
+
+    #[test]
+    fn explicit_discard_suppresses_a_racing_snapshot_until_save_or_reopen() {
+        let fixture = Fixture::new();
+        let source = fixture.0.join("source.hwpx");
+        std::fs::write(&source, b"first").unwrap();
+        let mut state = DesktopDocumentState::default();
+        state.opened_path(&source, 0).unwrap();
+        let document_id = state.document_id().unwrap().to_owned();
+        assert!(state.should_write_recovery(1));
+        state.suppress_recovery_for(&document_id);
+        assert!(!state.should_write_recovery(1));
+        state.mark_saved(&source, 1).unwrap();
+        assert!(state.should_write_recovery(2));
+    }
+}

--- a/crates/hwp-viewer/src/lib.rs
+++ b/crates/hwp-viewer/src/lib.rs
@@ -6,7 +6,9 @@
 //! hwp-viewer --features rhwp`, or `cargo tauri dev`); the command *logic* is factored into pure
 //! functions so it is unit-testable headless. The A3 embedded control server lives in [`server`].
 
+mod desktop_state;
 mod open_request;
+mod recovery;
 pub mod server;
 
 use serde_json::{json, Value};
@@ -18,8 +20,10 @@ use tauri::{Emitter, Manager};
 /// `Arc` so the heavy commands can clone a handle out of `State` and move it into a
 /// `spawn_blocking` worker, keeping the parse/serialize/render off the async/IPC thread.
 pub type SharedSession = Arc<Mutex<hwp_mcp::Session>>;
+pub(crate) type SharedDesktopState = Arc<Mutex<desktop_state::DesktopDocumentState>>;
 
 const DESKTOP_OPEN_REQUEST_EVENT: &str = "desktop-open-request";
+const DESKTOP_CLOSE_REQUEST_EVENT: &str = "desktop-close-request";
 
 fn queue_open_paths(app: &tauri::AppHandle, paths: Vec<String>) {
     let queued = app.state::<open_request::OpenRequestQueue>().push(paths);
@@ -78,9 +82,18 @@ fn pages(s: &mut hwp_mcp::Session) -> u32 {
 // loop stays responsive on tens-of-MB files; the `Mutex` lock is taken INSIDE the worker (cloning the
 // `Arc` out of `State` first), never on the async runtime thread.
 #[tauri::command]
-async fn open_doc(path: String, sess: tauri::State<'_, SharedSession>) -> Result<Value, String> {
+async fn open_doc(
+    path: String,
+    sess: tauri::State<'_, SharedSession>,
+    desktop: tauri::State<'_, SharedDesktopState>,
+) -> Result<Value, String> {
     let sess = sess.inner().clone();
+    let desktop = desktop.inner().clone();
     tauri::async_runtime::spawn_blocking(move || {
+        // Capture the identity before parsing. The path stays memory-only; recovery metadata receives
+        // only the random document id created here.
+        let mut next_desktop = desktop_state::DesktopDocumentState::default();
+        next_desktop.opened_path(std::path::Path::new(&path), 0)?;
         let mut s = sess.lock().map_err(|_| "session poisoned")?;
         // accepts .hwp (view) and .hwpx; surface the 2-tier capability (editable) + format for the chip.
         let (format, editable) = match apply_intent(&mut s, Intent::Open { path })? {
@@ -89,6 +102,7 @@ async fn open_doc(path: String, sess: tauri::State<'_, SharedSession>) -> Result
             } => (format, editable),
             _ => return Err("unexpected outcome".into()),
         };
+        *desktop.lock().map_err(|_| "desktop state poisoned")? = next_desktop;
 
         Ok(json!({
             "pages": pages(&mut s),
@@ -101,6 +115,152 @@ async fn open_doc(path: String, sess: tauri::State<'_, SharedSession>) -> Result
     })
     .await
     .map_err(|e| e.to_string())?
+}
+
+#[tauri::command]
+async fn open_recovery(
+    document_id: String,
+    generation: u64,
+    app: tauri::AppHandle,
+    sess: tauri::State<'_, SharedSession>,
+    desktop: tauri::State<'_, SharedDesktopState>,
+) -> Result<Value, String> {
+    let app_data = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("app-data directory unavailable: {e}"))?;
+    let sess = sess.inner().clone();
+    let desktop = desktop.inner().clone();
+    tauri::async_runtime::spawn_blocking(move || {
+        let bytes = recovery::RecoveryStore::new(&app_data)?.read(&document_id, generation)?;
+        let mut next_desktop = desktop_state::DesktopDocumentState::default();
+        next_desktop.opened_recovery(0)?;
+        let mut s = sess.lock().map_err(|_| "session poisoned")?;
+        let opened = hwp_mcp::open_bytes(&mut s, &bytes, "recovered.hwpx")?;
+        let pages = pages(&mut s);
+        *desktop.lock().map_err(|_| "desktop state poisoned")? = next_desktop;
+        Ok(json!({
+            "pages": pages,
+            "editable": opened.editable,
+            "format": opened.format,
+            "convertedPath": Value::Null,
+        }))
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+#[tauri::command]
+async fn desktop_session_status(
+    sess: tauri::State<'_, SharedSession>,
+    desktop: tauri::State<'_, SharedDesktopState>,
+) -> Result<desktop_state::DesktopSessionStatus, String> {
+    let sess = sess.inner().clone();
+    let desktop = desktop.inner().clone();
+    tauri::async_runtime::spawn_blocking(move || {
+        let revision = sess
+            .lock()
+            .map_err(|_| "session poisoned")?
+            .doc
+            .as_ref()
+            .map(|doc| doc.revision())
+            .unwrap_or(0);
+        Ok(desktop
+            .lock()
+            .map_err(|_| "desktop state poisoned")?
+            .status(revision))
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+#[tauri::command]
+async fn write_recovery_snapshot(
+    app: tauri::AppHandle,
+    sess: tauri::State<'_, SharedSession>,
+    desktop: tauri::State<'_, SharedDesktopState>,
+) -> Result<Option<recovery::RecoverySummary>, String> {
+    let app_data = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("app-data directory unavailable: {e}"))?;
+    let sess = sess.inner().clone();
+    let desktop = desktop.inner().clone();
+    tauri::async_runtime::spawn_blocking(move || {
+        // Keep the normal session -> desktop lock order through the write. A concurrent Save either
+        // waits and then removes this completed snapshot, or wins first and makes this a clean no-op;
+        // it can never leave a stale recovery record after a successful save.
+        let session = sess.lock().map_err(|_| "session poisoned")?;
+        let revision = session.doc.as_ref().ok_or("no document open")?.revision();
+        let state = desktop.lock().map_err(|_| "desktop state poisoned")?;
+        if !state.should_write_recovery(revision) {
+            return Ok(None);
+        }
+        let document_id = state
+            .document_id()
+            .ok_or("no desktop document open")?
+            .to_owned();
+        let bytes = hwp_mcp::export_bytes(&session)?;
+        let saved_at_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_err(|_| "system clock is before the Unix epoch")?
+            .as_millis()
+            .try_into()
+            .map_err(|_| "system clock timestamp overflow")?;
+        recovery::RecoveryStore::new(&app_data)
+            .and_then(|store| store.write(&document_id, revision, saved_at_ms, &bytes))
+            .map(Some)
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+#[tauri::command]
+async fn list_recovery_snapshots(
+    app: tauri::AppHandle,
+) -> Result<recovery::RecoveryListing, String> {
+    let app_data = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("app-data directory unavailable: {e}"))?;
+    tauri::async_runtime::spawn_blocking(move || {
+        recovery::RecoveryStore::new(&app_data)?.list_with_warnings()
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+#[tauri::command]
+async fn discard_recovery_snapshots(
+    document_id: String,
+    app: tauri::AppHandle,
+    desktop: tauri::State<'_, SharedDesktopState>,
+) -> Result<(), String> {
+    let app_data = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("app-data directory unavailable: {e}"))?;
+    let desktop = desktop.inner().clone();
+    tauri::async_runtime::spawn_blocking(move || {
+        // Mark the live document before deleting. A snapshot already holding the desktop lock
+        // finishes first and is then deleted; one waiting behind this command becomes a no-op.
+        desktop
+            .lock()
+            .map_err(|_| "desktop state poisoned")?
+            .suppress_recovery_for(&document_id);
+        recovery::RecoveryStore::new(&app_data)?.discard_document(&document_id)
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+#[tauri::command]
+fn allow_desktop_close(desktop: tauri::State<'_, SharedDesktopState>) -> Result<(), String> {
+    desktop
+        .lock()
+        .map_err(|_| "desktop state poisoned")?
+        .allow_close_once();
+    Ok(())
 }
 
 #[tauri::command]
@@ -212,16 +372,45 @@ fn apply_content(content: String, sess: tauri::State<'_, SharedSession>) -> Resu
 #[tauri::command]
 async fn export_hwpx(
     path: String,
+    overwrite_confirmed: Option<bool>,
+    app: tauri::AppHandle,
     sess: tauri::State<'_, SharedSession>,
+    desktop: tauri::State<'_, SharedDesktopState>,
 ) -> Result<String, String> {
     let sess = sess.inner().clone();
+    let desktop = desktop.inner().clone();
+    let app_data = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("app-data directory unavailable: {e}"))?;
     tauri::async_runtime::spawn_blocking(move || {
         let mut s = sess.lock().map_err(|_| "session poisoned")?;
+        let revision = s.doc.as_ref().ok_or("no document open")?.revision();
+        let destination = std::path::PathBuf::from(&path);
+        {
+            let state = desktop.lock().map_err(|_| "desktop state poisoned")?;
+            if !overwrite_confirmed.unwrap_or(false) && state.external_conflict(&destination)? {
+                return Err("EXTERNAL_SOURCE_CHANGED".into());
+            }
+        }
         match apply_intent(&mut s, Intent::Export { path })? {
-            Outcome::Exported { bytes, open_safe } => Ok(format!(
-                "{bytes} bytes · editor-open-safety {}",
-                if open_safe { "OK" } else { "FAIL" }
-            )),
+            Outcome::Exported { bytes, open_safe } => {
+                let mut state = desktop.lock().map_err(|_| "desktop state poisoned")?;
+                state.mark_saved(&destination, revision)?;
+                let recovery_warning = state.document_id().and_then(|document_id| {
+                    recovery::RecoveryStore::new(&app_data)
+                        .and_then(|store| store.discard_document(document_id))
+                        .err()
+                });
+                let mut message = format!(
+                    "{bytes} bytes · editor-open-safety {}",
+                    if open_safe { "OK" } else { "FAIL" }
+                );
+                if let Some(error) = recovery_warning {
+                    message.push_str(&format!(" · 저장 성공, 복구본 정리 실패: {error}"));
+                }
+                Ok(message)
+            }
             _ => Err("unexpected outcome".into()),
         }
     })
@@ -1726,16 +1915,46 @@ pub fn run() {
     let app = builder
         .plugin(tauri_plugin_dialog::init())
         .manage(SharedSession::default())
+        .manage(SharedDesktopState::default())
         .manage(open_request::OpenRequestQueue::default())
         .setup(|app| {
             let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
             let paths = open_request::paths_from_argv(std::env::args_os(), &cwd);
             queue_open_paths(app.handle(), paths);
+            if let Some(window) = app.get_webview_window("main") {
+                let handle = app.handle().clone();
+                window.on_window_event(move |event| {
+                    let tauri::WindowEvent::CloseRequested { api, .. } = event else {
+                        return;
+                    };
+                    let revision = handle
+                        .state::<SharedSession>()
+                        .lock()
+                        .ok()
+                        .and_then(|session| session.doc.as_ref().map(|doc| doc.revision()))
+                        .unwrap_or(0);
+                    let prevent = handle
+                        .state::<SharedDesktopState>()
+                        .lock()
+                        .is_ok_and(|mut state| state.should_prevent_close(revision));
+                    if prevent {
+                        api.prevent_close();
+                        // No document metadata in the event; the webview queries only the dirty bit.
+                        let _ = handle.emit(DESKTOP_CLOSE_REQUEST_EVENT, ());
+                    }
+                });
+            }
             server::spawn(app.handle().clone());
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
             open_doc,
+            open_recovery,
+            desktop_session_status,
+            write_recovery_snapshot,
+            list_recovery_snapshots,
+            discard_recovery_snapshots,
+            allow_desktop_close,
             render_page,
             render_doc_html,
             render_own_page,
@@ -2238,5 +2457,37 @@ mod tests {
             reopened.plain_text().contains("바이트 내보내기"),
             "the live edit is in the exported bytes"
         );
+    }
+
+    #[test]
+    fn desktop_recovery_snapshot_reopens_the_latest_completed_revision() {
+        let mut sess = hwp_mcp::Session::default();
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../corpus/hwpx/FormattingShowcase.hwpx"
+        );
+        mcp_call(&mut sess, "open_document", json!({ "path": path })).unwrap();
+        mcp_call(
+            &mut sess,
+            "apply_content",
+            json!({ "content": r#"{"blocks":[{"type":"heading","text":"복구 최신 리비전","style":"개요 1"}]}"# }),
+        )
+        .unwrap();
+        let revision = sess.doc.as_ref().unwrap().revision();
+        let bytes = hwp_mcp::export_bytes(&sess).unwrap();
+        let root = std::env::temp_dir().join(format!(
+            "auto-hwp-recovery-roundtrip-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir(&root).unwrap();
+        let store = recovery::RecoveryStore::new(&root).unwrap();
+        let saved = store
+            .write("00112233445566778899aabbccddeeff", revision, 1, &bytes)
+            .unwrap();
+        let recovered = store.read(&saved.document_id, saved.generation).unwrap();
+        let reopened = hwp_core::Engine::open(&recovered).unwrap();
+        assert!(reopened.plain_text().contains("복구 최신 리비전"));
+        let _ = std::fs::remove_dir_all(&root);
     }
 }

--- a/crates/hwp-viewer/src/recovery.rs
+++ b/crates/hwp-viewer/src/recovery.rs
@@ -1,0 +1,547 @@
+//! Private, bounded desktop recovery snapshots for issue #141.
+//!
+//! Recovery records intentionally contain no source path or document name. The random document id
+//! exists only to group two generations. Bytes are always HWPX produced by the shared serializer.
+
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+pub(crate) const RECOVERY_SCHEMA_VERSION: u32 = 1;
+const MAX_GENERATIONS_PER_DOCUMENT: usize = 2;
+const DEFAULT_TOTAL_CAP: u64 = 256 * 1024 * 1024;
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct SnapshotMetadata {
+    schema_version: u32,
+    document_id: String,
+    generation: u64,
+    revision: u64,
+    saved_at_ms: u64,
+    byte_len: u64,
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct RecoverySummary {
+    pub(crate) document_id: String,
+    pub(crate) generation: u64,
+    pub(crate) revision: u64,
+    pub(crate) saved_at_ms: u64,
+    pub(crate) byte_len: u64,
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct RecoveryListing {
+    pub(crate) records: Vec<RecoverySummary>,
+    pub(crate) warnings: Vec<String>,
+}
+
+impl From<&SnapshotMetadata> for RecoverySummary {
+    fn from(value: &SnapshotMetadata) -> Self {
+        Self {
+            document_id: value.document_id.clone(),
+            generation: value.generation,
+            revision: value.revision,
+            saved_at_ms: value.saved_at_ms,
+            byte_len: value.byte_len,
+        }
+    }
+}
+
+pub(crate) struct RecoveryStore {
+    root: PathBuf,
+    total_cap: u64,
+}
+
+impl RecoveryStore {
+    pub(crate) fn new(app_data_dir: &Path) -> Result<Self, String> {
+        Self::with_cap(app_data_dir, DEFAULT_TOTAL_CAP)
+    }
+
+    fn with_cap(app_data_dir: &Path, total_cap: u64) -> Result<Self, String> {
+        let root = app_data_dir.join("recovery-v1");
+        create_private_dir(&root)?;
+        Ok(Self { root, total_cap })
+    }
+
+    pub(crate) fn write(
+        &self,
+        document_id: &str,
+        revision: u64,
+        saved_at_ms: u64,
+        bytes: &[u8],
+    ) -> Result<RecoverySummary, String> {
+        validate_document_id(document_id)?;
+        if bytes.len() < 4 || !bytes.starts_with(b"PK") {
+            return Err("recovery snapshot is not an HWPX ZIP".into());
+        }
+        if bytes.len() as u64 > self.total_cap {
+            return Err("recovery snapshot exceeds the total size cap".into());
+        }
+        let dir = self.root.join(document_id);
+        create_private_dir(&dir)?;
+        let existing = self.records_for(document_id)?;
+        let generation = existing
+            .iter()
+            .map(|(meta, _, _)| meta.generation)
+            .max()
+            .unwrap_or(0)
+            .saturating_add(1);
+        let metadata = SnapshotMetadata {
+            schema_version: RECOVERY_SCHEMA_VERSION,
+            document_id: document_id.to_owned(),
+            generation,
+            revision,
+            saved_at_ms,
+            byte_len: bytes.len() as u64,
+        };
+        let stem = format!("snapshot-{generation:020}");
+        let bytes_path = dir.join(format!("{stem}.hwpx"));
+        let meta_path = dir.join(format!("{stem}.json"));
+        hwp_core::atomic_write(&bytes_path, bytes)
+            .map_err(|e| format!("recovery bytes write failed: {e}"))?;
+        let metadata_bytes = serde_json::to_vec(&metadata)
+            .map_err(|e| format!("recovery metadata encode failed: {e}"))?;
+        if let Err(error) = hwp_core::atomic_write(&meta_path, &metadata_bytes) {
+            let _ = std::fs::remove_file(&bytes_path);
+            return Err(format!("recovery metadata write failed: {error}"));
+        }
+        set_private_file(&bytes_path)?;
+        set_private_file(&meta_path)?;
+        self.prune(Some((document_id, generation)))?;
+        Ok((&metadata).into())
+    }
+
+    pub(crate) fn list(&self) -> Result<Vec<RecoverySummary>, String> {
+        let mut records = self.all_records()?;
+        records.sort_by(|a, b| snapshot_order(&a.0, &b.0));
+        records.reverse();
+        Ok(records.iter().map(|(meta, _, _)| meta.into()).collect())
+    }
+
+    pub(crate) fn list_with_warnings(&self) -> Result<RecoveryListing, String> {
+        let records = self.list()?;
+        let quarantined = count_quarantined(&self.root)?;
+        let warnings = if quarantined == 0 {
+            Vec::new()
+        } else {
+            vec![format!(
+                "손상되었거나 호환되지 않는 복구 파일 {quarantined}건을 로컬 격리했습니다"
+            )]
+        };
+        Ok(RecoveryListing { records, warnings })
+    }
+
+    pub(crate) fn read(&self, document_id: &str, generation: u64) -> Result<Vec<u8>, String> {
+        validate_document_id(document_id)?;
+        let record = self
+            .records_for(document_id)?
+            .into_iter()
+            .find(|(meta, _, _)| meta.generation == generation)
+            .ok_or("recovery snapshot not found")?;
+        let bytes =
+            std::fs::read(&record.1).map_err(|e| format!("recovery snapshot read failed: {e}"))?;
+        if bytes.len() as u64 != record.0.byte_len || !bytes.starts_with(b"PK") {
+            self.quarantine_pair(&record.1, &record.2)?;
+            return Err("recovery snapshot is corrupt and was quarantined".into());
+        }
+        Ok(bytes)
+    }
+
+    pub(crate) fn discard_document(&self, document_id: &str) -> Result<(), String> {
+        validate_document_id(document_id)?;
+        let dir = self.root.join(document_id);
+        if dir.exists() {
+            std::fs::remove_dir_all(&dir).map_err(|e| format!("recovery discard failed: {e}"))?;
+        }
+        Ok(())
+    }
+
+    fn prune(&self, preserve: Option<(&str, u64)>) -> Result<(), String> {
+        let mut records = self.all_records()?;
+        records.sort_by(|a, b| snapshot_order(&a.0, &b.0));
+
+        let mut per_document = std::collections::HashMap::<String, Vec<usize>>::new();
+        for (index, (meta, _, _)) in records.iter().enumerate() {
+            per_document
+                .entry(meta.document_id.clone())
+                .or_default()
+                .push(index);
+        }
+        let mut remove = std::collections::HashSet::new();
+        for indexes in per_document.values() {
+            let excess = indexes.len().saturating_sub(MAX_GENERATIONS_PER_DOCUMENT);
+            remove.extend(
+                indexes
+                    .iter()
+                    .copied()
+                    .filter(|index| {
+                        !preserve.is_some_and(|(document_id, generation)| {
+                            records[*index].0.document_id == document_id
+                                && records[*index].0.generation == generation
+                        })
+                    })
+                    .take(excess),
+            );
+        }
+
+        let mut total: u64 = records
+            .iter()
+            .enumerate()
+            .filter(|(index, _)| !remove.contains(index))
+            .map(|(_, (meta, _, _))| meta.byte_len)
+            .sum();
+        for (index, (meta, _, _)) in records.iter().enumerate() {
+            if total <= self.total_cap {
+                break;
+            }
+            if preserve.is_some_and(|(document_id, generation)| {
+                meta.document_id == document_id && meta.generation == generation
+            }) {
+                continue;
+            }
+            if remove.insert(index) {
+                total = total.saturating_sub(meta.byte_len);
+            }
+        }
+        for index in remove {
+            let (_, bytes_path, meta_path) = &records[index];
+            remove_pair(bytes_path, meta_path)?;
+        }
+        Ok(())
+    }
+
+    fn all_records(&self) -> Result<Vec<(SnapshotMetadata, PathBuf, PathBuf)>, String> {
+        let mut out = Vec::new();
+        for entry in std::fs::read_dir(&self.root)
+            .map_err(|e| format!("recovery directory read failed: {e}"))?
+        {
+            let entry = entry.map_err(|e| format!("recovery directory entry failed: {e}"))?;
+            if !entry.path().is_dir() {
+                continue;
+            }
+            let Some(document_id) = entry.file_name().to_str().map(str::to_owned) else {
+                continue;
+            };
+            if validate_document_id(&document_id).is_err() {
+                continue;
+            }
+            out.extend(self.records_for(&document_id)?);
+        }
+        Ok(out)
+    }
+
+    fn records_for(
+        &self,
+        document_id: &str,
+    ) -> Result<Vec<(SnapshotMetadata, PathBuf, PathBuf)>, String> {
+        let dir = self.root.join(document_id);
+        if !dir.exists() {
+            return Ok(Vec::new());
+        }
+        let mut out = Vec::new();
+        for entry in std::fs::read_dir(&dir)
+            .map_err(|e| format!("recovery document directory read failed: {e}"))?
+        {
+            let entry = entry.map_err(|e| format!("recovery entry failed: {e}"))?;
+            let meta_path = entry.path();
+            if meta_path.extension().and_then(|value| value.to_str()) != Some("json") {
+                continue;
+            }
+            let parsed = std::fs::read(&meta_path)
+                .map_err(|e| format!("recovery metadata read failed: {e}"))
+                .and_then(|bytes| {
+                    serde_json::from_slice::<SnapshotMetadata>(&bytes)
+                        .map_err(|e| format!("recovery metadata is incompatible: {e}"))
+                });
+            let Ok(meta) = parsed else {
+                let quarantine = meta_path.with_extension("json.quarantine");
+                let _ = std::fs::rename(&meta_path, quarantine);
+                continue;
+            };
+            if meta.schema_version != RECOVERY_SCHEMA_VERSION || meta.document_id != document_id {
+                let quarantine = meta_path.with_extension("json.quarantine");
+                let _ = std::fs::rename(&meta_path, quarantine);
+                continue;
+            }
+            let bytes_path = meta_path.with_extension("hwpx");
+            if !bytes_path.is_file() {
+                let quarantine = meta_path.with_extension("json.quarantine");
+                let _ = std::fs::rename(&meta_path, quarantine);
+                continue;
+            }
+            out.push((meta, bytes_path, meta_path));
+        }
+        Ok(out)
+    }
+
+    fn quarantine_pair(&self, bytes_path: &Path, meta_path: &Path) -> Result<(), String> {
+        let document_id = bytes_path
+            .parent()
+            .and_then(Path::file_name)
+            .and_then(|value| value.to_str())
+            .ok_or("recovery quarantine document id unavailable")?;
+        validate_document_id(document_id)?;
+        let quarantine = self.root.join("quarantine").join(document_id);
+        create_private_dir(&quarantine)?;
+        for path in [bytes_path, meta_path] {
+            if path.exists() {
+                let Some(name) = path.file_name() else {
+                    continue;
+                };
+                let target = quarantine.join(format!("{}.quarantine", name.to_string_lossy()));
+                std::fs::rename(path, target)
+                    .map_err(|e| format!("recovery quarantine failed: {e}"))?;
+            }
+        }
+        Ok(())
+    }
+}
+
+fn validate_document_id(document_id: &str) -> Result<(), String> {
+    if document_id.len() != 32
+        || !document_id
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+    {
+        return Err("invalid recovery document id".into());
+    }
+    Ok(())
+}
+
+fn snapshot_order(a: &SnapshotMetadata, b: &SnapshotMetadata) -> std::cmp::Ordering {
+    (a.saved_at_ms, &a.document_id, a.generation).cmp(&(
+        b.saved_at_ms,
+        &b.document_id,
+        b.generation,
+    ))
+}
+
+fn remove_pair(bytes_path: &Path, meta_path: &Path) -> Result<(), String> {
+    for path in [bytes_path, meta_path] {
+        if path.exists() {
+            std::fs::remove_file(path).map_err(|e| format!("recovery prune failed: {e}"))?;
+        }
+    }
+    Ok(())
+}
+
+fn create_private_dir(path: &Path) -> Result<(), String> {
+    std::fs::create_dir_all(path).map_err(|e| format!("recovery directory create failed: {e}"))?;
+    let metadata = std::fs::symlink_metadata(path)
+        .map_err(|e| format!("recovery directory metadata failed: {e}"))?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return Err("recovery directory is not a private regular directory".into());
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700))
+            .map_err(|e| format!("recovery directory permissions failed: {e}"))?;
+    }
+    Ok(())
+}
+
+fn set_private_file(path: &Path) -> Result<(), String> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+            .map_err(|e| format!("recovery file permissions failed: {e}"))?;
+    }
+    #[cfg(not(unix))]
+    let _ = path;
+    Ok(())
+}
+
+fn count_quarantined(root: &Path) -> Result<usize, String> {
+    fn walk(path: &Path, count: &mut usize) -> Result<(), String> {
+        for entry in
+            std::fs::read_dir(path).map_err(|e| format!("recovery quarantine scan failed: {e}"))?
+        {
+            let entry = entry.map_err(|e| format!("recovery quarantine entry failed: {e}"))?;
+            let path = entry.path();
+            if path.is_dir() {
+                walk(&path, count)?;
+            } else if path
+                .extension()
+                .and_then(|value| value.to_str())
+                .is_some_and(|extension| extension == "quarantine")
+                || path
+                    .parent()
+                    .and_then(Path::file_name)
+                    .and_then(|value| value.to_str())
+                    == Some("quarantine")
+            {
+                *count += 1;
+            }
+        }
+        Ok(())
+    }
+    let mut count = 0;
+    walk(root, &mut count)?;
+    Ok(count)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static FIXTURE_ID: AtomicU64 = AtomicU64::new(0);
+    const DOC_A: &str = "00112233445566778899aabbccddeeff";
+    const DOC_B: &str = "ffeeddccbbaa99887766554433221100";
+
+    struct Fixture(PathBuf);
+
+    impl Fixture {
+        fn new() -> Self {
+            let id = FIXTURE_ID.fetch_add(1, Ordering::Relaxed);
+            let path = std::env::temp_dir().join(format!(
+                "auto-hwp-recovery-store-{}-{id}",
+                std::process::id()
+            ));
+            std::fs::create_dir(&path).unwrap();
+            Self(path)
+        }
+    }
+
+    impl Drop for Fixture {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn hwpx(fill: u8, len: usize) -> Vec<u8> {
+        let mut bytes = vec![fill; len.max(4)];
+        bytes[0..4].copy_from_slice(b"PK\x03\x04");
+        bytes
+    }
+
+    #[test]
+    fn retains_two_generations_and_latest_first() {
+        let fixture = Fixture::new();
+        let store = RecoveryStore::with_cap(&fixture.0, 1_000).unwrap();
+        store.write(DOC_A, 1, 100, &hwpx(1, 20)).unwrap();
+        store.write(DOC_A, 2, 200, &hwpx(2, 20)).unwrap();
+        store.write(DOC_A, 3, 300, &hwpx(3, 20)).unwrap();
+        let list = store.list().unwrap();
+        assert_eq!(list.len(), 2);
+        assert_eq!(list[0].revision, 3);
+        assert_eq!(list[1].revision, 2);
+        assert_eq!(store.read(DOC_A, list[0].generation).unwrap(), hwpx(3, 20));
+    }
+
+    #[test]
+    fn total_cap_prunes_oldest_deterministically() {
+        let fixture = Fixture::new();
+        let store = RecoveryStore::with_cap(&fixture.0, 30).unwrap();
+        store.write(DOC_A, 1, 100, &hwpx(1, 20)).unwrap();
+        store.write(DOC_B, 1, 200, &hwpx(2, 20)).unwrap();
+        let list = store.list().unwrap();
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].document_id, DOC_B);
+    }
+
+    #[test]
+    fn clock_rollback_never_prunes_the_snapshot_just_reported_as_saved() {
+        let fixture = Fixture::new();
+        let store = RecoveryStore::with_cap(&fixture.0, 30).unwrap();
+        store.write(DOC_A, 1, 200, &hwpx(1, 20)).unwrap();
+        let newest_write = store.write(DOC_B, 1, 100, &hwpx(2, 20)).unwrap();
+        let list = store.list().unwrap();
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].document_id, newest_write.document_id);
+    }
+
+    #[test]
+    fn corrupt_bytes_are_quarantined_without_touching_other_records() {
+        let fixture = Fixture::new();
+        let store = RecoveryStore::with_cap(&fixture.0, 1_000).unwrap();
+        let first = store.write(DOC_A, 1, 100, &hwpx(1, 20)).unwrap();
+        store.write(DOC_B, 1, 200, &hwpx(2, 20)).unwrap();
+        let bad = store
+            .root
+            .join(DOC_A)
+            .join(format!("snapshot-{:020}.hwpx", first.generation));
+        std::fs::write(&bad, b"bad").unwrap();
+        assert!(store.read(DOC_A, first.generation).is_err());
+        assert_eq!(store.list().unwrap().len(), 1);
+        assert_eq!(store.list().unwrap()[0].document_id, DOC_B);
+    }
+
+    #[test]
+    fn metadata_is_path_free_and_discard_is_scoped() {
+        let fixture = Fixture::new();
+        let store = RecoveryStore::with_cap(&fixture.0, 1_000).unwrap();
+        store.write(DOC_A, 1, 100, &hwpx(1, 20)).unwrap();
+        store.write(DOC_B, 1, 200, &hwpx(2, 20)).unwrap();
+        let metadata = std::fs::read_to_string(
+            store
+                .root
+                .join(DOC_A)
+                .join("snapshot-00000000000000000001.json"),
+        )
+        .unwrap();
+        assert!(!metadata.contains("path"));
+        assert!(!metadata.contains("name"));
+        store.discard_document(DOC_A).unwrap();
+        let list = store.list().unwrap();
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].document_id, DOC_B);
+    }
+
+    #[test]
+    fn incompatible_metadata_is_quarantined_and_reported_without_hiding_valid_records() {
+        let fixture = Fixture::new();
+        let store = RecoveryStore::with_cap(&fixture.0, 1_000).unwrap();
+        store.write(DOC_A, 1, 100, &hwpx(1, 20)).unwrap();
+        let invalid_dir = store.root.join(DOC_B);
+        create_private_dir(&invalid_dir).unwrap();
+        std::fs::write(
+            invalid_dir.join("snapshot-00000000000000000001.json"),
+            b"{}",
+        )
+        .unwrap();
+        let listing = store.list_with_warnings().unwrap();
+        assert_eq!(listing.records.len(), 1);
+        assert_eq!(listing.warnings.len(), 1);
+        assert!(listing.warnings[0].contains("격리"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn recovery_root_rejects_a_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let fixture = Fixture::new();
+        let outside = fixture.0.join("outside");
+        std::fs::create_dir(&outside).unwrap();
+        symlink(&outside, fixture.0.join("recovery-v1")).unwrap();
+        assert!(RecoveryStore::with_cap(&fixture.0, 1_000).is_err());
+    }
+
+    #[test]
+    fn corrupt_records_from_two_documents_quarantine_without_name_collision() {
+        let fixture = Fixture::new();
+        let store = RecoveryStore::with_cap(&fixture.0, 1_000).unwrap();
+        let first = store.write(DOC_A, 1, 100, &hwpx(1, 20)).unwrap();
+        let second = store.write(DOC_B, 1, 200, &hwpx(2, 20)).unwrap();
+        for (document_id, generation) in [
+            (first.document_id.as_str(), first.generation),
+            (second.document_id.as_str(), second.generation),
+        ] {
+            let bytes = store
+                .root
+                .join(document_id)
+                .join(format!("snapshot-{generation:020}.hwpx"));
+            std::fs::write(bytes, b"bad").unwrap();
+            assert!(store.read(document_id, generation).is_err());
+        }
+        let listing = store.list_with_warnings().unwrap();
+        assert!(listing.records.is_empty());
+        assert_eq!(listing.warnings.len(), 1);
+    }
+}

--- a/crates/hwp-viewer/ui/src/WorkspaceShell.tsx
+++ b/crates/hwp-viewer/ui/src/WorkspaceShell.tsx
@@ -4,7 +4,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { open as openDialog, save as saveDialog } from "@tauri-apps/plugin-dialog";
 import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
-import { HwpWorkspace, TauriAdapter, type OnAiRequest } from "@auto-hwp/react";
+import { HwpWorkspace, TauriAdapter, type DesktopSessionStatus, type OnAiRequest } from "@auto-hwp/react";
 import "@auto-hwp/react/styles.css";
 
 /// WorkspaceShell — the issue-044 desktop shell. Behind the build-time flag `VITE_SHELL=workspace`, the
@@ -16,18 +16,43 @@ import "@auto-hwp/react/styles.css";
 /// browser-first component cannot own. Per docs/TAURI-CONVERGENCE.md §4 the 4 in-scope seams are:
 ///   1. 타이틀바   — the h-9 (36px) CSS titlebar + `data-tauri-drag-region`, the SAME discipline the legacy
 ///                  app uses so the macOS traffic lights stay centered (ccb9d5a; NEVER re-pin the lights).
-///   2. 파일 열기  — a native file dialog → path, bridged into `adapter.open(bytes)` via `resolveOpenPath`.
+///   2. 파일 열기  — a native file dialog → path, bridged into `adapter.open(bytes)` through an opaque
+///                  host payload (recovery uses a separate opaque identifier; neither path is exported).
 ///   3. 저장/내보내기 — native save dialogs + ATOMIC writes (P0-1), reusing the existing path-based export
 ///                  commands; the web `<a download>` convention is intercepted via the opt-in `onExport`.
 ///   4. 드래그드롭 열기 — Tauri `onDragDropEvent` → open a dropped .hwp/.hwpx (same UX as the legacy app).
 /// registerFont is a documented no-op on desktop (native font stack), so NO `fontCatalog` is injected.
 
 // One adapter for the shell's lifetime (it holds the Tauri `invoke` seam; the open document lives in the
-// Rust session). `resolveOpenPath` bridges the web `open(bytes)` seam to the desktop's path-based
-// `open_doc`: the shell encodes the picked native PATH into the `document.bytes` it hands the workspace,
-// and this decodes it straight back — no temp file, no extra command (the file is opened in place).
+// Rust session). The shell bridges the web `open(bytes)` seam to the desktop's path-based `open_doc` by
+// encoding the picked native path into the host-only payload. Recovery uses an opaque document id and
+// generation instead — no temp file and no source path is persisted in recovery metadata.
 const PATH_CODEC = { encode: (p: string) => new TextEncoder().encode(p), decode: (b: Uint8Array) => new TextDecoder().decode(b) };
-const adapter = new TauriAdapter({ invoke, resolveOpenPath: async (bytes) => PATH_CODEC.decode(bytes) });
+const RECOVERY_PREFIX = "auto-hwp-recovery:";
+type RecoverySummary = { documentId: string; generation: number; revision: number; savedAtMs: number; byteLen: number };
+type RecoveryListing = { records: RecoverySummary[]; warnings: string[] };
+type SaveContinuation = "none" | "replace" | "close";
+const recoveryPayload = (record: RecoverySummary) =>
+  new TextEncoder().encode(`${RECOVERY_PREFIX}${record.documentId}:${record.generation}`);
+const adapter = new TauriAdapter({
+  invoke,
+  openDocument: async (bytes) => {
+    const request = PATH_CODEC.decode(bytes);
+    if (request.startsWith(RECOVERY_PREFIX)) {
+      const [documentId, rawGeneration] = request.slice(RECOVERY_PREFIX.length).split(":");
+      if (!/^[0-9a-f]{32}$/.test(documentId) || !/^\d+$/.test(rawGeneration)) {
+        throw new Error("잘못된 복구 요청입니다");
+      }
+      const result = await invoke<{ pages: number; editable: boolean; format: string }>("open_recovery", {
+        documentId,
+        generation: Number(rawGeneration),
+      });
+      return { ...result, sections: 1 };
+    }
+    const result = await invoke<{ pages: number; editable: boolean; format: string }>("open_doc", { path: request });
+    return { ...result, sections: 1 };
+  },
+});
 
 const IS_DOC = /\.(hwp|hwpx)$/i;
 const MAX_PENDING_OPEN_REQUESTS = 8;
@@ -53,6 +78,14 @@ function WorkspaceShell() {
   const [docName, setDocName] = useState<string | null>(null);
   const [note, setNote] = useState<string>("");
   const [pendingOpenPaths, setPendingOpenPaths] = useState<string[]>([]);
+  const [sessionStatus, setSessionStatus] = useState<DesktopSessionStatus | null>(null);
+  const [recoveries, setRecoveries] = useState<RecoverySummary[]>([]);
+  const [recoveryScanComplete, setRecoveryScanComplete] = useState(false);
+  const [restoredFromId, setRestoredFromId] = useState<string | null>(null);
+  const [closeRequested, setCloseRequested] = useState(false);
+  const [pendingOverwrite, setPendingOverwrite] = useState<{ path: string; after: SaveContinuation } | null>(null);
+  const snapshotTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const recoveryDisabled = useRef(false);
   const hasDoc = doc != null;
 
   const flash = useCallback((s: string) => {
@@ -60,9 +93,69 @@ function WorkspaceShell() {
     window.setTimeout(() => setNote((cur) => (cur === s ? "" : cur)), 4000);
   }, []);
 
-  // Open a native path by handing the workspace a fresh `document` whose bytes carry the path (a new
-  // object each call → the workspace re-opens even when the same file is re-picked). resolveOpenPath
-  // decodes the path back and the Rust `open_doc` reads the real file in place.
+  // The adapter compares the authoritative Rust revision after every accepted Intent. Read-only
+  // queries do not trigger this observer. A completed edit schedules one path-free HWPX snapshot
+  // after two idle seconds; persistence failure is visible and disables retries for this process.
+  useEffect(() => {
+    adapter.onSessionStatus = setSessionStatus;
+    adapter.onMutation = () => {
+      if (snapshotTimer.current) window.clearTimeout(snapshotTimer.current);
+      if (recoveryDisabled.current) return;
+      snapshotTimer.current = window.setTimeout(() => {
+        snapshotTimer.current = null;
+        void invoke<RecoverySummary | null>("write_recovery_snapshot")
+          .then((record) => {
+            if (record) flash(`복구 저장됨 · 편집 ${record.revision}회`);
+          })
+          .catch((error) => {
+            recoveryDisabled.current = true;
+            flash(`복구 저장을 중단했습니다: ${error}`);
+          });
+      }, 2000);
+    };
+    return () => {
+      adapter.onMutation = null;
+      adapter.onSessionStatus = null;
+      if (snapshotTimer.current) window.clearTimeout(snapshotTimer.current);
+    };
+  }, [flash]);
+
+  useEffect(() => {
+    let cancelled = false;
+    let unlistenClose: undefined | (() => void);
+    let unlistenChanged: undefined | (() => void);
+    void invoke<RecoveryListing>("list_recovery_snapshots")
+      .then((listing) => {
+        if (!cancelled) {
+          setRecoveries(listing.records);
+          setRecoveryScanComplete(true);
+          if (listing.warnings[0]) flash(listing.warnings[0]);
+        }
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          setRecoveryScanComplete(true);
+          flash(`복구 목록을 확인하지 못했습니다: ${error}`);
+        }
+      });
+    void listen("desktop-close-request", () => setCloseRequested(true)).then((un) => {
+      if (cancelled) un();
+      else unlistenClose = un;
+    });
+    void listen("doc-changed", () => void adapter.refreshSessionStatus()).then((un) => {
+      if (cancelled) un();
+      else unlistenChanged = un;
+    });
+    return () => {
+      cancelled = true;
+      unlistenClose?.();
+      unlistenChanged?.();
+    };
+  }, [flash]);
+
+  // Open a native path by handing the workspace a fresh `document` whose host-only bytes carry the path
+  // (a new object each call → the workspace re-opens even when the same file is re-picked). The adapter
+  // decodes it and Rust `open_doc` reads the real file in place.
   const openPath = useCallback((path: string) => {
     const name = basename(path);
     setDoc({ bytes: PATH_CODEC.encode(path), name });
@@ -104,25 +197,19 @@ function WorkspaceShell() {
     };
   }, [flash, requestOpen]);
 
-  // One native window owns one Rust session in v1. Until #141 adds a precise dirty signal, the first
-  // document can open immediately but every replacement pauses on the in-app confirmation below.
-  // Do not use `window.confirm`: packaged WKWebView behavior is not consistent enough for a data-loss
-  // boundary, and an app-owned dialog is both testable and visible.
+  // Clean replacement is immediate. Dirty replacement waits for the explicit save/discard/cancel
+  // surface below. Do not use window.confirm at this data-loss boundary.
   useEffect(() => {
     const path = pendingOpenPaths[0];
-    if (!path || hasDoc) return;
+    if (
+      !path ||
+      !recoveryScanComplete ||
+      (!hasDoc && recoveries.length > 0) ||
+      (hasDoc && (sessionStatus == null || sessionStatus.dirty))
+    ) return;
     openPath(path);
     setPendingOpenPaths((current) => current.slice(1));
-  }, [hasDoc, openPath, pendingOpenPaths]);
-
-  const resolveReplacement = useCallback(
-    (replace: boolean) => {
-      const path = pendingOpenPaths[0];
-      if (replace && path) openPath(path);
-      setPendingOpenPaths((current) => current.slice(1));
-    },
-    [openPath, pendingOpenPaths],
-  );
+  }, [hasDoc, openPath, pendingOpenPaths, recoveries.length, recoveryScanComplete, sessionStatus]);
 
   const doOpen = useCallback(async () => {
     try {
@@ -137,16 +224,96 @@ function WorkspaceShell() {
   // 저장 (HWPX) — the atomic P0-1 path (`hwp_core::atomic_write`: temp + fsync + rename) via the existing
   // path-based `export_hwpx` command. The byte twin (`toHwpx()`) exists on the adapter but the host chrome
   // reuses the tested atomic writer, so no bare-bytes write command is introduced (엔진 무접촉).
-  const doSaveHwpx = useCallback(async () => {
-    if (!hasDoc) return;
+  const discardRecoveryIds = useCallback(async () => {
+    if (snapshotTimer.current) {
+      window.clearTimeout(snapshotTimer.current);
+      snapshotTimer.current = null;
+    }
+    const ids = new Set([sessionStatus?.documentId, restoredFromId].filter((id): id is string => !!id));
+    for (const documentId of ids) await invoke("discard_recovery_snapshots", { documentId });
+    setRestoredFromId(null);
+  }, [restoredFromId, sessionStatus?.documentId]);
+
+  const finishContinuation = useCallback(
+    async (after: SaveContinuation) => {
+      if (after === "replace") {
+        const path = pendingOpenPaths[0];
+        if (path) openPath(path);
+        setPendingOpenPaths((current) => current.slice(1));
+      } else if (after === "close") {
+        await invoke("allow_desktop_close");
+        await getCurrentWebviewWindow().close();
+      }
+      setCloseRequested(false);
+    },
+    [openPath, pendingOpenPaths],
+  );
+
+  const saveToPath = useCallback(
+    async (path: string, overwriteConfirmed: boolean, after: SaveContinuation): Promise<boolean> => {
+      try {
+        if (snapshotTimer.current) {
+          window.clearTimeout(snapshotTimer.current);
+          snapshotTimer.current = null;
+        }
+        const message = await invoke<string>("export_hwpx", { path, overwriteConfirmed });
+        if (restoredFromId) await invoke("discard_recovery_snapshots", { documentId: restoredFromId });
+        setRestoredFromId(null);
+        setSessionStatus(await adapter.sessionStatus());
+        flash(message);
+        await finishContinuation(after);
+        return true;
+      } catch (error) {
+        if (!overwriteConfirmed && String(error).includes("EXTERNAL_SOURCE_CHANGED")) {
+          setPendingOverwrite({ path, after });
+          return false;
+        }
+        flash(`저장 실패: ${error}`);
+        return false;
+      }
+    },
+    [finishContinuation, flash, restoredFromId],
+  );
+
+  const doSaveHwpx = useCallback(async (after: SaveContinuation = "none") => {
+    if (!hasDoc) return false;
     try {
-      const path = await saveDialog({ defaultPath: "export.hwpx", filters: [{ name: "HWPX", extensions: ["hwpx"] }] });
-      if (typeof path !== "string") return;
-      flash(await invoke<string>("export_hwpx", { path }));
+      const path = await saveDialog({ defaultPath: docName?.replace(/\.hwp$/i, ".hwpx") ?? "export.hwpx", filters: [{ name: "HWPX", extensions: ["hwpx"] }] });
+      if (typeof path !== "string") return false;
+      return await saveToPath(path, false, after);
     } catch (e) {
       flash(`저장 실패: ${e}`);
+      return false;
     }
-  }, [hasDoc, flash]);
+  }, [docName, hasDoc, flash, saveToPath]);
+
+  const discardAndContinue = useCallback(
+    async (after: Exclude<SaveContinuation, "none">) => {
+      try {
+        await discardRecoveryIds();
+        await finishContinuation(after);
+      } catch (error) {
+        flash(`복구본 삭제 실패: ${error}`);
+      }
+    },
+    [discardRecoveryIds, finishContinuation, flash],
+  );
+
+  const restoreRecovery = useCallback((record: RecoverySummary) => {
+    setRestoredFromId(record.documentId);
+    setDoc({ bytes: recoveryPayload(record), name: "복구본.hwpx" });
+    setDocName("복구본.hwpx");
+    setRecoveries([]);
+  }, []);
+
+  const discardRecovery = useCallback(async (record: RecoverySummary) => {
+    try {
+      await invoke("discard_recovery_snapshots", { documentId: record.documentId });
+      setRecoveries((current) => current.filter((item) => item.documentId !== record.documentId));
+    } catch (error) {
+      flash(`복구본 삭제 실패: ${error}`);
+    }
+  }, [flash]);
 
   // 내보내기 (HTML/PDF) — the workspace's export buttons route HERE (opt-in `onExport`) instead of a
   // browser download. Native save dialog + the existing path-based atomic export commands, which
@@ -155,7 +322,9 @@ function WorkspaceShell() {
     async (data: Uint8Array | string, filename: string, mime: string) => {
       void data; // reusing the atomic path commands (P0-1), not writing the passed bytes — same session.
       try {
-        if (mime === "application/pdf") {
+        if (/hwpx|zip/i.test(mime)) {
+          await doSaveHwpx();
+        } else if (mime === "application/pdf") {
           const path = await saveDialog({ defaultPath: filename, filters: [{ name: "PDF", extensions: ["pdf"] }] });
           if (typeof path !== "string") return;
           flash(`PDF 내보냄 · ${await invoke<string>("export_doc_pdf", { path })}`);
@@ -168,7 +337,7 @@ function WorkspaceShell() {
         flash(`내보내기 실패: ${e}`);
       }
     },
-    [flash],
+    [doSaveHwpx, flash],
   );
 
   // 드래그드롭 열기 — the WebView never fires a browser `drop`, so subscribe to Tauri's native
@@ -211,7 +380,7 @@ function WorkspaceShell() {
           저장
         </button>
         <span data-tauri-drag-region className="ml-1 text-sm font-medium">
-          {docName ?? "한칸"}
+          {docName ?? "한칸"}{sessionStatus?.dirty ? " •" : ""}
         </span>
         <span
           data-shell-mode="workspace"
@@ -231,34 +400,81 @@ function WorkspaceShell() {
         <HwpWorkspace adapter={adapter} document={doc} onAiRequest={disabledAi} enableEditing onExport={onExport} />
       </div>
 
-      {hasDoc && pendingOpenPaths[0] && (
+      {!hasDoc && recoveries[0] && (
         <div
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/35 p-6"
           role="dialog"
           aria-modal="true"
-          aria-labelledby="replace-document-title"
+          aria-labelledby="recovery-title"
         >
           <div className="w-full max-w-sm rounded-xl bg-white p-5 shadow-2xl dark:bg-neutral-800">
-            <h2 id="replace-document-title" className="text-base font-semibold">
-              현재 문서를 닫을까요?
+            <h2 id="recovery-title" className="text-base font-semibold">
+              복구 가능한 편집본이 있습니다
             </h2>
             <p className="mt-2 text-sm leading-6 text-neutral-600 dark:text-neutral-300">
-              {basename(pendingOpenPaths[0])} 파일을 열면 저장하지 않은 변경은 사라질 수 있습니다.
+              {new Date(recoveries[0].savedAtMs).toLocaleString()} · 편집 {recoveries[0].revision}회 · {Math.ceil(recoveries[0].byteLen / 1024)}KB
+              <br />복구하면 원본을 덮어쓰지 않는 새 미저장 문서로 열립니다.
+            </p>
+            <div className="mt-5 flex justify-end gap-2">
+              <button
+                onClick={() => void discardRecovery(recoveries[0])}
+                className="rounded-md border border-black/15 px-3 py-1.5 text-sm dark:border-white/20"
+              >
+                삭제
+              </button>
+              <button
+                autoFocus
+                onClick={() => restoreRecovery(recoveries[0])}
+                className="rounded-md bg-violet-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-violet-500"
+              >
+                복구하기
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {(closeRequested || (hasDoc && !!pendingOpenPaths[0] && !!sessionStatus?.dirty)) && !pendingOverwrite && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/35 p-6" role="dialog" aria-modal="true" aria-labelledby="dirty-document-title">
+          <div className="w-full max-w-sm rounded-xl bg-white p-5 shadow-2xl dark:bg-neutral-800">
+            <h2 id="dirty-document-title" className="text-base font-semibold">변경 내용을 저장할까요?</h2>
+            <p className="mt-2 text-sm leading-6 text-neutral-600 dark:text-neutral-300">
+              {closeRequested ? "앱을 닫기 전에" : `${basename(pendingOpenPaths[0])} 파일을 열기 전에`} 저장, 버리기, 취소 중 하나를 선택하세요.
             </p>
             <div className="mt-5 flex justify-end gap-2">
               <button
                 autoFocus
-                onClick={() => resolveReplacement(false)}
+                onClick={() => closeRequested ? setCloseRequested(false) : setPendingOpenPaths((current) => current.slice(1))}
                 className="rounded-md border border-black/15 px-3 py-1.5 text-sm dark:border-white/20"
-              >
-                취소
-              </button>
+              >취소</button>
               <button
-                onClick={() => resolveReplacement(true)}
+                onClick={() => void discardAndContinue(closeRequested ? "close" : "replace")}
+                className="rounded-md border border-red-300 px-3 py-1.5 text-sm text-red-700 dark:border-red-800 dark:text-red-300"
+              >버리기</button>
+              <button
+                onClick={() => void doSaveHwpx(closeRequested ? "close" : "replace")}
                 className="rounded-md bg-violet-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-violet-500"
-              >
-                열기
-              </button>
+              >저장</button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {pendingOverwrite && (
+        <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/40 p-6" role="dialog" aria-modal="true" aria-labelledby="external-change-title">
+          <div className="w-full max-w-sm rounded-xl bg-white p-5 shadow-2xl dark:bg-neutral-800">
+            <h2 id="external-change-title" className="text-base font-semibold">파일이 외부에서 변경되었습니다</h2>
+            <p className="mt-2 text-sm leading-6 text-neutral-600 dark:text-neutral-300">열어 둔 뒤 다른 앱이 파일을 변경했습니다. 검토 없이 덮어쓰지 않습니다.</p>
+            <div className="mt-5 flex justify-end gap-2">
+              <button autoFocus onClick={() => setPendingOverwrite(null)} className="rounded-md border border-black/15 px-3 py-1.5 text-sm dark:border-white/20">취소</button>
+              <button
+                onClick={() => {
+                  const pending = pendingOverwrite;
+                  setPendingOverwrite(null);
+                  void saveToPath(pending.path, true, pending.after);
+                }}
+                className="rounded-md bg-red-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-red-500"
+              >변경 확인 후 덮어쓰기</button>
             </div>
           </div>
         </div>

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,6 +3,26 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
+- 갱신: 2026-08-23 · Codex(sol) — **#141 데스크톱 무손실 복구 구현·실앱 QA 완료, 게시 준비**.
+  `codex/issue-141-desktop-recovery`를 #145 head `c190e8e` 위에 쌓아 Rust authoritative
+  revision/dirty 상태, 원본 identity(경로는 메모리 전용)와 외부 변경 덮어쓰기 차단, app-data
+  HWPX 복구본(문서당 2세대·총 256MiB·디렉터리 0700/파일 0600·경로/파일명 무저장), 손상/스키마
+  격리 경고, dirty 교체/닫기의 저장·버리기·취소, 재시작 복구/삭제, 복구본의 새 미저장 문서 열기를
+  구현했다. 시작 시 복구 스캔보다 OS open 큐가 먼저 빠지는 경쟁과 저장/autosave 경합도 차단했다.
+  headless 회귀는 hwp-viewer 29건(복구 root symlink 거부·다문서 격리 충돌·discard/autosave
+  경합 포함), React 427건, JS 전체 1,007건, PDF visual 51/51,
+  canonical 8/18/24·98.9%+, Playwright 85 pass/3 intentional skip, licenses green이다. 실제 ad-hoc
+  서명 `.app`에서 공개 benchmark.hwp 8쪽 열기→편집→dirty bullet→닫기 차단/취소→0600 snapshot→
+  강제종료→복구 제안→최신 rev 복원→새 HWPX 저장→clean 종료를 확인했다. 앱 번들은 성공했고
+  최종 코드도 `--bundles app` 패키징·ad-hoc 서명이 PASS했다(DMG 기본 실행만 로컬 샌드박스의
+  bundle_dmg 단계에서 실패). full verify의 기본 3100은 실행 중인 타 FACTSHEET 앱을 재사용해
+  file-input timeout이 났고, 기존 앱을 건드리지 않은 `PW_PORT=3141` 전수 재실행은 85/85 PASS했다.
+  테스트 복구본/출력은 정리했다.
+  사용자 승인 후 PR #137은 main `6574a6d`로 squash 병합했고 #138은 main 위에 #102 커밋만
+  재배치해 원래 head와 byte-identical tree로 새 CI를 실행 중이다. #145도 최신 main 위로 기능
+  트리를 그대로 보존해 재배치하고 새 CI를 실행 중이다. **다음:** 이 변경을 단일 커밋으로 만든 뒤
+  #145 green/병합 → 최신 main 위 rebase → push/PR(`Closes #141`) → 필수 CI, 이어 #142 착수.
+
 - 갱신: 2026-08-23 · Codex(sol) — **PR #136 병합 · 데스크톱 #139 로드맵/#140 구현·실앱 QA**.
   사용자 승인에 따라 #136을 squash 병합(main `0c354cb`, #100 close)했고 #137은 main 위
   `ad55605`로 재배치해 필수 checks 3종 green·MERGEABLE, #138은 그 위 `e18a396`로 정리했다.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,19 @@
 
 ---
 
+## 2026-08-23 (Codex sol) · #137 병합 · #138/#145 재배치
+- 사용자 자율 진행 승인; #137 squash 병합(main `6574a6d`) 후 #138을 main 기반으로 재배치.
+- #138은 이전 head와 byte-identical tree·#102 독립 12파일로 새 CI 실행 중.
+- #145도 기능 트리 무변경으로 최신 main에 재배치해 새 CI 실행 중.
+- 다음: #145 green/병합 → #141 rebase·push·PR·CI → #142.
+
+## 2026-08-23 (Codex sol) · #141 무손실 복구 구현·실앱 QA
+- revision dirty·외부변경 차단·비공개 2세대 HWPX 복구·격리/상한·저장/버리기/취소 구현.
+- cold-open/recovery-scan·저장/discard-autosave 경합과 symlink/격리 충돌을 잠그고 테스트 green.
+- full verify: canonical 8/18/24, PDF 51/51, JS 1,007, PW_PORT=3141 85 pass/3 skip, licenses PASS.
+- 실제 `.app`: 편집→dirty-close 차단→0600 snapshot→강제종료→최신 rev 복원→저장/clean 종료 PASS.
+- #137/#145 green 유지·미병합; 다음은 승인 후 #141 commit/PR, #145 병합 뒤 #142.
+
 ## 2026-08-23 (Codex sol) · #136 병합 · #140 데스크톱 파일 열기 구현
 - #136 squash 병합(main `0c354cb`, #100 close); #137은 green/MERGEABLE, #138 stack 재정렬.
 - #139 우산과 #140~#144를 만들고 #140 single-instance/cold·warm open/교체 확인을 구현.

--- a/packages/react/src/TauriAdapter.ts
+++ b/packages/react/src/TauriAdapter.ts
@@ -17,6 +17,14 @@ type TauriHitDto = {
  *  hard @tauri-apps dependency — the host passes its own `invoke`. */
 export type Invoke = <T>(cmd: string, args?: Record<string, unknown>) => Promise<T>;
 
+export type DesktopSessionStatus = {
+  documentId: string | null;
+  revision: number;
+  savedRevision: number;
+  dirty: boolean;
+  hasSource: boolean;
+};
+
 export interface TauriAdapterOptions {
   /** The Tauri `invoke`. */
   invoke: Invoke;
@@ -24,6 +32,9 @@ export interface TauriAdapterOptions {
    *  this to bridge the web `open(bytes)` seam — e.g. write the bytes to a temp file and return the
    *  path. Reference impl: the real app migration (issue 044) wires this to a Tauri command. */
   resolveOpenPath?: (bytes: Uint8Array, name?: string) => Promise<string>;
+  /** Optional host-owned open dispatcher. Desktop recovery uses this to open app-data HWPX bytes by
+   *  opaque recovery id without manufacturing a source path or exposing it to the shared workspace. */
+  openDocument?: (bytes: Uint8Array, name?: string) => Promise<OpenResult>;
 }
 
 /// TauriAdapter — the DESKTOP backend for the shared @auto-hwp/react workspace (issue 043 convergence
@@ -46,19 +57,61 @@ export interface TauriAdapterOptions {
 export class TauriAdapter implements EngineAdapter {
   private invoke: Invoke;
   private resolveOpenPath?: (bytes: Uint8Array, name?: string) => Promise<string>;
+  private openDocument?: (bytes: Uint8Array, name?: string) => Promise<OpenResult>;
+  private lastRevision: number | null = null;
+  /** Fires only when the authoritative Rust revision changed, never for read-only Intent queries. */
+  onMutation: (() => void) | null = null;
+  /** Host chrome observes open/save/dirty transitions without putting paths in React state. */
+  onSessionStatus: ((status: DesktopSessionStatus) => void) | null = null;
 
   constructor(opts: TauriAdapterOptions) {
     this.invoke = opts.invoke;
     this.resolveOpenPath = opts.resolveOpenPath;
+    this.openDocument = opts.openDocument;
   }
 
   async open(bytes: Uint8Array, name?: string): Promise<OpenResult> {
+    if (this.openDocument) {
+      const opened = await this.openDocument(bytes, name);
+      await this.syncRevision(false);
+      return opened;
+    }
     if (!this.resolveOpenPath) {
       throw new Error("TauriAdapter.open needs `resolveOpenPath` (the app opens by path, not bytes)");
     }
     const path = await this.resolveOpenPath(bytes, name);
     const r = await this.invoke<{ pages: number; editable: boolean; format: string }>("open_doc", { path });
+    await this.syncRevision(false);
     return { format: r.format, editable: r.editable, sections: 1, pages: r.pages };
+  }
+
+  async sessionStatus(): Promise<DesktopSessionStatus> {
+    return this.invoke<DesktopSessionStatus>("desktop_session_status");
+  }
+
+  /** Reconcile mutations performed outside this adapter (for example the embedded MCP control
+   *  server's `doc-changed` event) through the same authoritative revision comparison. */
+  refreshSessionStatus(): Promise<DesktopSessionStatus> {
+    return this.syncRevision(true);
+  }
+
+  private async syncRevision(notify: boolean): Promise<DesktopSessionStatus> {
+    const status = await this.sessionStatus();
+    const changed = this.lastRevision != null && status.revision !== this.lastRevision;
+    this.lastRevision = status.revision;
+    try {
+      this.onSessionStatus?.(status);
+    } catch {
+      /* host observer errors never turn a successful engine operation into a failure */
+    }
+    if (notify && changed) {
+      try {
+        this.onMutation?.();
+      } catch {
+        /* same observer isolation as WasmAdapter */
+      }
+    }
+    return status;
   }
 
   pageCount(): Promise<number> {
@@ -236,14 +289,16 @@ export class TauriAdapter implements EngineAdapter {
   /** Replace (issue 045) — the desktop `replace_text` command, ONE undo unit (all=false → the first match
    *  in the doc). Its `ReplaceResult` ({replaced, pages}) matches editor-core's `ReplaceResult` verbatim.
    *  Same run-preserving op-bus core as the wasm `Replace` Intent (040 교훈: no plain-text collapse). */
-  replace(query: string, replacement: string, opts: FindReplaceOptions): Promise<ReplaceResult> {
-    return this.invoke<ReplaceResult>("replace_text", {
+  async replace(query: string, replacement: string, opts: FindReplaceOptions): Promise<ReplaceResult> {
+    const result = await this.invoke<ReplaceResult>("replace_text", {
       query,
       replacement,
       caseSensitive: !!opts.caseSensitive,
       wholeWord: !!opts.wholeWord,
       all: !!opts.all,
     });
+    await this.syncRevision(true);
+    return result;
   }
 
   /** Apply one schema-v0 Intent through the desktop's GENERAL `apply_intent_json` command (issue 043) —
@@ -251,17 +306,21 @@ export class TauriAdapter implements EngineAdapter {
    *  covered (SetTableCellRuns / SetCellRangeFmt / ApplyContent / TableInsertRows / …), so no Intent
    *  silently no-ops; the command returns the `{kind, …}` Outcome (wasm-identical) and rejects with the
    *  typed op-bus error verbatim on a refused edit. */
-  applyIntent(intent: Intent): Promise<Outcome> {
-    return this.invoke<Outcome>("apply_intent_json", { intent });
+  async applyIntent(intent: Intent): Promise<Outcome> {
+    const outcome = await this.invoke<Outcome>("apply_intent_json", { intent });
+    await this.syncRevision(true);
+    return outcome;
   }
 
   async undo(): Promise<boolean> {
     await this.invoke<number>("undo");
+    await this.syncRevision(true);
     return true;
   }
 
   async redo(): Promise<boolean> {
     await this.invoke<number>("redo");
+    await this.syncRevision(true);
     return true;
   }
 

--- a/packages/react/src/__tests__/desktopParity.contract.test.ts
+++ b/packages/react/src/__tests__/desktopParity.contract.test.ts
@@ -111,12 +111,12 @@ describe("desktop adapter contract (issue #64 D0)", () => {
     }
   });
 
-  it("the 24 direct TauriAdapter invoke commands are registered in generate_handler", () => {
+  it("the 25 direct TauriAdapter invoke commands are registered in generate_handler", () => {
     const handler = generateHandlerCommands(readRepo("crates/hwp-viewer/src/lib.rs"));
     const commands = tauriDirectCommands(tauriSrc);
-    expect(commands).toHaveLength(24);
+    expect(commands).toHaveLength(25);
     const unique = new Set(commands);
-    expect(unique.size).toBe(24);
+    expect(unique.size).toBe(25);
     for (const cmd of unique) {
       expect(handler.has(cmd), `${cmd} is invoked by TauriAdapter but not in generate_handler![]`).toBe(true);
     }

--- a/packages/react/src/__tests__/tauriAdapter.test.ts
+++ b/packages/react/src/__tests__/tauriAdapter.test.ts
@@ -12,6 +12,9 @@ import type { Intent } from "../types";
 function mockInvoke(returns: Record<string, unknown>) {
   const calls: { cmd: string; args?: Record<string, unknown> }[] = [];
   const invoke = vi.fn(async (cmd: string, args?: Record<string, unknown>) => {
+    if (cmd === "desktop_session_status") {
+      return returns[cmd] ?? { documentId: "001122", revision: 0, savedRevision: 0, dirty: false, hasSource: true };
+    }
     calls.push({ cmd, args });
     return returns[cmd];
   });
@@ -34,6 +37,15 @@ describe("TauriAdapter — open / lifecycle (issue 043)", () => {
     const { invoke } = mockInvoke({});
     const a = new TauriAdapter({ invoke });
     await expect(a.open(new Uint8Array())).rejects.toThrow(/resolveOpenPath/);
+  });
+
+  it("openDocument override keeps opaque recovery ids out of the shared path bridge", async () => {
+    const { invoke } = mockInvoke({});
+    const openDocument = vi.fn(async () => ({ format: "HWPX", editable: true, sections: 1, pages: 3 }));
+    const a = new TauriAdapter({ invoke, openDocument });
+    const bytes = new TextEncoder().encode("recovery:opaque-id:2");
+    await expect(a.open(bytes, "복구본.hwpx")).resolves.toMatchObject({ pages: 3 });
+    expect(openDocument).toHaveBeenCalledWith(bytes, "복구본.hwpx");
   });
 
   it("dispose() is a no-op (the desktop session outlives the component)", () => {
@@ -186,6 +198,27 @@ describe("TauriAdapter — run reads + edit intents (issue 043)", () => {
     await expect(a.applyIntent({ intent: "SetParagraphText", section: 0, block: 3, text: "x" })).rejects.toThrow(
       /structural content/,
     );
+  });
+
+  it("mutation callback follows the Rust revision and ignores read-only Intent queries", async () => {
+    let revision = 0;
+    const invoke = vi.fn(async (cmd: string) => {
+      if (cmd === "desktop_session_status") {
+        return { documentId: "001122", revision, savedRevision: 0, dirty: revision > 0, hasSource: true };
+      }
+      if (cmd === "apply_intent_json") return { kind: "ok" };
+      if (cmd === "open_doc") return { pages: 1, editable: true, format: "HWPX" };
+      throw new Error(`unexpected ${cmd}`);
+    }) as <T>(cmd: string, args?: Record<string, unknown>) => Promise<T>;
+    const a = new TauriAdapter({ invoke, resolveOpenPath: async () => "/tmp/a.hwpx" });
+    const onMutation = vi.fn();
+    a.onMutation = onMutation;
+    await a.open(new Uint8Array([1]), "a.hwpx");
+    await a.applyIntent({ intent: "DocProfile" });
+    expect(onMutation).not.toHaveBeenCalled();
+    revision = 1;
+    await a.applyIntent({ intent: "SetParagraphText", section: 0, block: 0, text: "edited" });
+    expect(onMutation).toHaveBeenCalledTimes(1);
   });
 
   it("undo / redo resolve true and call the undo/redo commands", async () => {

--- a/packages/react/src/__tests__/workspaceShell.tauri.test.tsx
+++ b/packages/react/src/__tests__/workspaceShell.tauri.test.tsx
@@ -34,6 +34,7 @@ function makeInvoke(calls: string[]) {
     const table = <R,>(v: R) => v as unknown as T;
     switch (cmd) {
       case "open_doc": return table({ pages: 1, editable: true, format: "hwpx" });
+      case "desktop_session_status": return table({ documentId: "001122", revision: 0, savedRevision: 0, dirty: false, hasSource: true });
       case "own_page_count": return table(1);
       case "render_own_page": return table(SVG);
       case "own_hit_test": return table(null);

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -168,7 +168,7 @@ export type { CodedError, RecoverySnapshot, RecoverySnapshotSource, RecoveryInfo
 // Web Worker (parse/layout/export/toHwpx off the main thread); the adapter surface is unchanged.
 export type { WasmAdapterOptions, WasmAdapterWorkerOptions } from "./WasmAdapter";
 export { TauriAdapter } from "./TauriAdapter";
-export type { TauriAdapterOptions, Invoke } from "./TauriAdapter";
+export type { DesktopSessionStatus, TauriAdapterOptions, Invoke } from "./TauriAdapter";
 
 // Headless core (issue 026) — the React binding hook + a re-export of @auto-hwp/editor-core so a host can
 // build a fully custom UI over the SAME core (no @auto-hwp/react components required). The heavy editing

--- a/scripts/tests/desktop-shell-mode.test.mjs
+++ b/scripts/tests/desktop-shell-mode.test.mjs
@@ -124,7 +124,14 @@ test("desktop file-open requests converge on one bounded, private, single-instan
   assert.match(shell, /listen\("desktop-open-request"/);
   assert.match(shell, /invoke<string\[\]>\("take_open_requests"\)/);
   assert.match(shell, /role="dialog"/);
-  assert.match(shell, /resolveReplacement\(false\)/);
-  assert.match(shell, /resolveReplacement\(true\)/);
+  assert.match(shell, /sessionStatus\.dirty/);
+  assert.match(shell, />취소<\/button>/);
+  assert.match(shell, />버리기<\/button>/);
+  assert.match(shell, />저장<\/button>/);
+  assert.match(shell, /write_recovery_snapshot/);
+  assert.match(shell, /window\.clearTimeout\(snapshotTimer\.current\)/, "save must cancel a queued recovery write");
+  assert.match(shell, /list_recovery_snapshots/);
+  assert.match(shell, /!recoveryScanComplete/, "cold-open must wait for the recovery scan");
+  assert.match(shell, /EXTERNAL_SOURCE_CHANGED/);
   assert.doesNotMatch(shell, /window\.confirm\s*\(/);
 });


### PR DESCRIPTION
Closes #141

Stacked on #145 until the truthful file-open lifecycle lands; then this PR will be retargeted to main.

Implements authoritative Rust revision and dirty state, external-source overwrite protection, private bounded HWPX recovery snapshots, explicit restore/discard, and save/discard/cancel close and replace flows.

Validation: hwp-viewer 29 tests; React 427 tests; JS total 1,007; canonical layout 8/18/24 pages and 98.9%+ line accuracy; PDF visual 51/51; Playwright 85 pass and 3 intentional skips on isolated port 3141; licenses green. Packaged macOS app QA covered edit, dirty close prevention, crash restart recovery, latest revision restore, save cleanup, and clean close. No user path or document name is persisted in recovery metadata.