### PR TITLE
feat: add first-party HWP5 parser skeleton

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
       - name: test (native)
         run: cargo test --workspace
       - name: wasm hygiene (pure core compiles to wasm32)
-        run: cargo check -p hwp-model -p hwp-ops -p hwp-ingest --target wasm32-unknown-unknown
+        run: cargo check -p hwp-model -p hwp-ops -p hwp-ingest -p hwp-hwp5 --target wasm32-unknown-unknown
       - uses: actions/setup-node@v4
         with:
           node-version: "20"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2040,12 +2040,14 @@ name = "hwp-core"
 version = "0.0.1"
 dependencies = [
  "hwp-foreign",
+ "hwp-hwp5",
  "hwp-hwpx",
  "hwp-ingest",
  "hwp-model",
  "hwp-ops",
  "hwp-rhwp",
  "hwp-typeset",
+ "serde_json",
  "zip 2.4.2",
 ]
 
@@ -2098,12 +2100,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "hwp-hwp5"
+version = "0.0.1"
+dependencies = [
+ "cfb 0.14.0",
+ "flate2",
+ "hwp-ingest",
+ "hwp-model",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "hwp-hwp5-patch"
 version = "0.0.1"
 dependencies = [
  "cfb 0.14.0",
  "flate2",
  "hwp-core",
+ "hwp-hwp5",
  "hwp-model",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ hwp-jsx = { path = "crates/hwp-jsx" }
 hwp-export = { path = "crates/hwp-export" }
 hwp-foreign = { path = "crates/hwp-foreign" }
 hwp-hwp5-patch = { path = "crates/hwp-hwp5-patch" }
+hwp-hwp5 = { path = "crates/hwp-hwp5" }
 
 [profile.release]
 opt-level = 3

--- a/crates/hwp-core/Cargo.toml
+++ b/crates/hwp-core/Cargo.toml
@@ -21,6 +21,7 @@ pdfin = ["hwp-foreign/pdfin"]
 hwp-model = { workspace = true }
 hwp-ingest = { workspace = true }
 hwp-hwpx = { workspace = true }
+hwp-hwp5 = { workspace = true }
 hwp-typeset = { workspace = true }
 hwp-ops = { workspace = true }
 hwp-rhwp = { workspace = true }
@@ -29,3 +30,4 @@ hwp-foreign = { workspace = true }
 [dev-dependencies]
 # Build a tiny in-memory `.docx` for the P5 `Engine::open` DOCX-routing test (docx feature only).
 zip = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/hwp-core/src/lib.rs
+++ b/crates/hwp-core/src/lib.rs
@@ -50,6 +50,64 @@ impl Engine {
     }
 }
 
+/// Run only the first-party HWP5 parser lane. This entry point is intentionally separate from
+/// [`Engine::open`]: until the native DocInfo/text slices land, it validates the owned container and
+/// record layers and then returns `CapabilityUnavailable`. It never calls or falls back to rhwp.
+pub fn open_hwp5_own(bytes: &[u8]) -> Result<SemanticDoc> {
+    hwp_hwp5::OwnHwp5Parser::new()
+        .parse(bytes)
+        .map_err(|error| match error {
+            hwp_hwp5::Error::SemanticSlicePending => {
+                Error::CapabilityUnavailable(hwp_hwp5::OWN_SEMANTIC_SLICE_PENDING)
+            }
+            other => Error::Parse(other.to_string()),
+        })
+}
+
+/// Content-free structural comparison between the first-party HWP5 candidate and the current rhwp
+/// semantic oracle. Production routing is not changed by this diagnostic.
+pub fn hwp5_differential(bytes: &[u8]) -> Result<hwp_hwp5::DifferentialReport> {
+    let native = hwp_hwp5::probe(bytes).map_err(|error| Error::Parse(error.to_string()))?;
+    let semantic = RhwpEngine::new().parse(bytes, SourceFormat::Hwp5)?;
+    Ok(hwp_hwp5::compare_with_semantic(&native, &semantic))
+}
+
+#[cfg(all(test, feature = "rhwp"))]
+mod hwp5_candidate_tests {
+    use super::*;
+
+    fn benchmark() -> Vec<u8> {
+        std::fs::read(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../benchmarks/benchmark.hwp"
+        ))
+        .unwrap()
+    }
+
+    #[test]
+    fn own_only_fails_closed_even_when_rhwp_is_available() {
+        assert!(matches!(
+            open_hwp5_own(&benchmark()),
+            Err(Error::CapabilityUnavailable(message))
+                if message == hwp_hwp5::OWN_SEMANTIC_SLICE_PENDING
+        ));
+    }
+
+    #[test]
+    fn differential_is_content_free_and_deterministic() {
+        let first = hwp5_differential(&benchmark()).unwrap();
+        let second = hwp5_differential(&benchmark()).unwrap();
+        eprintln!("{}", serde_json::to_string_pretty(&first).unwrap());
+        assert_eq!(first, second);
+        assert!(first.native.paragraphs > 0);
+        assert!(first.oracle.paragraphs > 0);
+        let json = serde_json::to_string(&first).unwrap();
+        assert!(!json.contains("benchmark.hwp"));
+        assert!(!json.contains("BodyText"));
+        assert!(json.contains("topo-fnv1a64:"));
+    }
+}
+
 /// **W4.4 — HWPX 수식 enrichment.** HWPX 파서는 `<hp:equation>` 을 verbatim(script + 박스)으로만
 /// 잡아 `EquationRef::rendered_svg` 가 비어 있고, 그래서 own-render/HTML 이 스텁 박스를 그린다.
 /// `.hwp` lift 는 062-5 에서 이미 rhwp 수식 엔진을 부르고 있으므로, 같은 엔진을

--- a/crates/hwp-hwp5-patch/src/raw.rs
+++ b/crates/hwp-hwp5-patch/src/raw.rs
@@ -1,4 +1,5 @@
 use crate::{Error, Result};
+pub(crate) use hwp_hwp5::Record;
 
 pub(crate) const TAG_PARA_HEADER: u16 = 0x42;
 pub(crate) const TAG_PARA_TEXT: u16 = 0x43;
@@ -10,17 +11,6 @@ pub(crate) const TAG_TABLE: u16 = 0x4d;
 
 // HWP stores control IDs as `u32::from_be_bytes(*b"....")`, serialized LE.
 const CTRL_TABLE: u32 = u32::from_be_bytes(*b"tbl ");
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) struct Record {
-    pub(crate) tag: u16,
-    pub(crate) level: u16,
-    pub(crate) size: usize,
-    pub(crate) head: usize,
-    pub(crate) data: usize,
-    pub(crate) end: usize,
-    pub(crate) extended: bool,
-}
 
 #[derive(Clone, Debug)]
 pub(crate) struct RawParagraph {
@@ -47,47 +37,8 @@ pub(crate) struct RawCell {
 }
 
 pub(crate) fn parse_records(raw: &[u8]) -> Result<Vec<Record>> {
-    let mut out = Vec::new();
-    let mut p = 0usize;
-    while p < raw.len() {
-        if raw[p..].iter().all(|byte| *byte == 0) {
-            break;
-        }
-        let head = p;
-        let header = read_u32(raw, p)?;
-        p += 4;
-        let tag = (header & 0x3ff) as u16;
-        let level = ((header >> 10) & 0x3ff) as u16;
-        let packed_size = ((header >> 20) & 0xfff) as usize;
-        let (size, extended) = if packed_size == 0xfff {
-            let size = read_u32(raw, p)? as usize;
-            p += 4;
-            (size, true)
-        } else {
-            (packed_size, false)
-        };
-        let data = p;
-        let end = data
-            .checked_add(size)
-            .filter(|end| *end <= raw.len())
-            .ok_or_else(|| {
-                Error::Record(format!(
-                    "record at byte {head} declares {size} bytes beyond section length {}",
-                    raw.len()
-                ))
-            })?;
-        out.push(Record {
-            tag,
-            level,
-            size,
-            head,
-            data,
-            end,
-            extended,
-        });
-        p = end;
-    }
-    Ok(out)
+    hwp_hwp5::walk_records(raw, hwp_hwp5::RecordLimits::default())
+        .map_err(|error| Error::Record(error.to_string()))
 }
 
 pub(crate) fn parse_section(records: &[Record], raw: &[u8]) -> Result<Vec<RawParagraph>> {

--- a/crates/hwp-hwp5/Cargo.toml
+++ b/crates/hwp-hwp5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "hwp-hwp5-patch"
-description = "Original-byte HWP5 text patcher: maps SemanticDoc paragraph addresses back to BodyText records and rewrites only edited streams."
+name = "hwp-hwp5"
+description = "First-party, bounded HWP5 container and record inspection for auto-hwp."
 edition.workspace = true
 version.workspace = true
 license.workspace = true
@@ -9,11 +9,10 @@ rust-version.workspace = true
 [dependencies]
 cfb = { workspace = true }
 flate2 = { workspace = true }
-hwp-hwp5 = { workspace = true }
+hwp-ingest = { workspace = true }
 hwp-model = { workspace = true }
 serde = { workspace = true }
-serde_json = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-hwp-core = { workspace = true, features = ["rhwp"] }
+serde_json = { workspace = true }

--- a/crates/hwp-hwp5/src/header.rs
+++ b/crates/hwp-hwp5/src/header.rs
@@ -1,0 +1,131 @@
+use serde::Serialize;
+use thiserror::Error;
+
+pub const FILE_HEADER_SIZE: usize = 256;
+pub const HWP_SIGNATURE: &[u8] = b"HWP Document File";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+pub struct HwpVersion {
+    pub major: u8,
+    pub minor: u8,
+    pub build: u8,
+    pub revision: u8,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+pub struct FileHeaderFlags {
+    pub raw: u32,
+    pub compressed: bool,
+    pub encrypted: bool,
+    pub distribution: bool,
+    pub script: bool,
+    pub drm: bool,
+    pub xml_template: bool,
+    pub document_history: bool,
+    pub digital_signature: bool,
+    pub public_key_encrypted: bool,
+    pub modified_certificate: bool,
+    pub prepare_distribution: bool,
+}
+
+impl FileHeaderFlags {
+    pub fn from_raw(raw: u32) -> Self {
+        Self {
+            raw,
+            compressed: raw & (1 << 0) != 0,
+            encrypted: raw & (1 << 1) != 0,
+            distribution: raw & (1 << 2) != 0,
+            script: raw & (1 << 3) != 0,
+            drm: raw & (1 << 4) != 0,
+            xml_template: raw & (1 << 5) != 0,
+            document_history: raw & (1 << 6) != 0,
+            digital_signature: raw & (1 << 7) != 0,
+            public_key_encrypted: raw & (1 << 8) != 0,
+            modified_certificate: raw & (1 << 9) != 0,
+            prepare_distribution: raw & (1 << 10) != 0,
+        }
+    }
+
+    /// Flags for which a transparent first-party parse must not infer clear body records.
+    pub fn body_is_opaque(self) -> bool {
+        self.encrypted || self.distribution || self.drm || self.public_key_encrypted
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+pub struct FileHeader {
+    pub version: HwpVersion,
+    pub flags: FileHeaderFlags,
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum HeaderError {
+    #[error("FileHeader is shorter than {FILE_HEADER_SIZE} bytes: {0}")]
+    TooShort(usize),
+    #[error("invalid HWP5 FileHeader signature")]
+    InvalidSignature,
+}
+
+pub fn parse_file_header(data: &[u8]) -> Result<FileHeader, HeaderError> {
+    if data.len() < FILE_HEADER_SIZE {
+        return Err(HeaderError::TooShort(data.len()));
+    }
+    let signature = &data[..32];
+    if !signature.starts_with(HWP_SIGNATURE) {
+        return Err(HeaderError::InvalidSignature);
+    }
+    Ok(FileHeader {
+        version: HwpVersion {
+            revision: data[32],
+            build: data[33],
+            minor: data[34],
+            major: data[35],
+        },
+        flags: FileHeaderFlags::from_raw(u32::from_le_bytes(
+            data[36..40].try_into().expect("fixed four-byte slice"),
+        )),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn header(flags: u32) -> Vec<u8> {
+        let mut bytes = vec![0; FILE_HEADER_SIZE];
+        bytes[..HWP_SIGNATURE.len()].copy_from_slice(HWP_SIGNATURE);
+        bytes[32..36].copy_from_slice(&[7, 6, 1, 5]);
+        bytes[36..40].copy_from_slice(&flags.to_le_bytes());
+        bytes
+    }
+
+    #[test]
+    fn parses_exact_version_and_security_flags() {
+        let parsed = parse_file_header(&header(0x7ff)).unwrap();
+        assert_eq!(
+            parsed.version,
+            HwpVersion {
+                major: 5,
+                minor: 1,
+                build: 6,
+                revision: 7
+            }
+        );
+        assert!(parsed.flags.compressed);
+        assert!(parsed.flags.encrypted);
+        assert!(parsed.flags.distribution);
+        assert!(parsed.flags.prepare_distribution);
+        assert!(parsed.flags.body_is_opaque());
+    }
+
+    #[test]
+    fn rejects_short_and_wrong_signature() {
+        assert_eq!(parse_file_header(&[0; 40]), Err(HeaderError::TooShort(40)));
+        let mut bytes = header(0);
+        bytes[0] = b'X';
+        assert_eq!(
+            parse_file_header(&bytes),
+            Err(HeaderError::InvalidSignature)
+        );
+    }
+}

--- a/crates/hwp-hwp5/src/lib.rs
+++ b/crates/hwp-hwp5/src/lib.rs
@@ -1,0 +1,70 @@
+//! First-party HWP5 boundary: bounded CFB/FileHeader/record inspection and content-free
+//! differential telemetry. It deliberately does not claim semantic parsing until DocInfo and body
+//! text slices are implemented; [`OwnHwp5Parser::parse`] therefore fails closed without calling
+//! rhwp or any other parser.
+
+mod header;
+mod probe;
+mod record;
+
+pub use header::{
+    parse_file_header, FileHeader, FileHeaderFlags, HeaderError, HwpVersion, FILE_HEADER_SIZE,
+    HWP_SIGNATURE,
+};
+pub use probe::{
+    compare_with_semantic, probe, DifferentialReport, Hwp5Probe, StreamProbe, StructuralDelta,
+    StructuralInventory,
+};
+pub use record::{walk_records, Record, RecordError, RecordLimits};
+
+use hwp_model::document::SemanticDoc;
+use thiserror::Error;
+
+pub const OWN_SEMANTIC_SLICE_PENDING: &str =
+    "first-party HWP5 SemanticDoc decode is not complete (DocInfo/text slice pending)";
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("input limit rejected HWP5: {0}")]
+    Limit(#[from] hwp_ingest::limits::DocLimit),
+    #[error("CFB error: {0}")]
+    Cfb(String),
+    #[error("required HWP5 stream is missing: {0}")]
+    MissingStream(&'static str),
+    #[error(
+        "BodyText sections are not contiguous: expected Section{expected}, found Section{actual}"
+    )]
+    NonContiguousSections { expected: usize, actual: usize },
+    #[error(transparent)]
+    Header(#[from] HeaderError),
+    #[error("opaque HWP5 body is not inspected (flags=0x{0:08x})")]
+    OpaqueBody(u32),
+    #[error("record stream error: {0}")]
+    Record(#[from] RecordError),
+    #[error("decompressed HWP5 data exceeds {limit}-byte limit")]
+    DecompressedLimit { limit: u64 },
+    #[error("{OWN_SEMANTIC_SLICE_PENDING}")]
+    SemanticSlicePending,
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Explicit own-parser entry point. This type has no rhwp dependency and cannot silently fall back.
+#[derive(Default)]
+pub struct OwnHwp5Parser;
+
+impl OwnHwp5Parser {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub fn inspect(&self, bytes: &[u8]) -> Result<Hwp5Probe> {
+        probe(bytes)
+    }
+
+    pub fn parse(&self, bytes: &[u8]) -> Result<SemanticDoc> {
+        // Validate everything this slice owns before reporting the precise missing capability.
+        let _ = self.inspect(bytes)?;
+        Err(Error::SemanticSlicePending)
+    }
+}

--- a/crates/hwp-hwp5/src/probe.rs
+++ b/crates/hwp-hwp5/src/probe.rs
@@ -1,0 +1,371 @@
+use crate::{parse_file_header, walk_records, Error, FileHeader, Record, RecordLimits, Result};
+use cfb::CompoundFile;
+use flate2::read::DeflateDecoder;
+use hwp_ingest::limits::{self, MAX_DECOMPRESSED_TOTAL, MAX_ENTRY_COUNT};
+use hwp_model::document::{Block, Inline, SemanticDoc};
+use serde::Serialize;
+use std::io::{Cursor, Read, Seek};
+
+const TAG_PARA_HEADER: u16 = 0x42;
+const TAG_PARA_CHAR_SHAPE: u16 = 0x44;
+const TAG_CTRL_HEADER: u16 = 0x47;
+const TAG_TABLE: u16 = 0x4d;
+const TAG_PICTURE: u16 = 0x55;
+const TAG_EQUATION: u16 = 0x58;
+const TAG_CHART: u16 = 0x5f;
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct StreamProbe {
+    /// `None` is DocInfo; `Some(n)` is the standard BodyText section ordinal. No source path is kept.
+    pub section: Option<usize>,
+    pub decompressed_bytes: usize,
+    pub records: Vec<Record>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct Hwp5Probe {
+    pub header: FileHeader,
+    pub streams: Vec<StreamProbe>,
+    pub inventory: StructuralInventory,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize)]
+pub struct StructuralInventory {
+    pub sections: usize,
+    pub paragraphs: usize,
+    pub runs: usize,
+    pub tables: usize,
+    pub images: usize,
+    pub controls: usize,
+    pub equations: usize,
+    pub charts: usize,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize)]
+pub struct StructuralDelta {
+    pub sections: i64,
+    pub paragraphs: i64,
+    pub runs: i64,
+    pub tables: i64,
+    pub images: i64,
+    pub controls: i64,
+    pub equations: i64,
+    pub charts: i64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct DifferentialReport {
+    pub schema: &'static str,
+    pub native: StructuralInventory,
+    pub oracle: StructuralInventory,
+    pub delta: StructuralDelta,
+    /// FNV-1a over typed AST topology markers only. It is not a source/content hash.
+    pub semantic_topology_fingerprint: String,
+}
+
+pub fn probe(bytes: &[u8]) -> Result<Hwp5Probe> {
+    limits::check_raw_size(bytes.len())?;
+    let mut compound =
+        CompoundFile::open(Cursor::new(bytes)).map_err(|error| Error::Cfb(error.to_string()))?;
+    let entries: Vec<(String, bool)> = compound
+        .walk()
+        .map(|entry| {
+            (
+                entry.path().to_string_lossy().into_owned(),
+                entry.is_stream(),
+            )
+        })
+        .collect();
+    if entries.len() > MAX_ENTRY_COUNT {
+        return Err(limits::DocLimit::TooManyEntries {
+            count: entries.len(),
+            limit: MAX_ENTRY_COUNT,
+        }
+        .into());
+    }
+    let header_bytes = read_stream_bounded(&mut compound, "/FileHeader", 256)?;
+    let header = parse_file_header(&header_bytes)?;
+    if header.flags.body_is_opaque() {
+        return Err(Error::OpaqueBody(header.flags.raw));
+    }
+
+    let mut budget_used = 0u64;
+    let mut streams = Vec::new();
+    if !entries
+        .iter()
+        .any(|(path, is_stream)| *is_stream && path == "/DocInfo")
+    {
+        return Err(Error::MissingStream("DocInfo"));
+    }
+    streams.push(inspect_stream(
+        &mut compound,
+        "/DocInfo",
+        None,
+        header.flags.compressed,
+        &mut budget_used,
+    )?);
+    let mut sections: Vec<usize> = entries
+        .iter()
+        .filter(|(_, is_stream)| *is_stream)
+        .filter_map(|(path, _)| path.strip_prefix("/BodyText/Section")?.parse().ok())
+        .collect();
+    sections.sort_unstable();
+    if sections.is_empty() {
+        return Err(Error::MissingStream("BodyText/Section0"));
+    }
+    for (expected, section) in sections.into_iter().enumerate() {
+        if section != expected {
+            return Err(Error::NonContiguousSections {
+                expected,
+                actual: section,
+            });
+        }
+        let path = format!("/BodyText/Section{section}");
+        streams.push(inspect_stream(
+            &mut compound,
+            &path,
+            Some(section),
+            header.flags.compressed,
+            &mut budget_used,
+        )?);
+    }
+    let inventory = native_inventory(&streams);
+    Ok(Hwp5Probe {
+        header,
+        streams,
+        inventory,
+    })
+}
+
+fn inspect_stream<R: Read + Seek>(
+    compound: &mut CompoundFile<R>,
+    path: &str,
+    section: Option<usize>,
+    compressed: bool,
+    budget_used: &mut u64,
+) -> Result<StreamProbe> {
+    let stored = read_stream_bounded(compound, path, MAX_DECOMPRESSED_TOTAL as usize)?;
+    let raw = if compressed {
+        inflate_bounded(&stored, budget_used)?
+    } else {
+        account(stored.len(), budget_used)?;
+        stored
+    };
+    let records = walk_records(&raw, RecordLimits::default())?;
+    Ok(StreamProbe {
+        section,
+        decompressed_bytes: raw.len(),
+        records,
+    })
+}
+
+fn read_stream_bounded<R: Read + Seek>(
+    compound: &mut CompoundFile<R>,
+    path: &str,
+    limit: usize,
+) -> Result<Vec<u8>> {
+    let mut stream = compound
+        .open_stream(path)
+        .map_err(|error| Error::Cfb(error.to_string()))?;
+    let mut bytes = Vec::new();
+    stream
+        .by_ref()
+        .take(limit as u64 + 1)
+        .read_to_end(&mut bytes)
+        .map_err(|error| Error::Cfb(error.to_string()))?;
+    if bytes.len() > limit {
+        return Err(Error::DecompressedLimit {
+            limit: limit as u64,
+        });
+    }
+    Ok(bytes)
+}
+
+fn inflate_bounded(stored: &[u8], budget_used: &mut u64) -> Result<Vec<u8>> {
+    let remaining = MAX_DECOMPRESSED_TOTAL.saturating_sub(*budget_used);
+    let mut raw = Vec::new();
+    DeflateDecoder::new(stored)
+        .take(remaining + 1)
+        .read_to_end(&mut raw)
+        .map_err(|error| Error::Cfb(format!("deflate stream rejected: {error}")))?;
+    account(raw.len(), budget_used)?;
+    Ok(raw)
+}
+
+fn account(size: usize, budget_used: &mut u64) -> Result<()> {
+    *budget_used = budget_used.saturating_add(size as u64);
+    if *budget_used > MAX_DECOMPRESSED_TOTAL {
+        return Err(Error::DecompressedLimit {
+            limit: MAX_DECOMPRESSED_TOTAL,
+        });
+    }
+    Ok(())
+}
+
+fn native_inventory(streams: &[StreamProbe]) -> StructuralInventory {
+    let mut out = StructuralInventory {
+        sections: streams
+            .iter()
+            .filter(|stream| stream.section.is_some())
+            .count(),
+        ..StructuralInventory::default()
+    };
+    for stream in streams.iter().filter(|stream| stream.section.is_some()) {
+        for record in &stream.records {
+            match record.tag {
+                TAG_PARA_HEADER => out.paragraphs += 1,
+                TAG_PARA_CHAR_SHAPE => out.runs += record.size / 8,
+                TAG_TABLE => out.tables += 1,
+                TAG_PICTURE => out.images += 1,
+                TAG_CTRL_HEADER => out.controls += 1,
+                TAG_EQUATION => out.equations += 1,
+                TAG_CHART => out.charts += 1,
+                _ => {}
+            }
+        }
+    }
+    out
+}
+
+pub fn compare_with_semantic(native: &Hwp5Probe, oracle: &SemanticDoc) -> DifferentialReport {
+    let (oracle_inventory, fingerprint) = semantic_inventory(oracle);
+    DifferentialReport {
+        schema: "auto-hwp.hwp5-differential.v1",
+        native: native.inventory,
+        oracle: oracle_inventory,
+        delta: delta(native.inventory, oracle_inventory),
+        semantic_topology_fingerprint: format!("topo-fnv1a64:{fingerprint:016x}"),
+    }
+}
+
+fn delta(a: StructuralInventory, b: StructuralInventory) -> StructuralDelta {
+    let d = |left: usize, right: usize| left as i64 - right as i64;
+    StructuralDelta {
+        sections: d(a.sections, b.sections),
+        paragraphs: d(a.paragraphs, b.paragraphs),
+        runs: d(a.runs, b.runs),
+        tables: d(a.tables, b.tables),
+        images: d(a.images, b.images),
+        controls: d(a.controls, b.controls),
+        equations: d(a.equations, b.equations),
+        charts: d(a.charts, b.charts),
+    }
+}
+
+fn semantic_inventory(doc: &SemanticDoc) -> (StructuralInventory, u64) {
+    let mut inventory = StructuralInventory {
+        sections: doc.sections.len(),
+        ..StructuralInventory::default()
+    };
+    let mut hash = Fnv1a::new();
+    hash.marker(1, doc.sections.len());
+    for section in &doc.sections {
+        visit_blocks(&section.blocks, &mut inventory, &mut hash);
+        hash.marker(2, section.decorations.len());
+        for decoration in &section.decorations {
+            visit_blocks(&decoration.blocks, &mut inventory, &mut hash);
+        }
+    }
+    (inventory, hash.0)
+}
+
+fn visit_blocks(blocks: &[Block], inventory: &mut StructuralInventory, hash: &mut Fnv1a) {
+    hash.marker(3, blocks.len());
+    for block in blocks {
+        match block {
+            Block::Paragraph(paragraph) => {
+                inventory.paragraphs += 1;
+                inventory.runs += paragraph.runs.len();
+                hash.marker(4, paragraph.runs.len());
+                for run in &paragraph.runs {
+                    hash.marker(5, run.content.len());
+                    for inline in &run.content {
+                        match inline {
+                            Inline::Text(_) => hash.marker(6, 0),
+                            Inline::Image(_) => {
+                                inventory.images += 1;
+                                inventory.controls += 1;
+                                hash.marker(7, 0);
+                            }
+                            Inline::Equation(_) => {
+                                inventory.equations += 1;
+                                inventory.controls += 1;
+                                hash.marker(8, 0);
+                            }
+                            Inline::Chart(_) => {
+                                inventory.charts += 1;
+                                inventory.controls += 1;
+                                hash.marker(9, 0);
+                            }
+                            Inline::Note(note) => {
+                                inventory.controls += 1;
+                                hash.marker(10, note.body.len());
+                                visit_blocks(&note.body, inventory, hash);
+                            }
+                            Inline::FieldBegin(_)
+                            | Inline::FieldEnd(_)
+                            | Inline::Bookmark(_)
+                            | Inline::Raw(_) => {
+                                inventory.controls += 1;
+                                hash.marker(11, 0);
+                            }
+                        }
+                    }
+                }
+            }
+            Block::Table(table) => {
+                inventory.tables += 1;
+                inventory.controls += 1;
+                hash.marker(12, table.cells.len());
+                for cell in &table.cells {
+                    visit_blocks(&cell.blocks, inventory, hash);
+                }
+            }
+        }
+    }
+}
+
+struct Fnv1a(u64);
+
+impl Fnv1a {
+    fn new() -> Self {
+        Self(0xcbf29ce484222325)
+    }
+
+    fn marker(&mut self, tag: u8, count: usize) {
+        for byte in std::iter::once(tag).chain((count as u64).to_le_bytes()) {
+            self.0 ^= byte as u64;
+            self.0 = self.0.wrapping_mul(0x100000001b3);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn topology_fingerprint_ignores_text_content() {
+        let mut left = SemanticDoc::default();
+        left.sections.push(Default::default());
+        left.sections[0]
+            .blocks
+            .push(Block::Paragraph(Default::default()));
+        left.sections[0].blocks[0] = Block::Paragraph(hwp_model::document::Paragraph {
+            runs: vec![hwp_model::document::Run {
+                char_shape: 0,
+                char_ref: None,
+                content: vec![Inline::Text("private-a".into())],
+            }],
+            ..Default::default()
+        });
+        let mut right = left.clone();
+        let Block::Paragraph(paragraph) = &mut right.sections[0].blocks[0] else {
+            unreachable!()
+        };
+        paragraph.runs[0].content[0] = Inline::Text("different-secret".into());
+        let (_, a) = semantic_inventory(&left);
+        let (_, b) = semantic_inventory(&right);
+        assert_eq!(a, b);
+    }
+}

--- a/crates/hwp-hwp5/src/record.rs
+++ b/crates/hwp-hwp5/src/record.rs
@@ -1,0 +1,191 @@
+use serde::Serialize;
+use thiserror::Error;
+
+/// A single HWP5 record's provenance within its decompressed record stream.
+/// No source bytes are copied into this descriptor.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+pub struct Record {
+    pub tag: u16,
+    pub level: u16,
+    pub size: usize,
+    #[serde(rename = "header_offset")]
+    pub head: usize,
+    #[serde(rename = "data_offset")]
+    pub data: usize,
+    #[serde(rename = "end_offset")]
+    pub end: usize,
+    pub extended: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RecordLimits {
+    pub max_stream_bytes: usize,
+    pub max_records: usize,
+}
+
+impl Default for RecordLimits {
+    fn default() -> Self {
+        Self {
+            max_stream_bytes: hwp_ingest::limits::MAX_DECOMPRESSED_TOTAL as usize,
+            max_records: 1_000_000,
+        }
+    }
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum RecordError {
+    #[error("record stream exceeds {limit}-byte limit: {size}")]
+    StreamTooLarge { size: usize, limit: usize },
+    #[error("record count exceeds {limit} limit")]
+    TooManyRecords { limit: usize },
+    #[error("truncated record header at byte {offset}")]
+    TruncatedHeader { offset: usize },
+    #[error("record at byte {offset} declares {size} bytes beyond stream length {stream_len}")]
+    TruncatedData {
+        offset: usize,
+        size: usize,
+        stream_len: usize,
+    },
+}
+
+pub fn walk_records(raw: &[u8], limits: RecordLimits) -> Result<Vec<Record>, RecordError> {
+    if raw.len() > limits.max_stream_bytes {
+        return Err(RecordError::StreamTooLarge {
+            size: raw.len(),
+            limit: limits.max_stream_bytes,
+        });
+    }
+    let mut records = Vec::new();
+    let mut cursor = 0usize;
+    while cursor < raw.len() {
+        if raw[cursor..].iter().all(|byte| *byte == 0) {
+            break;
+        }
+        if records.len() >= limits.max_records {
+            return Err(RecordError::TooManyRecords {
+                limit: limits.max_records,
+            });
+        }
+        let head = cursor;
+        let header =
+            read_u32(raw, cursor).ok_or(RecordError::TruncatedHeader { offset: cursor })?;
+        cursor += 4;
+        let tag = (header & 0x3ff) as u16;
+        let level = ((header >> 10) & 0x3ff) as u16;
+        let packed_size = ((header >> 20) & 0xfff) as usize;
+        let (size, extended) = if packed_size == 0xfff {
+            let value = read_u32(raw, cursor)
+                .ok_or(RecordError::TruncatedHeader { offset: cursor })?
+                as usize;
+            cursor += 4;
+            (value, true)
+        } else {
+            (packed_size, false)
+        };
+        let data_offset = cursor;
+        let end_offset = data_offset
+            .checked_add(size)
+            .filter(|end| *end <= raw.len())
+            .ok_or(RecordError::TruncatedData {
+                offset: head,
+                size,
+                stream_len: raw.len(),
+            })?;
+        records.push(Record {
+            tag,
+            level,
+            size,
+            head,
+            data: data_offset,
+            end: end_offset,
+            extended,
+        });
+        cursor = end_offset;
+    }
+    Ok(records)
+}
+
+fn read_u32(raw: &[u8], offset: usize) -> Option<u32> {
+    Some(u32::from_le_bytes(
+        raw.get(offset..offset + 4)?.try_into().ok()?,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn record(tag: u16, level: u16, data: &[u8], extended: bool) -> Vec<u8> {
+        let packed = if extended { 0xfff } else { data.len() as u32 };
+        let mut out = ((tag as u32) | ((level as u32) << 10) | (packed << 20))
+            .to_le_bytes()
+            .to_vec();
+        if extended {
+            out.extend_from_slice(&(data.len() as u32).to_le_bytes());
+        }
+        out.extend_from_slice(data);
+        out
+    }
+
+    #[test]
+    fn preserves_unknown_tag_and_exact_raw_span() {
+        let bytes = record(0x3aa, 17, &[1, 2, 3], false);
+        let records = walk_records(&bytes, RecordLimits::default()).unwrap();
+        assert_eq!(
+            records,
+            vec![Record {
+                tag: 0x3aa,
+                level: 17,
+                size: 3,
+                head: 0,
+                data: 4,
+                end: 7,
+                extended: false,
+            }]
+        );
+    }
+
+    #[test]
+    fn accepts_extended_header_and_zero_tail() {
+        let mut bytes = record(0x43, 1, &[8; 12], true);
+        bytes.extend_from_slice(&[0; 7]);
+        let records = walk_records(&bytes, RecordLimits::default()).unwrap();
+        assert_eq!(records[0].data, 8);
+        assert_eq!(records[0].end, 20);
+        assert!(records[0].extended);
+    }
+
+    #[test]
+    fn rejects_truncation_and_record_exhaustion() {
+        assert!(matches!(
+            walk_records(&[1, 2, 3], RecordLimits::default()),
+            Err(RecordError::TruncatedHeader { .. })
+        ));
+        let bytes = record(1, 0, &[], false);
+        assert_eq!(
+            walk_records(
+                &bytes,
+                RecordLimits {
+                    max_stream_bytes: 100,
+                    max_records: 0
+                }
+            ),
+            Err(RecordError::TooManyRecords { limit: 0 })
+        );
+        assert_eq!(
+            walk_records(
+                &bytes,
+                RecordLimits {
+                    max_stream_bytes: 3,
+                    max_records: 1
+                }
+            ),
+            Err(RecordError::StreamTooLarge { size: 4, limit: 3 })
+        );
+        let extended_without_size = ((1_u32) | (0xfff << 20)).to_le_bytes();
+        assert_eq!(
+            walk_records(&extended_without_size, RecordLimits::default()),
+            Err(RecordError::TruncatedHeader { offset: 4 })
+        );
+    }
+}

--- a/crates/hwp-hwp5/tests/public_probe.rs
+++ b/crates/hwp-hwp5/tests/public_probe.rs
@@ -1,0 +1,36 @@
+use hwp_hwp5::{probe, Error, OwnHwp5Parser};
+
+fn benchmark() -> Vec<u8> {
+    std::fs::read(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../benchmarks/benchmark.hwp"
+    ))
+    .unwrap()
+}
+
+#[test]
+fn public_hwp5_has_bounded_content_free_record_provenance() {
+    let parsed = probe(&benchmark()).unwrap();
+    assert_eq!(parsed.inventory.sections, 1);
+    assert!(parsed.inventory.paragraphs > 0);
+    assert!(parsed.inventory.tables > 0);
+    assert!(parsed
+        .streams
+        .iter()
+        .flat_map(|stream| &stream.records)
+        .all(|record| record.head <= record.data && record.data <= record.end));
+
+    let json = serde_json::to_string(&parsed).unwrap();
+    assert!(!json.contains("benchmark.hwp"));
+    assert!(!json.contains("BodyText"));
+    assert!(!json.contains("FileHeader"));
+    assert!(json.contains("header_offset"));
+}
+
+#[test]
+fn explicit_own_parser_never_falls_back() {
+    assert!(matches!(
+        OwnHwp5Parser::new().parse(&benchmark()),
+        Err(Error::SemanticSlicePending)
+    ));
+}

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,6 +3,37 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
+- 갱신: 2026-08-23 · Codex(sol) — **#107 전체 검증 green·게시 준비**.
+  rhwp boundary 6, fmt/clippy/workspace, 신규 8 + patch 11 + core differential 2, PDF visual 51,
+  canonical 8/18/24·line 98.9%+, public corpus contract 84, oracle 82, HWPX locks, wasm32+optimized
+  7,793,352B, licenses가 green이다. 새 worktree의 node_modules 부재로 full script가 JS 진입에서
+  한 번 환경 실패했으나 동일 lockfile의 기존 설치본을 symlink 재사용해 JS build/crosscheck/i18n,
+  Vitest 269+64+427+247+11=1,018과 실제 Chromium Playwright 85 pass/3 intentional skip를 완료했다.
+  generated wasm/JS·external/rhwp diff는 없다. 최종 diff/security review에서 production `unsafe`·
+  credential/path/text/hash 유출·silent fallback을 발견하지 않았고, missing DocInfo/Section0와 section
+  gap도 fail-closed로 보강 후 focused test/clippy/wasm을 재통과했다. **다음:** commit·push→PR `Closes #107`/
+  `Refs #94 #87`→필수 CI·리뷰/댓글 확인→자율 병합→#94 첫 child issue/branch.
+
+- 갱신: 2026-08-23 · Codex(sol) — **#107 first-party HWP5 skeleton·differential 구현**.
+  신규 wasm-clean `hwp-hwp5`가 CFB/FileHeader 11개 flag, 64MiB raw·256MiB cumulative inflate·
+  4096 entry·1M record 상한, normal/extended bounded record walk와 unknown tag의 stream-relative
+  raw-span provenance를 소유한다. `hwp-hwp5-patch`도 이 워커를 재사용해 중복 parser truth를 없앴다.
+  `open_hwp5_own`은 DocInfo/text slice 전까지 명시적으로 fail-closed하고 rhwp fallback이 없으며,
+  `hwp5_differential`은 native↔rhwp 구조 8축과 본문/경로/원본 hash 없는 SemanticDoc topology
+  fingerprint를 낸다. production `Engine::open` 기본은 불변이다. focused 8+11+2 tests와 wasm32
+  check green. 디스크 부족으로 완료/현재 worktree의 재생성 가능 `target/` 35GiB를 정리했다.
+  **다음:** 문서 계약→clippy/workspace/전체 조판 게이트→commit·push·PR #107→CI·병합, 이어 #94
+  DocInfo pool+PARA_TEXT 최소 SemanticDoc slice를 별도 issue-first 단위로 착수한다.
+
+- 갱신: 2026-08-23 · Codex(sol) — **PR #152 병합 · #107 자체 HWP5 skeleton 착수**.
+  #151 PR #152는 head `d65c844`에서 issue-link·build-test·licenses green, CLEAN/MERGEABLE,
+  리뷰/댓글 0을 확인한 뒤 main `1b272844`로 squash 병합했고 원격 브랜치를 삭제했다. #87에는
+  F0 완료 증거를 남기되 F1+ epic이라 open 유지했고, #94/#107을 blocked→ready로 전환했다.
+  최신 main에서 `codex/issue-107-hwp5-skeleton`을 만들었다. **다음:** `hwp-hwp5-patch`의 CFB·
+  FileHeader·record walker를 읽고 재사용 가능한 first-party `hwp-hwp5` 경계를 설계한다. 첫 PR은
+  production default/fallback을 바꾸지 않고 FileHeader security flags·bounded record walk·unknown
+  raw-span provenance·content-free dual-parser report를 구현한다. `external/rhwp`는 변경하지 않는다.
+
 - 갱신: 2026-08-23 · Codex(sol) — **#151 전체 검증·공개 truth surface 정합 완료**.
   `verify-local.sh --full`의 Rust workspace/clippy·HWP5 feature·canonical 8/18/24와 98.9%+·
   PDF visual 51·public corpus 84·oracle 82·HWPX locks·WASM 7,793,352B·licenses·JS builds와

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,6 +3,13 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
+- 갱신: 2026-08-23 · Codex(sol) — **#107 PR #153 게시**.
+  검증 완료 commit `513e8e2`를 push하고 PR #153(`Closes #107`, `Refs #94 #87`)을 만들었다.
+  production route 불변, own-only fail-closed, content-free differential, hostile bounds, public benchmark
+  gap(1/1 sections·353/352 paragraphs·389/382 runs·32/32 tables·38/32 controls)을 본문에 명시했다.
+  **다음:** 상태 commit push→issue-link/build-test/licenses·mergeability·review/comment 감시→green 자율
+  병합·원격 브랜치 정리→#94 첫 child issue로 DocInfo pool/paragraph text slice를 분리 착수한다.
+
 - 갱신: 2026-08-23 · Codex(sol) — **#107 전체 검증 green·게시 준비**.
   rhwp boundary 6, fmt/clippy/workspace, 신규 8 + patch 11 + core differential 2, PDF visual 51,
   canonical 8/18/24·line 98.9%+, public corpus contract 84, oracle 82, HWPX locks, wasm32+optimized

--- a/docs/DEPENDENCY-STRATEGY.md
+++ b/docs/DEPENDENCY-STRATEGY.md
@@ -11,7 +11,7 @@
 
 | Capability (trait) | 의미 | 부트스트랩 구현 | 자체 구현 목표 |
 |---|---|---|---|
-| `DocumentParser` | bytes → SemanticDoc | `hwp-rhwp`(HWP5/HWP3), `hwp-hwpx`(HWPX) | HWPX는 자체 완료; #107/#94 자체 HWP5 파서 |
+| `DocumentParser` | bytes → SemanticDoc | `hwp-rhwp`(HWP5/HWP3), `hwp-hwpx`(HWPX) | HWPX 자체 완료; #107 `hwp-hwp5` container/record+differential 완료, #94 semantic cutover |
 | `LayoutEngine` | doc → line segs/pagination | 없음(저장 lineseg는 oracle만) | **`hwp-typeset` 생산 경로** |
 | `Renderer` | layout → PageLayerTree(paint IR) | 없음(`source:"original"`은 read-only 비교만) | **`hwp-render` 생산 경로** |
 | `HwpxSerializer` | doc → .hwpx (dirty-only) | **없음**(rhwp 직렬화기는 한컴 비호환) | **`hwp-hwpx` 자체 — 처음부터 우리 것** |

--- a/docs/HWP5-NATIVE-PARSER.md
+++ b/docs/HWP5-NATIVE-PARSER.md
@@ -1,0 +1,47 @@
+# First-party HWP5 parser boundary
+
+Issue #107 introduces the first owned binary-HWP layer without changing production parsing.
+
+## What is owned now
+
+`crates/hwp-hwp5` parses the CFB `FileHeader`, exposes every documented property/security flag,
+walks `DocInfo` and `BodyText/SectionN` records, and preserves unknown records as `(tag, level,
+size, header/data/end offsets, extended-header bit)`. Offsets are relative to the decompressed
+standard stream. Source bytes, text, filenames, credentials, and source hashes are never copied
+into the probe or differential report.
+
+Untrusted input is bounded before and during inspection:
+
+- raw file: 64 MiB;
+- CFB entries: 4,096;
+- cumulative decompressed record data: 256 MiB;
+- records per stream: 1,000,000;
+- every normal and extended record length is checked before forming a span.
+
+Encrypted, distribution, DRM, and public-key-encrypted bodies are opaque to this slice and are
+rejected instead of being interpreted as records.
+
+## Parser modes
+
+- `Engine::open`: unchanged production route. Binary HWP still uses the governed rhwp bootstrap.
+- `open_hwp5_own`: explicit first-party-only route. It validates the owned layers, then returns the
+  precise pending-capability error until DocInfo and text decoding land. It cannot call rhwp.
+- `hwp5_differential`: explicitly runs the owned probe and current rhwp semantic oracle, then reports
+  section/paragraph/run/table/image/control/equation/chart counts and their deltas.
+
+The report's `topo-fnv1a64:*` value hashes only typed `SemanticDoc` topology markers and collection
+cardinalities. It deliberately ignores text, URLs, image bytes, source paths, provenance bytes, and
+style values. It is a regression fingerprint, not a document/content identity hash.
+
+Raw-record counts and semantic counts are not treated as equivalent truth. In particular, native
+`runs` currently counts `PARA_CHAR_SHAPE` position tuples and native `controls` counts
+`CTRL_HEADER` records. Semantic `controls` counts typed table/image/equation/chart and remaining
+field/note/raw control nodes. The differential makes these gaps measurable; it does not relax a gate
+or claim semantic parity.
+
+## Cutover rule
+
+The next #94 slices promote DocInfo pools and paragraph text/control decoding into this crate. The
+production route may change only when public-corpus differential gates, native/wasm parity, hostile
+input tests, and the canonical 8/18/24-page + 98.9% line gate remain green. Explicit own-parser mode
+must continue to fail closed for every unsupported semantic construct.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,10 @@
 
 ---
 
+## 2026-08-23 (Codex sol) · #107 PR #153
+- commit `513e8e2` push, PR #153(`Closes #107`, `Refs #94 #87`) 게시.
+- 다음 required CI/review 감시→green 자율 병합→#94 first semantic slice.
+
 ## 2026-08-23 (Codex sol) · #107 full green
 - Rust/clippy·canonical 8/18/24+98.9%·PDF51·corpus84·oracle82·HWPX·WASM/licenses green.
 - JS build/Vitest 1,018; actual Chromium E2E 85 pass/3 intentional skip.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,22 @@
 
 ---
 
+## 2026-08-23 (Codex sol) · #107 full green
+- Rust/clippy·canonical 8/18/24+98.9%·PDF51·corpus84·oracle82·HWPX·WASM/licenses green.
+- JS build/Vitest 1,018; actual Chromium E2E 85 pass/3 intentional skip.
+- generated diff 0. 다음 final review→commit/push→PR/CI/merge→#94 child.
+
+## 2026-08-23 (Codex sol) · #107 자체 HWP5 skeleton 구현
+- wasm-clean `hwp-hwp5`: FileHeader/security flags·bounded CFB/record walk·unknown raw spans.
+- `hwp-hwp5-patch`가 공용 walker를 재사용; own-only fail-closed, production route 불변.
+- content-free native↔rhwp 8축 differential+topology fingerprint; focused 21 tests+wasm green.
+- 다음 docs/clippy/full gate→PR/CI/병합→#94 DocInfo/text slice.
+
+## 2026-08-23 (Codex sol) · #152 병합 → #107 착수
+- PR #152 필수 CI·CLEAN 확인 후 main `1b272844` 병합, 원격 브랜치 정리.
+- #87 F0 완료 기록·epic open 유지, #94/#107 ready 전환.
+- 최신 main worktree 생성. 다음 hwp-hwp5-patch 재사용 감사→own skeleton/differential 구현.
+
 ## 2026-08-23 (Codex sol) · #151 full green
 - full Rust/조판/PDF/WASM/licenses와 Vitest 1,018 green; Chromium E2E 85 pass/3 skip.
 - 공개 `/bench`·CONTRIBUTING·진단 문구까지 정확한 rhwp 예외 경계로 교정, Next 20 routes build green.

--- a/docs/RHWP-FORK-GOVERNANCE.md
+++ b/docs/RHWP-FORK-GOVERNANCE.md
@@ -43,5 +43,7 @@ HWPX를 rhwp에 다시 넣어 생산 렌더·저장하지 않는다. rhwp 직렬
 ## 독립화 순서
 
 F0(#87/#151)은 이 문서·검증기·코드 경계를 소유한다. F1(#107)은 자체 HWP5 container/record
-skeleton과 differential harness를 만들고, F2(#94)는 feature별 파서를 교체한다. 한 기능씩 corpus와
+경계를 `hwp-hwp5`로 구현했다(`docs/HWP5-NATIVE-PARSER.md`). production decode는 아직 rhwp이며,
+#94가 DocInfo/text/object semantic slice와 corpus parity를 순차 승격한다. 자체 전용 API는 미지원
+slice에서 fail-closed하고 production route로 fallback하지 않는다. 한 기능씩 corpus와
 lineseg/페이지/PDF 시각 오라클을 통과시킨 뒤에만 rhwp 호출을 제거한다.

--- a/scripts/verify-local.sh
+++ b/scripts/verify-local.sh
@@ -130,6 +130,7 @@ else
 fi
 
 echo "═══ wasm 위생 ═══"
+cargo check -p hwp-hwp5 --target wasm32-unknown-unknown
 cargo check -p hwp-wasm --target wasm32-unknown-unknown
 
 if command -v cargo-deny >/dev/null 2>&1; then


### PR DESCRIPTION
Closes #107
Refs #94
Refs #87

## Outcome
- adds wasm-clean first-party `hwp-hwp5` for CFB FileHeader/security flags and bounded DocInfo/BodyText record walks
- preserves unknown record tag/level/size plus stream-relative raw-span provenance without copying source bytes
- makes `open_hwp5_own` fail closed with no rhwp fallback until the DocInfo/text semantic slice lands
- adds content-free native↔rhwp structural differential over sections, paragraphs, runs, tables, images, controls, equations, and charts
- moves `hwp-hwp5-patch` onto the shared first-party record walker; production `Engine::open` routing is unchanged

## Security and privacy
- 64 MiB raw, 4,096 CFB entry, 256 MiB cumulative decompression, and 1,000,000 record-per-stream caps
- malformed normal/extended records, missing required streams, non-contiguous sections, and opaque security bodies fail closed
- reports contain no filename, text, credential, source bytes, or source/content hash; the topology fingerprint hashes typed structure only
- `external/rhwp` and generated artifacts have zero diff

## Verification
- `cargo fmt --all --check` and workspace clippy/tests
- hwp-hwp5 8, hwp-hwp5-patch 11, core differential 2 focused tests
- wasm32 check and optimized WASM 7,793,352 bytes
- canonical layout 8/18/24 and line accuracy >=98.9%; PDF visual 51
- public corpus contracts 84; oracle sweep 82; HWPX locks; licenses
- Vitest 1,018; Chromium Playwright 85 passed / 3 intentional skips

## Current measured gap (public benchmark)
Native/oracle: sections 1/1, paragraphs 353/352, runs 389/382, tables 32/32, controls 38/32. These are an explicit next-slice baseline, not a parity claim or relaxed gate.