### PR TITLE
feat: first-party HWP5 text semantic slice

### DIFF
--- a/crates/hwp-core/src/lib.rs
+++ b/crates/hwp-core/src/lib.rs
@@ -51,17 +51,12 @@ impl Engine {
 }
 
 /// Run only the first-party HWP5 parser lane. This entry point is intentionally separate from
-/// [`Engine::open`]: until the native DocInfo/text slices land, it validates the owned container and
-/// record layers and then returns `CapabilityUnavailable`. It never calls or falls back to rhwp.
+/// [`Engine::open`]: it accepts the strict text-only subset and returns a parse error for every
+/// unsupported construct. It never calls or falls back to rhwp.
 pub fn open_hwp5_own(bytes: &[u8]) -> Result<SemanticDoc> {
     hwp_hwp5::OwnHwp5Parser::new()
         .parse(bytes)
-        .map_err(|error| match error {
-            hwp_hwp5::Error::SemanticSlicePending => {
-                Error::CapabilityUnavailable(hwp_hwp5::OWN_SEMANTIC_SLICE_PENDING)
-            }
-            other => Error::Parse(other.to_string()),
-        })
+        .map_err(|error| Error::Parse(error.to_string()))
 }
 
 /// Content-free structural comparison between the first-party HWP5 candidate and the current rhwp
@@ -86,11 +81,10 @@ mod hwp5_candidate_tests {
 
     #[test]
     fn own_only_fails_closed_even_when_rhwp_is_available() {
-        assert!(matches!(
-            open_hwp5_own(&benchmark()),
-            Err(Error::CapabilityUnavailable(message))
-                if message == hwp_hwp5::OWN_SEMANTIC_SLICE_PENDING
-        ));
+        let error = open_hwp5_own(&benchmark()).unwrap_err().to_string();
+        assert!(error.contains("HWP5"));
+        assert!(error.contains("tag"));
+        assert!(!error.contains("benchmark.hwp"));
     }
 
     #[test]

--- a/crates/hwp-hwp5/src/lib.rs
+++ b/crates/hwp-hwp5/src/lib.rs
@@ -1,11 +1,11 @@
-//! First-party HWP5 boundary: bounded CFB/FileHeader/record inspection and content-free
-//! differential telemetry. It deliberately does not claim semantic parsing until DocInfo and body
-//! text slices are implemented; [`OwnHwp5Parser::parse`] therefore fails closed without calling
-//! rhwp or any other parser.
+//! First-party HWP5 boundary: bounded CFB/FileHeader/record inspection, a strict text-only semantic
+//! slice, and content-free differential telemetry. [`OwnHwp5Parser::parse`] accepts only the owned
+//! subset and fails closed without calling rhwp or any other parser for every unsupported record.
 
 mod header;
 mod probe;
 mod record;
+mod semantic;
 
 pub use header::{
     parse_file_header, FileHeader, FileHeaderFlags, HeaderError, HwpVersion, FILE_HEADER_SIZE,
@@ -19,9 +19,6 @@ pub use record::{walk_records, Record, RecordError, RecordLimits};
 
 use hwp_model::document::SemanticDoc;
 use thiserror::Error;
-
-pub const OWN_SEMANTIC_SLICE_PENDING: &str =
-    "first-party HWP5 SemanticDoc decode is not complete (DocInfo/text slice pending)";
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -41,10 +38,40 @@ pub enum Error {
     OpaqueBody(u32),
     #[error("record stream error: {0}")]
     Record(#[from] RecordError),
+    #[error(
+        "HWP5 record tag {tag:#x} at section {section:?} byte {offset} is malformed: {reason}"
+    )]
+    MalformedRecord {
+        tag: u16,
+        section: Option<usize>,
+        offset: usize,
+        reason: &'static str,
+    },
+    #[error("HWP5 pool count mismatch for tag {tag:#x}: expected {expected}, found {actual}")]
+    PoolCountMismatch {
+        tag: u16,
+        expected: usize,
+        actual: usize,
+    },
+    #[error("HWP5 {kind} reference {index} is outside pool size {pool_len} at section {section:?} byte {offset}")]
+    InvalidReference {
+        kind: &'static str,
+        index: usize,
+        pool_len: usize,
+        section: Option<usize>,
+        offset: usize,
+    },
+    #[error(
+        "unsupported text-only HWP5 record tag {tag:#x} at section {section} bytes {start}..{end}"
+    )]
+    UnsupportedBodyRecord {
+        tag: u16,
+        section: usize,
+        start: usize,
+        end: usize,
+    },
     #[error("decompressed HWP5 data exceeds {limit}-byte limit")]
     DecompressedLimit { limit: u64 },
-    #[error("{OWN_SEMANTIC_SLICE_PENDING}")]
-    SemanticSlicePending,
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -63,8 +90,6 @@ impl OwnHwp5Parser {
     }
 
     pub fn parse(&self, bytes: &[u8]) -> Result<SemanticDoc> {
-        // Validate everything this slice owns before reporting the precise missing capability.
-        let _ = self.inspect(bytes)?;
-        Err(Error::SemanticSlicePending)
+        semantic::parse_text_only(bytes)
     }
 }

--- a/crates/hwp-hwp5/src/probe.rs
+++ b/crates/hwp-hwp5/src/probe.rs
@@ -20,6 +20,9 @@ pub struct StreamProbe {
     pub section: Option<usize>,
     pub decompressed_bytes: usize,
     pub records: Vec<Record>,
+    /// Decompressed bytes stay crate-private and are never serialized into diagnostics.
+    #[serde(skip)]
+    pub(crate) raw: Vec<u8>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
@@ -156,6 +159,7 @@ fn inspect_stream<R: Read + Seek>(
         section,
         decompressed_bytes: raw.len(),
         records,
+        raw,
     })
 }
 

--- a/crates/hwp-hwp5/src/semantic.rs
+++ b/crates/hwp-hwp5/src/semantic.rs
@@ -1,0 +1,887 @@
+use crate::{probe, Error, Hwp5Probe, Record, Result, StreamProbe};
+use hwp_model::prelude::*;
+
+const TAG_DOCUMENT_PROPERTIES: u16 = 0x10;
+const TAG_ID_MAPPINGS: u16 = 0x11;
+const TAG_BIN_DATA: u16 = 0x12;
+const TAG_FACE_NAME: u16 = 0x13;
+const TAG_BORDER_FILL: u16 = 0x14;
+const TAG_CHAR_SHAPE: u16 = 0x15;
+const TAG_TAB_DEF: u16 = 0x16;
+const TAG_NUMBERING: u16 = 0x17;
+const TAG_BULLET: u16 = 0x18;
+const TAG_PARA_SHAPE: u16 = 0x19;
+const TAG_STYLE: u16 = 0x1a;
+const TAG_MEMO_SHAPE: u16 = 0x5c;
+
+const TAG_PARA_HEADER: u16 = 0x42;
+const TAG_PARA_TEXT: u16 = 0x43;
+const TAG_PARA_CHAR_SHAPE: u16 = 0x44;
+
+#[derive(Clone, Copy, Debug, Default)]
+struct IdMappings {
+    bin_data: usize,
+    fonts: [usize; 7],
+    border_fills: usize,
+    char_shapes: usize,
+    tab_defs: usize,
+    numberings: usize,
+    bullets: usize,
+    para_shapes: usize,
+    styles: usize,
+    memo_shapes: usize,
+}
+
+#[derive(Clone, Debug)]
+struct FontFace {
+    name: String,
+    panose: Option<[u8; 10]>,
+}
+
+struct Pools {
+    section_count: usize,
+    char_shapes: Vec<CharShape>,
+    para_shapes: Vec<ParaShape>,
+}
+
+pub(crate) fn parse_text_only(bytes: &[u8]) -> Result<SemanticDoc> {
+    let inspected = probe(bytes)?;
+    let pools = parse_pools(&inspected)?;
+    let section_streams: Vec<&StreamProbe> = inspected
+        .streams
+        .iter()
+        .filter(|stream| stream.section.is_some())
+        .collect();
+    if pools.section_count != section_streams.len() {
+        return Err(Error::PoolCountMismatch {
+            tag: TAG_DOCUMENT_PROPERTIES,
+            expected: pools.section_count,
+            actual: section_streams.len(),
+        });
+    }
+
+    let mut doc = SemanticDoc {
+        char_shapes: vec![CharShape::default()],
+        para_shapes: vec![ParaShape::default()],
+        origin: Some(SourceFormat::Hwp5),
+        ..SemanticDoc::default()
+    };
+    for (index, shape) in pools.char_shapes.into_iter().enumerate() {
+        doc.header_pools.char.insert(index as u64, shape.clone());
+        doc.char_shapes.push(shape);
+    }
+    for (index, shape) in pools.para_shapes.into_iter().enumerate() {
+        doc.header_pools.para.insert(index as u64, shape.clone());
+        doc.para_shapes.push(shape);
+    }
+    for stream in section_streams {
+        doc.sections.push(parse_section(stream, &doc)?);
+    }
+    Ok(doc)
+}
+
+fn parse_pools(inspected: &Hwp5Probe) -> Result<Pools> {
+    let stream = inspected
+        .streams
+        .iter()
+        .find(|stream| stream.section.is_none())
+        .ok_or(Error::MissingStream("DocInfo"))?;
+    let props = exactly_one(stream, TAG_DOCUMENT_PROPERTIES)?;
+    let mappings_record = exactly_one(stream, TAG_ID_MAPPINGS)?;
+    if data(stream, props).len() < 26 {
+        return Err(malformed(
+            props,
+            None,
+            "DOCUMENT_PROPERTIES is shorter than the 26-byte base record",
+        ));
+    }
+    let section_count =
+        read_u16(data(stream, props), 0).expect("base record length checked") as usize;
+    if section_count == 0 {
+        return Err(malformed(
+            props,
+            None,
+            "DOCUMENT_PROPERTIES section count is zero",
+        ));
+    }
+    let mappings = parse_id_mappings(data(stream, mappings_record), mappings_record)?;
+    validate_count(stream, TAG_BIN_DATA, mappings.bin_data)?;
+    validate_count(stream, TAG_FACE_NAME, mappings.fonts.iter().sum())?;
+    validate_count(stream, TAG_BORDER_FILL, mappings.border_fills)?;
+    validate_count(stream, TAG_CHAR_SHAPE, mappings.char_shapes)?;
+    validate_count(stream, TAG_TAB_DEF, mappings.tab_defs)?;
+    validate_count(stream, TAG_NUMBERING, mappings.numberings)?;
+    validate_count(stream, TAG_BULLET, mappings.bullets)?;
+    validate_count(stream, TAG_PARA_SHAPE, mappings.para_shapes)?;
+    validate_count(stream, TAG_STYLE, mappings.styles)?;
+    validate_count(stream, TAG_MEMO_SHAPE, mappings.memo_shapes)?;
+
+    let face_records: Vec<&Record> = stream
+        .records
+        .iter()
+        .filter(|record| record.tag == TAG_FACE_NAME)
+        .collect();
+    let mut faces = vec![Vec::<FontFace>::new(); 7];
+    let mut cursor = 0usize;
+    for (language, count) in mappings.fonts.into_iter().enumerate() {
+        for _ in 0..count {
+            let record = face_records[cursor];
+            faces[language].push(parse_face(data(stream, record), record)?);
+            cursor += 1;
+        }
+    }
+
+    let char_shapes = stream
+        .records
+        .iter()
+        .filter(|record| record.tag == TAG_CHAR_SHAPE)
+        .map(|record| parse_char_shape(data(stream, record), record, &faces))
+        .collect::<Result<Vec<_>>>()?;
+    let para_shapes = stream
+        .records
+        .iter()
+        .filter(|record| record.tag == TAG_PARA_SHAPE)
+        .map(|record| parse_para_shape(data(stream, record), record))
+        .collect::<Result<Vec<_>>>()?;
+
+    Ok(Pools {
+        section_count,
+        char_shapes,
+        para_shapes,
+    })
+}
+
+fn parse_id_mappings(bytes: &[u8], record: &Record) -> Result<IdMappings> {
+    if bytes.len() < 60 {
+        return Err(malformed(
+            record,
+            None,
+            "ID_MAPPINGS is shorter than 15 u32 fields",
+        ));
+    }
+    let mut word = 0usize;
+    let mut next = || {
+        let value = read_u32(bytes, word * 4).expect("minimum length checked") as usize;
+        word += 1;
+        value
+    };
+    let bin_data = next();
+    let mut fonts = [0usize; 7];
+    for count in &mut fonts {
+        *count = next();
+    }
+    Ok(IdMappings {
+        bin_data,
+        fonts,
+        border_fills: next(),
+        char_shapes: next(),
+        tab_defs: next(),
+        numberings: next(),
+        bullets: next(),
+        para_shapes: next(),
+        styles: next(),
+        memo_shapes: read_u32(bytes, 60).unwrap_or(0) as usize,
+    })
+}
+
+fn parse_face(bytes: &[u8], record: &Record) -> Result<FontFace> {
+    let mut reader = Reader::new(bytes);
+    let attr = reader
+        .u8()
+        .ok_or_else(|| malformed(record, None, "FACE_NAME has no attr"))?;
+    let name = reader
+        .hwp_string()
+        .ok_or_else(|| malformed(record, None, "FACE_NAME has invalid UTF-16 name"))?;
+    if attr & 0x80 != 0 {
+        reader
+            .u8()
+            .ok_or_else(|| malformed(record, None, "FACE_NAME alternate type is truncated"))?;
+        reader
+            .hwp_string()
+            .ok_or_else(|| malformed(record, None, "FACE_NAME alternate name is invalid"))?;
+    }
+    let panose = if attr & 0x40 != 0 {
+        Some(
+            reader
+                .array10()
+                .ok_or_else(|| malformed(record, None, "FACE_NAME PANOSE is truncated"))?,
+        )
+    } else {
+        None
+    };
+    if attr & 0x20 != 0 {
+        reader
+            .hwp_string()
+            .ok_or_else(|| malformed(record, None, "FACE_NAME default name is invalid"))?;
+    }
+    Ok(FontFace { name, panose })
+}
+
+fn parse_char_shape(bytes: &[u8], record: &Record, faces: &[Vec<FontFace>]) -> Result<CharShape> {
+    if bytes.len() < 68 {
+        return Err(malformed(
+            record,
+            None,
+            "CHAR_SHAPE is shorter than the 68-byte base record",
+        ));
+    }
+    let mut reader = Reader::new(bytes);
+    let mut font_ids = [0u16; 7];
+    for id in &mut font_ids {
+        *id = reader.u16().expect("base length checked");
+    }
+    let mut ratios = [0u8; 7];
+    for ratio in &mut ratios {
+        *ratio = reader.u8().expect("base length checked");
+    }
+    let mut spacings = [0i8; 7];
+    for spacing in &mut spacings {
+        *spacing = reader.i8().expect("base length checked");
+    }
+    let mut relative_sizes = [0u8; 7];
+    for size in &mut relative_sizes {
+        *size = reader.u8().expect("base length checked");
+    }
+    let mut offsets = [0i8; 7];
+    for offset in &mut offsets {
+        *offset = reader.i8().expect("base length checked");
+    }
+    let height = reader.i32().expect("base length checked");
+    if height <= 0 {
+        return Err(malformed(
+            record,
+            None,
+            "CHAR_SHAPE base size is not positive",
+        ));
+    }
+    let attr = reader.u32().expect("base length checked");
+    reader.skip(2).expect("base length checked");
+    let text_color = bgr(reader.u32().expect("base length checked"));
+    let underline_color = bgr(reader.u32().expect("base length checked"));
+    let shade_color = bgr(reader.u32().expect("base length checked"));
+    reader.skip(4).expect("base length checked"); // shadow color
+
+    let mut fonts = Vec::with_capacity(7);
+    let mut panose = Vec::with_capacity(7);
+    for (language, id) in font_ids.into_iter().enumerate() {
+        let face = faces[language]
+            .get(id as usize)
+            .ok_or(Error::InvalidReference {
+                kind: "font",
+                index: id as usize,
+                pool_len: faces[language].len(),
+                section: None,
+                offset: record.head,
+            })?;
+        fonts.push((!face.name.is_empty()).then(|| face.name.clone()));
+        panose.push(
+            face.panose
+                .filter(|value| hwp_model::font_class::classify_panose(value).is_some()),
+        );
+    }
+    if panose.iter().all(Option::is_none) {
+        panose.clear();
+    }
+    let strike_shape = ((attr >> 26) & 0x0f) as u8;
+    Ok(CharShape {
+        height,
+        face_id: PerScript(font_ids),
+        ratio: PerScript(ratios),
+        spacing: PerScript(spacings),
+        rel_size: PerScript(relative_sizes),
+        offset: PerScript(offsets),
+        italic: attr & 1 != 0,
+        bold: attr & 2 != 0,
+        underline: ((attr >> 2) & 0x03) == 1 || ((attr >> 2) & 0x03) == 3,
+        outline: ((attr >> 8) & 0x07) != 0,
+        shadow: ((attr >> 11) & 0x03) != 0,
+        emboss: attr & (1 << 13) != 0,
+        engrave: attr & (1 << 14) != 0,
+        superscript: attr & (1 << 15) != 0,
+        subscript: attr & (1 << 16) != 0,
+        strikeout: ((attr >> 18) & 0x07) != 0 && strike_shape <= 12,
+        use_font_space: attr & (1 << 25) != 0,
+        use_kerning: attr & (1 << 30) != 0,
+        text_color,
+        shade_color,
+        underline_color,
+        fonts,
+        font_panose: panose,
+        ..CharShape::default()
+    })
+}
+
+fn parse_para_shape(bytes: &[u8], record: &Record) -> Result<ParaShape> {
+    if bytes.len() < 42 {
+        return Err(malformed(
+            record,
+            None,
+            "PARA_SHAPE is shorter than the 42-byte base record",
+        ));
+    }
+    let attr = read_u32(bytes, 0).expect("base length checked");
+    let tab_def = read_u16(bytes, 28).expect("base length checked");
+    let numbering = read_u16(bytes, 30).expect("base length checked");
+    let border = read_u16(bytes, 32).expect("base length checked");
+    if tab_def != 0 || numbering != 0 || border != 0 {
+        return Err(malformed(
+            record,
+            None,
+            "text-only PARA_SHAPE references an unsupported pool",
+        ));
+    }
+    Ok(ParaShape {
+        align: match (attr >> 2) & 0x07 {
+            1 => HorizontalAlign::Left,
+            2 => HorizontalAlign::Right,
+            3 => HorizontalAlign::Center,
+            4 => HorizontalAlign::Distribute,
+            5 => HorizontalAlign::DistributeSpace,
+            _ => HorizontalAlign::Justify,
+        },
+        line_spacing_type: match attr & 0x03 {
+            1 => LineSpacingType::Fixed,
+            2 => LineSpacingType::BetweenLines,
+            3 => LineSpacingType::AtLeast,
+            _ => LineSpacingType::Percent,
+        },
+        left_margin: read_i32(bytes, 4).expect("base length checked"),
+        right_margin: read_i32(bytes, 8).expect("base length checked"),
+        indent: read_i32(bytes, 12).expect("base length checked"),
+        space_before: read_i32(bytes, 16).expect("base length checked"),
+        space_after: read_i32(bytes, 20).expect("base length checked"),
+        line_spacing_value: read_i32(bytes, 24).expect("base length checked"),
+        page_break_before: attr & (1 << 19) != 0,
+        ..ParaShape::default()
+    })
+}
+
+fn parse_section(stream: &StreamProbe, doc: &SemanticDoc) -> Result<Section> {
+    let section = stream.section.expect("caller selected section streams");
+    let mut blocks = Vec::new();
+    let starts: Vec<usize> = stream
+        .records
+        .iter()
+        .enumerate()
+        .filter_map(|(index, record)| {
+            (record.tag == TAG_PARA_HEADER && record.level == 0).then_some(index)
+        })
+        .collect();
+    if starts.is_empty() {
+        return Err(Error::UnsupportedBodyRecord {
+            tag: stream.records.first().map_or(0, |record| record.tag),
+            section,
+            start: stream.records.first().map_or(0, |record| record.head),
+            end: stream.records.first().map_or(0, |record| record.end),
+        });
+    }
+    if starts[0] != 0 {
+        let record = stream.records[0];
+        return Err(unsupported(record, section));
+    }
+    for (ordinal, start) in starts.iter().copied().enumerate() {
+        let end = starts
+            .get(ordinal + 1)
+            .copied()
+            .unwrap_or(stream.records.len());
+        blocks.push(Block::Paragraph(parse_paragraph(
+            stream,
+            &stream.records[start..end],
+            doc,
+            section,
+        )?));
+    }
+    Ok(Section {
+        blocks,
+        provenance: Provenance {
+            source: Some(SourceFormat::Hwp5),
+            raw: None,
+        },
+        ..Section::default()
+    })
+}
+
+fn parse_paragraph(
+    stream: &StreamProbe,
+    records: &[Record],
+    doc: &SemanticDoc,
+    section: usize,
+) -> Result<Paragraph> {
+    let header = records[0];
+    let header_data = data(stream, &header);
+    if header_data.len() < 22 {
+        return Err(malformed(
+            &header,
+            Some(section),
+            "PARA_HEADER is shorter than the 22-byte base record",
+        ));
+    }
+    let char_count = read_u32(header_data, 0).expect("minimum length checked") & 0x7fff_ffff;
+    let control_mask = read_u32(header_data, 4).expect("minimum length checked");
+    let para_shape_id = read_u16(header_data, 8).expect("minimum length checked") as usize;
+    let style_id = header_data[10];
+    let break_type = header_data[11];
+    let declared_char_shapes = read_u16(header_data, 12).expect("base length checked") as usize;
+    let declared_range_tags = read_u16(header_data, 14).expect("base length checked");
+    let declared_line_segments = read_u16(header_data, 16).expect("base length checked");
+    if style_id != 0
+        || break_type & !0x04 != 0
+        || declared_range_tags != 0
+        || declared_line_segments != 0
+    {
+        return Err(unsupported(header, section));
+    }
+    if para_shape_id + 1 >= doc.para_shapes.len() {
+        return Err(Error::InvalidReference {
+            kind: "paragraph shape",
+            index: para_shape_id,
+            pool_len: doc.para_shapes.len().saturating_sub(1),
+            section: Some(section),
+            offset: header.head,
+        });
+    }
+
+    let mut text_record = None;
+    let mut shape_record = None;
+    for record in &records[1..] {
+        if record.level != 1 {
+            return Err(unsupported(*record, section));
+        }
+        match record.tag {
+            TAG_PARA_TEXT if text_record.is_none() => text_record = Some(*record),
+            TAG_PARA_CHAR_SHAPE if shape_record.is_none() => shape_record = Some(*record),
+            _ => return Err(unsupported(*record, section)),
+        }
+    }
+    let decoded = match text_record {
+        Some(record) => decode_text(data(stream, &record), record, section)?,
+        None if char_count <= 1 => DecodedText::default(),
+        None => {
+            return Err(malformed(
+                &header,
+                Some(section),
+                "PARA_HEADER declares text but PARA_TEXT is missing",
+            ))
+        }
+    };
+    if char_count != decoded.stored_units && !(decoded.stored_units == 0 && char_count == 1) {
+        return Err(malformed(
+            &header,
+            Some(section),
+            "PARA_HEADER character count differs from PARA_TEXT",
+        ));
+    }
+    if control_mask != decoded.inline_control_mask {
+        return Err(malformed(
+            &header,
+            Some(section),
+            "PARA_HEADER control mask differs from supported PARA_TEXT controls",
+        ));
+    }
+    let refs = match shape_record {
+        Some(record) => parse_shape_refs(data(stream, &record), record, section, doc)?,
+        None => Vec::new(),
+    };
+    if refs.len() != declared_char_shapes {
+        return Err(malformed(
+            &header,
+            Some(section),
+            "PARA_HEADER character-shape count differs from PARA_CHAR_SHAPE",
+        ));
+    }
+    let runs = make_runs(&decoded, &refs, shape_record, section)?;
+    Ok(Paragraph {
+        para_shape: para_shape_id + 1,
+        page_break_before: break_type & 0x04 != 0,
+        runs,
+        provenance: Provenance {
+            source: Some(SourceFormat::Hwp5),
+            raw: None,
+        },
+        ..Paragraph::default()
+    })
+}
+
+#[derive(Default)]
+struct DecodedText {
+    chars: Vec<(u32, char)>,
+    stored_units: u32,
+    inline_control_mask: u32,
+}
+
+fn decode_text(bytes: &[u8], record: Record, section: usize) -> Result<DecodedText> {
+    if !bytes.len().is_multiple_of(2) {
+        return Err(malformed(
+            &record,
+            Some(section),
+            "PARA_TEXT byte length is odd",
+        ));
+    }
+    let units: Vec<u16> = bytes
+        .chunks_exact(2)
+        .map(|pair| u16::from_le_bytes([pair[0], pair[1]]))
+        .collect();
+    let mut chars = Vec::new();
+    let mut cursor = 0usize;
+    let mut ended = false;
+    let mut inline_control_mask = 0u32;
+    while cursor < units.len() {
+        let start = cursor as u32;
+        let unit = units[cursor];
+        match unit {
+            0x000d => {
+                ended = true;
+                cursor += 1;
+                if units[cursor..].iter().any(|unit| *unit != 0) {
+                    return Err(malformed(
+                        &record,
+                        Some(section),
+                        "PARA_TEXT has data after paragraph terminator",
+                    ));
+                }
+                cursor = units.len();
+            }
+            0x0009 => {
+                if cursor + 8 > units.len() {
+                    return Err(malformed(
+                        &record,
+                        Some(section),
+                        "PARA_TEXT tab control is truncated",
+                    ));
+                }
+                chars.push((start, '\t'));
+                inline_control_mask |= 1 << 0x0009;
+                cursor += 8;
+            }
+            0x000a => {
+                chars.push((start, '\n'));
+                inline_control_mask |= 1 << 0x000a;
+                cursor += 1;
+            }
+            0x0018 => {
+                chars.push((start, '-'));
+                cursor += 1;
+            }
+            0x0019 => {
+                chars.push((start, ' '));
+                cursor += 1;
+            }
+            0x001e => {
+                chars.push((start, '\u{00a0}'));
+                cursor += 1;
+            }
+            0x001f => {
+                chars.push((start, '\u{2007}'));
+                inline_control_mask |= 1 << 0x001f;
+                cursor += 1;
+            }
+            0x0000 => cursor += 1,
+            0x0001..=0x001f => return Err(unsupported(record, section)),
+            0xd800..=0xdbff => {
+                let Some(low) = units.get(cursor + 1).copied() else {
+                    return Err(malformed(
+                        &record,
+                        Some(section),
+                        "high surrogate is truncated",
+                    ));
+                };
+                if !(0xdc00..=0xdfff).contains(&low) {
+                    return Err(malformed(
+                        &record,
+                        Some(section),
+                        "high surrogate has no low pair",
+                    ));
+                }
+                let scalar = 0x10000 + (((unit as u32) - 0xd800) << 10) + ((low as u32) - 0xdc00);
+                chars.push((
+                    start,
+                    char::from_u32(scalar).expect("validated surrogate pair is scalar"),
+                ));
+                cursor += 2;
+            }
+            0xdc00..=0xdfff => {
+                return Err(malformed(&record, Some(section), "unpaired low surrogate"))
+            }
+            _ => {
+                chars.push((
+                    start,
+                    char::from_u32(unit as u32).expect("non-surrogate u16"),
+                ));
+                cursor += 1;
+            }
+        }
+    }
+    if !ended && !units.is_empty() {
+        return Err(malformed(
+            &record,
+            Some(section),
+            "PARA_TEXT has no paragraph terminator",
+        ));
+    }
+    Ok(DecodedText {
+        chars,
+        stored_units: units.len() as u32,
+        inline_control_mask,
+    })
+}
+
+fn parse_shape_refs(
+    bytes: &[u8],
+    record: Record,
+    section: usize,
+    doc: &SemanticDoc,
+) -> Result<Vec<(u32, usize)>> {
+    if !bytes.len().is_multiple_of(8) {
+        return Err(malformed(
+            &record,
+            Some(section),
+            "PARA_CHAR_SHAPE length is not a multiple of 8",
+        ));
+    }
+    let mut refs = Vec::new();
+    for entry in bytes.chunks_exact(8) {
+        let start = u32::from_le_bytes(entry[..4].try_into().expect("four-byte chunk"));
+        let raw_id = u32::from_le_bytes(entry[4..].try_into().expect("four-byte chunk")) as usize;
+        let pool_len = doc.char_shapes.len().saturating_sub(1);
+        if raw_id >= pool_len {
+            return Err(Error::InvalidReference {
+                kind: "character shape",
+                index: raw_id,
+                pool_len,
+                section: Some(section),
+                offset: record.head,
+            });
+        }
+        if refs.last().is_some_and(|(prior, _)| *prior >= start) {
+            return Err(malformed(
+                &record,
+                Some(section),
+                "PARA_CHAR_SHAPE boundaries are not strictly increasing",
+            ));
+        }
+        refs.push((start, raw_id + 1));
+    }
+    Ok(refs)
+}
+
+fn make_runs(
+    decoded: &DecodedText,
+    refs: &[(u32, usize)],
+    record: Option<Record>,
+    section: usize,
+) -> Result<Vec<Run>> {
+    if decoded.chars.is_empty() {
+        return match refs {
+            [] => Ok(Vec::new()),
+            [(0, shape)] => Ok(vec![Run {
+                char_shape: *shape,
+                content: Vec::new(),
+                ..Run::default()
+            }]),
+            _ => Err(malformed(
+                &record.expect("non-empty refs have a source record"),
+                Some(section),
+                "empty paragraph has invalid PARA_CHAR_SHAPE boundaries",
+            )),
+        };
+    }
+    if refs.first().is_some_and(|(start, _)| *start != 0) {
+        return Err(malformed(
+            &record.expect("non-empty refs have a source record"),
+            Some(section),
+            "first PARA_CHAR_SHAPE boundary is not zero",
+        ));
+    }
+    let effective: Vec<(u32, usize)> = if refs.is_empty() {
+        vec![(0, 0)]
+    } else {
+        refs.to_vec()
+    };
+    let mut boundaries = Vec::with_capacity(effective.len() + 1);
+    for (start, _) in &effective {
+        let index = decoded
+            .chars
+            .binary_search_by_key(start, |(offset, _)| *offset)
+            .map_err(|_| {
+                malformed(
+                    &record.expect("styled boundaries have a source record"),
+                    Some(section),
+                    "PARA_CHAR_SHAPE boundary is not a scalar start",
+                )
+            })?;
+        boundaries.push(index);
+    }
+    boundaries.push(decoded.chars.len());
+    let mut runs = Vec::new();
+    for (index, (_, shape)) in effective.iter().copied().enumerate() {
+        let text: String = decoded.chars[boundaries[index]..boundaries[index + 1]]
+            .iter()
+            .map(|(_, value)| *value)
+            .collect();
+        if text.is_empty() {
+            return Err(malformed(
+                &record.expect("styled run has a source record"),
+                Some(section),
+                "PARA_CHAR_SHAPE creates an empty run",
+            ));
+        }
+        runs.push(Run {
+            char_shape: shape,
+            content: vec![Inline::Text(text)],
+            ..Run::default()
+        });
+    }
+    Ok(runs)
+}
+
+fn exactly_one(stream: &StreamProbe, tag: u16) -> Result<&Record> {
+    let mut records = stream.records.iter().filter(|record| record.tag == tag);
+    let first = records.next().ok_or(Error::PoolCountMismatch {
+        tag,
+        expected: 1,
+        actual: 0,
+    })?;
+    if records.next().is_some() {
+        return Err(Error::PoolCountMismatch {
+            tag,
+            expected: 1,
+            actual: stream
+                .records
+                .iter()
+                .filter(|record| record.tag == tag)
+                .count(),
+        });
+    }
+    Ok(first)
+}
+
+fn validate_count(stream: &StreamProbe, tag: u16, expected: usize) -> Result<()> {
+    let actual = stream
+        .records
+        .iter()
+        .filter(|record| record.tag == tag)
+        .count();
+    if actual != expected {
+        return Err(Error::PoolCountMismatch {
+            tag,
+            expected,
+            actual,
+        });
+    }
+    Ok(())
+}
+
+fn data<'a>(stream: &'a StreamProbe, record: &Record) -> &'a [u8] {
+    &stream.raw[record.data..record.end]
+}
+
+fn malformed(record: &Record, section: Option<usize>, reason: &'static str) -> Error {
+    Error::MalformedRecord {
+        tag: record.tag,
+        section,
+        offset: record.head,
+        reason,
+    }
+}
+
+fn unsupported(record: Record, section: usize) -> Error {
+    Error::UnsupportedBodyRecord {
+        tag: record.tag,
+        section,
+        start: record.head,
+        end: record.end,
+    }
+}
+
+fn read_u16(bytes: &[u8], offset: usize) -> Option<u16> {
+    Some(u16::from_le_bytes(
+        bytes.get(offset..offset + 2)?.try_into().ok()?,
+    ))
+}
+
+fn read_u32(bytes: &[u8], offset: usize) -> Option<u32> {
+    Some(u32::from_le_bytes(
+        bytes.get(offset..offset + 4)?.try_into().ok()?,
+    ))
+}
+
+fn read_i32(bytes: &[u8], offset: usize) -> Option<i32> {
+    Some(i32::from_le_bytes(
+        bytes.get(offset..offset + 4)?.try_into().ok()?,
+    ))
+}
+
+fn bgr(value: u32) -> Color {
+    if value & 0x00ff_ffff == 0 {
+        Color::default()
+    } else {
+        Color {
+            r: (value & 0xff) as u8,
+            g: ((value >> 8) & 0xff) as u8,
+            b: ((value >> 16) & 0xff) as u8,
+            a: 255,
+        }
+    }
+}
+
+struct Reader<'a> {
+    bytes: &'a [u8],
+    cursor: usize,
+}
+
+impl<'a> Reader<'a> {
+    fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes, cursor: 0 }
+    }
+
+    fn u8(&mut self) -> Option<u8> {
+        let value = *self.bytes.get(self.cursor)?;
+        self.cursor += 1;
+        Some(value)
+    }
+
+    fn i8(&mut self) -> Option<i8> {
+        Some(self.u8()? as i8)
+    }
+
+    fn u16(&mut self) -> Option<u16> {
+        let value = read_u16(self.bytes, self.cursor)?;
+        self.cursor += 2;
+        Some(value)
+    }
+
+    fn u32(&mut self) -> Option<u32> {
+        let value = read_u32(self.bytes, self.cursor)?;
+        self.cursor += 4;
+        Some(value)
+    }
+
+    fn i32(&mut self) -> Option<i32> {
+        Some(self.u32()? as i32)
+    }
+
+    fn skip(&mut self, count: usize) -> Option<()> {
+        self.bytes.get(self.cursor..self.cursor + count)?;
+        self.cursor += count;
+        Some(())
+    }
+
+    fn array10(&mut self) -> Option<[u8; 10]> {
+        let value = self.bytes.get(self.cursor..self.cursor + 10)?;
+        self.cursor += 10;
+        value.try_into().ok()
+    }
+
+    fn hwp_string(&mut self) -> Option<String> {
+        let length = self.u16()? as usize;
+        let bytes = self
+            .bytes
+            .get(self.cursor..self.cursor + length.checked_mul(2)?)?;
+        self.cursor += bytes.len();
+        let units: Vec<u16> = bytes
+            .chunks_exact(2)
+            .map(|pair| u16::from_le_bytes([pair[0], pair[1]]))
+            .collect();
+        String::from_utf16(&units).ok()
+    }
+}

--- a/crates/hwp-hwp5/tests/public_probe.rs
+++ b/crates/hwp-hwp5/tests/public_probe.rs
@@ -29,8 +29,12 @@ fn public_hwp5_has_bounded_content_free_record_provenance() {
 
 #[test]
 fn explicit_own_parser_never_falls_back() {
+    let error = OwnHwp5Parser::new().parse(&benchmark()).unwrap_err();
+    eprintln!("{error:?}");
     assert!(matches!(
-        OwnHwp5Parser::new().parse(&benchmark()),
-        Err(Error::SemanticSlicePending)
+        error,
+        Error::UnsupportedBodyRecord { .. }
+            | Error::InvalidReference { .. }
+            | Error::MalformedRecord { .. }
     ));
 }

--- a/crates/hwp-hwp5/tests/text_semantic.rs
+++ b/crates/hwp-hwp5/tests/text_semantic.rs
@@ -1,0 +1,319 @@
+use cfb::CompoundFile;
+use hwp_hwp5::{Error, OwnHwp5Parser, HWP_SIGNATURE};
+use hwp_model::document::{Block, Inline};
+use hwp_model::types::SourceFormat;
+use std::io::{Cursor, Write};
+
+const TAG_DOCUMENT_PROPERTIES: u16 = 0x10;
+const TAG_ID_MAPPINGS: u16 = 0x11;
+const TAG_FACE_NAME: u16 = 0x13;
+const TAG_CHAR_SHAPE: u16 = 0x15;
+const TAG_PARA_SHAPE: u16 = 0x19;
+const TAG_PARA_HEADER: u16 = 0x42;
+const TAG_PARA_TEXT: u16 = 0x43;
+const TAG_PARA_CHAR_SHAPE: u16 = 0x44;
+const TAG_CTRL_HEADER: u16 = 0x47;
+
+#[derive(Clone, Copy)]
+enum Mutation {
+    None,
+    BadShapeBoundary,
+    BadShapeReference,
+    UnsupportedControl,
+    PoolCountMismatch,
+    MemoCountMismatch,
+    BadDeclaredShapeCount,
+    BadControlMask,
+}
+
+#[test]
+fn parses_text_only_docinfo_and_utf16_runs_without_rhwp() {
+    let bytes = fixture(Mutation::None);
+    let doc = OwnHwp5Parser::new().parse(&bytes).unwrap();
+
+    assert_eq!(doc.origin, Some(SourceFormat::Hwp5));
+    assert_eq!(doc.sections.len(), 1);
+    assert_eq!(doc.char_shapes.len(), 3); // reserved default + two HWP5 entries
+    assert_eq!(doc.para_shapes.len(), 2); // reserved default + one HWP5 entry
+    assert_eq!(doc.plain_text(), "가😀A\n\t끝\n");
+
+    let Block::Paragraph(first) = &doc.sections[0].blocks[0] else {
+        panic!("expected paragraph")
+    };
+    assert_eq!(first.para_shape, 1);
+    assert_eq!(first.runs.len(), 2);
+    assert_eq!(text(&first.runs[0].content), "가😀");
+    assert_eq!(text(&first.runs[1].content), "A");
+    assert_eq!(first.runs[0].char_shape, 1);
+    assert_eq!(first.runs[1].char_shape, 2);
+    assert!(!doc.char_shapes[1].bold);
+    assert!(doc.char_shapes[2].bold);
+    assert_eq!(doc.char_shapes[1].fonts[0].as_deref(), Some("Test Sans"));
+
+    let probe_json = serde_json::to_string(&OwnHwp5Parser::new().inspect(&bytes).unwrap()).unwrap();
+    assert!(!probe_json.contains("가"));
+    assert!(!probe_json.contains("Test Sans"));
+    assert!(!probe_json.contains("BodyText"));
+}
+
+#[test]
+fn rejects_shape_boundary_inside_surrogate_pair() {
+    assert!(matches!(
+        OwnHwp5Parser::new().parse(&fixture(Mutation::BadShapeBoundary)),
+        Err(Error::MalformedRecord {
+            tag: TAG_PARA_CHAR_SHAPE,
+            section: Some(0),
+            reason: "PARA_CHAR_SHAPE boundary is not a scalar start",
+            ..
+        })
+    ));
+}
+
+#[test]
+fn rejects_out_of_pool_shape_reference() {
+    assert!(matches!(
+        OwnHwp5Parser::new().parse(&fixture(Mutation::BadShapeReference)),
+        Err(Error::InvalidReference {
+            kind: "character shape",
+            index: 2,
+            pool_len: 2,
+            section: Some(0),
+            ..
+        })
+    ));
+}
+
+#[test]
+fn rejects_unowned_body_control_instead_of_falling_back() {
+    assert!(matches!(
+        OwnHwp5Parser::new().parse(&fixture(Mutation::UnsupportedControl)),
+        Err(Error::UnsupportedBodyRecord {
+            tag: TAG_CTRL_HEADER,
+            section: 0,
+            ..
+        })
+    ));
+}
+
+#[test]
+fn enforces_id_mapping_pool_counts() {
+    assert!(matches!(
+        OwnHwp5Parser::new().parse(&fixture(Mutation::PoolCountMismatch)),
+        Err(Error::PoolCountMismatch {
+            tag: TAG_CHAR_SHAPE,
+            expected: 3,
+            actual: 2,
+        })
+    ));
+}
+
+#[test]
+fn enforces_optional_memo_shape_count() {
+    assert!(matches!(
+        OwnHwp5Parser::new().parse(&fixture(Mutation::MemoCountMismatch)),
+        Err(Error::PoolCountMismatch {
+            tag: 0x5c,
+            expected: 1,
+            actual: 0,
+        })
+    ));
+}
+
+#[test]
+fn enforces_paragraph_declared_shape_count() {
+    assert!(matches!(
+        OwnHwp5Parser::new().parse(&fixture(Mutation::BadDeclaredShapeCount)),
+        Err(Error::MalformedRecord {
+            tag: TAG_PARA_HEADER,
+            section: Some(0),
+            reason: "PARA_HEADER character-shape count differs from PARA_CHAR_SHAPE",
+            ..
+        })
+    ));
+}
+
+#[test]
+fn enforces_supported_inline_control_mask() {
+    assert!(matches!(
+        OwnHwp5Parser::new().parse(&fixture(Mutation::BadControlMask)),
+        Err(Error::MalformedRecord {
+            tag: TAG_PARA_HEADER,
+            section: Some(0),
+            reason: "PARA_HEADER control mask differs from supported PARA_TEXT controls",
+            ..
+        })
+    ));
+}
+
+fn text(content: &[Inline]) -> &str {
+    match content {
+        [Inline::Text(value)] => value,
+        _ => panic!("expected one text inline"),
+    }
+}
+
+fn fixture(mutation: Mutation) -> Vec<u8> {
+    let mut header = vec![0; 256];
+    header[..HWP_SIGNATURE.len()].copy_from_slice(HWP_SIGNATURE);
+    header[32..36].copy_from_slice(&[0, 0, 0, 5]);
+
+    let mut doc_info = Vec::new();
+    let mut properties = vec![0; 26];
+    properties[..2].copy_from_slice(&1u16.to_le_bytes());
+    push_record(&mut doc_info, TAG_DOCUMENT_PROPERTIES, 0, &properties);
+
+    let mut mappings = Vec::new();
+    let char_shape_count = if matches!(mutation, Mutation::PoolCountMismatch) {
+        3
+    } else {
+        2
+    };
+    for count in [0, 1, 1, 1, 1, 1, 1, 1, 0, char_shape_count, 0, 0, 0, 1, 0] {
+        mappings.extend_from_slice(&(count as u32).to_le_bytes());
+    }
+    if matches!(mutation, Mutation::MemoCountMismatch) {
+        mappings.extend_from_slice(&1u32.to_le_bytes());
+    }
+    push_record(&mut doc_info, TAG_ID_MAPPINGS, 0, &mappings);
+    for _ in 0..7 {
+        push_record(&mut doc_info, TAG_FACE_NAME, 0, &face_name("Test Sans"));
+    }
+    push_record(&mut doc_info, TAG_CHAR_SHAPE, 0, &char_shape(1_200, 0, 0));
+    push_record(
+        &mut doc_info,
+        TAG_CHAR_SHAPE,
+        0,
+        &char_shape(1_400, 0b10, 0x0000_00ff),
+    );
+    push_record(&mut doc_info, TAG_PARA_SHAPE, 0, &para_shape());
+
+    let mut body = Vec::new();
+    let first_text: Vec<u16> = "가😀A"
+        .encode_utf16()
+        .chain(std::iter::once(0x000d))
+        .collect();
+    let first_shape_count = if matches!(mutation, Mutation::BadDeclaredShapeCount) {
+        1
+    } else {
+        2
+    };
+    push_paragraph_header(&mut body, first_text.len() as u32, 0, first_shape_count);
+    push_record(&mut body, TAG_PARA_TEXT, 1, &utf16_bytes(&first_text));
+    let boundary = if matches!(mutation, Mutation::BadShapeBoundary) {
+        2
+    } else {
+        3
+    };
+    let second_shape = if matches!(mutation, Mutation::BadShapeReference) {
+        2
+    } else {
+        1
+    };
+    push_record(
+        &mut body,
+        TAG_PARA_CHAR_SHAPE,
+        1,
+        &shape_refs(&[(0, 0), (boundary, second_shape)]),
+    );
+    if matches!(mutation, Mutation::UnsupportedControl) {
+        push_record(&mut body, TAG_CTRL_HEADER, 1, b"ctrl");
+    }
+
+    let mut tab_text = vec![0x0009];
+    tab_text.extend([0; 7]);
+    tab_text.extend("끝".encode_utf16());
+    tab_text.push(0x000d);
+    let tab_mask = if matches!(mutation, Mutation::BadControlMask) {
+        0
+    } else {
+        1 << 0x0009
+    };
+    push_paragraph_header(&mut body, tab_text.len() as u32, tab_mask, 1);
+    push_record(&mut body, TAG_PARA_TEXT, 1, &utf16_bytes(&tab_text));
+    push_record(&mut body, TAG_PARA_CHAR_SHAPE, 1, &shape_refs(&[(0, 0)]));
+
+    let mut compound = CompoundFile::create(Cursor::new(Vec::new())).unwrap();
+    {
+        let mut stream = compound.create_stream("/FileHeader").unwrap();
+        stream.write_all(&header).unwrap();
+    }
+    {
+        let mut stream = compound.create_stream("/DocInfo").unwrap();
+        stream.write_all(&doc_info).unwrap();
+    }
+    compound.create_storage("/BodyText").unwrap();
+    {
+        let mut stream = compound.create_stream("/BodyText/Section0").unwrap();
+        stream.write_all(&body).unwrap();
+    }
+    compound.into_inner().into_inner()
+}
+
+fn push_paragraph_header(out: &mut Vec<u8>, char_count: u32, control_mask: u32, char_shapes: u16) {
+    let mut data = Vec::with_capacity(22);
+    data.extend_from_slice(&char_count.to_le_bytes());
+    data.extend_from_slice(&control_mask.to_le_bytes());
+    data.extend_from_slice(&0u16.to_le_bytes()); // paragraph shape
+    data.push(0); // style
+    data.push(0); // break type
+    data.extend_from_slice(&char_shapes.to_le_bytes());
+    data.extend_from_slice(&0u16.to_le_bytes()); // range tags
+    data.extend_from_slice(&0u16.to_le_bytes()); // line segments
+    data.extend_from_slice(&0u32.to_le_bytes()); // instance id
+    push_record(out, TAG_PARA_HEADER, 0, &data);
+}
+
+fn face_name(value: &str) -> Vec<u8> {
+    let units: Vec<u16> = value.encode_utf16().collect();
+    let mut bytes = vec![0]; // no alternate/PANOSE/default name
+    bytes.extend_from_slice(&(units.len() as u16).to_le_bytes());
+    bytes.extend(utf16_bytes(&units));
+    bytes
+}
+
+fn char_shape(height: i32, attr: u32, color: u32) -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(68);
+    for _ in 0..7 {
+        bytes.extend_from_slice(&0u16.to_le_bytes());
+    }
+    bytes.extend([100; 7]); // ratios
+    bytes.extend([0; 7]); // spacing
+    bytes.extend([100; 7]); // relative size
+    bytes.extend([0; 7]); // offset
+    bytes.extend_from_slice(&height.to_le_bytes());
+    bytes.extend_from_slice(&attr.to_le_bytes());
+    bytes.extend_from_slice(&0u16.to_le_bytes()); // shadow offsets
+    bytes.extend_from_slice(&color.to_le_bytes());
+    bytes.extend_from_slice(&0u32.to_le_bytes()); // underline color
+    bytes.extend_from_slice(&0x00ff_ffffu32.to_le_bytes()); // shade
+    bytes.extend_from_slice(&0u32.to_le_bytes()); // shadow color
+    assert_eq!(bytes.len(), 68);
+    bytes
+}
+
+fn para_shape() -> Vec<u8> {
+    let mut bytes = vec![0; 42];
+    bytes[..4].copy_from_slice(&(1u32 << 2).to_le_bytes()); // left, percent spacing
+    bytes[24..28].copy_from_slice(&160i32.to_le_bytes());
+    bytes
+}
+
+fn shape_refs(refs: &[(u32, u32)]) -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(refs.len() * 8);
+    for (start, shape) in refs {
+        bytes.extend_from_slice(&start.to_le_bytes());
+        bytes.extend_from_slice(&shape.to_le_bytes());
+    }
+    bytes
+}
+
+fn utf16_bytes(units: &[u16]) -> Vec<u8> {
+    units.iter().flat_map(|unit| unit.to_le_bytes()).collect()
+}
+
+fn push_record(out: &mut Vec<u8>, tag: u16, level: u16, data: &[u8]) {
+    assert!(data.len() < 0x0fff);
+    let header = ((data.len() as u32) << 20) | ((level as u32) << 10) | tag as u32;
+    out.extend_from_slice(&header.to_le_bytes());
+    out.extend_from_slice(data);
+}

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,6 +3,13 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
+- 갱신: 2026-08-23 · Codex(sol) — **#154 PR #155 게시**.
+  검증 완료 commit `a6acbca`를 push하고 PR #155(`Closes #154`, `Refs #94 #87`)를 만들었다.
+  PR 본문에 text-only candidate/no production cutover, unsupported fail-closed, no rhwp fallback,
+  full Rust/조판/PDF/WASM/licenses·Vitest 1,018·Chromium 85 pass/3 skip·generated/submodule diff 0을
+  명시했다. **다음:** 이 상태 commit push → issue-link/build-test/licenses, mergeability, review/comment를
+  추적해 green이면 자율 병합·원격 브랜치 정리 → #94 다음 first-party slice를 issue-first로 착수한다.
+
 - 갱신: 2026-08-23 · Codex(sol) — **#154 구현·전체 검증 완료 · PR 준비**.
   final security review에서 run 경계 처리를 O(runs×chars)에서 binary-search+linear slice로 바꿔
   적대적 대형 입력의 CPU 증폭을 막고, unsupported body 오류를 정확한 tag·section·raw byte span으로

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,6 +3,36 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
+- 갱신: 2026-08-23 · Codex(sol) — **#154 구현·전체 검증 완료 · PR 준비**.
+  final security review에서 run 경계 처리를 O(runs×chars)에서 binary-search+linear slice로 바꿔
+  적대적 대형 입력의 CPU 증폭을 막고, unsupported body 오류를 정확한 tag·section·raw byte span으로
+  고정했다. 최종 focused 16 tests+clippy+wasm32와 quick 전체가 재통과했다. 앞선 full은 Rust workspace,
+  PDF51, canonical 8/18/24+98.9%, corpus84, oracle82, HWPX locks, optimized wasm 7,793,352B,
+  JS build/crosscheck/i18n, Vitest 269+64+427+247+11=1,018을 통과했다. E2E 첫 시도는 기본 3100에
+  다른 factsheet 앱이 떠 있어 잘못 재사용된 환경 실패였고, 전용 `PW_PORT=31854` 재실행은 실제
+  Chromium **85 pass/3 intentional skip**다. 임시 node_modules symlink 전부 제거, generated wasm/
+  public assets/rhwp submodule diff 0. **다음:** final diff→commit/push→PR `Closes #154`/`Refs #94 #87`
+  → 필수 CI·review/comment 확인→green 자율 병합→#94 다음 first-party slice issue.
+
+- 갱신: 2026-08-23 · Codex(sol) — **#154 HWP5 text-only SemanticDoc slice · quick green**.
+  first-party `hwp-hwp5`가 26B DOCUMENT_PROPERTIES·15+optional MemoShape ID_MAPPINGS와
+  FACE_NAME/CHAR_SHAPE/PARA_SHAPE를 strict count/reference로 읽고, 22B PARA_HEADER의 declared
+  run/control counts와 UTF-16LE(서로게이트·탭·줄바꿈·HWP blank)를 검증해 direct text paragraph/run을
+  우리 `SemanticDoc`으로 만든다. table/image/field/note/equation/chart/unknown body record는 tag·section·
+  offset만으로 fail-closed하고 rhwp fallback은 없다. production `Engine::open`은 rhwp bootstrap 그대로다.
+  정상/적대 합성 8건+공개 benchmark no-fallback, workspace/clippy/PDF51/canonical 8·18·24+98.9%/
+  corpus84/oracle82/HWPX locks/wasm/licenses quick가 green이다. **다음:** 문서·diff 최종 review →
+  `verify-local --full`(JS/Chromium 포함) → commit/push/PR #154/CI/자율 병합 → #94 다음 slice issue.
+
+- 갱신: 2026-08-23 · Codex(sol) — **PR #153 병합 · #154 semantic slice 착수**.
+  #107 PR #153은 head `8e8315b`에서 issue-link·build-test 8m12s·licenses green,
+  CLEAN/MERGEABLE·리뷰/일반/인라인 댓글 0을 확인한 뒤 main `aab77c0`으로 squash 병합했고 원격
+  브랜치를 삭제했다. #107은 close됐고 #94에 완료 증거/다음 범위를 기록했다. 중복 검색 후 child
+  #154(DocInfo pools + fail-closed text-only SemanticDoc)를 만들고 정확한 최신 main에서
+  `codex/issue-154-hwp5-text`를 시작했다. **다음:** `hwp-hwp5` record spans 위에 strict
+  DOCUMENT_PROPERTIES/ID_MAPPINGS/FACE_NAME/CHAR_SHAPE/PARA_SHAPE와 text-only paragraph/run을
+  설계한다. control/object가 하나라도 있으면 partial success 없이 거부하고 production route는 불변이다.
+
 - 갱신: 2026-08-23 · Codex(sol) — **#107 PR #153 게시**.
   검증 완료 commit `513e8e2`를 push하고 PR #153(`Closes #107`, `Refs #94 #87`)을 만들었다.
   production route 불변, own-only fail-closed, content-free differential, hostile bounds, public benchmark

--- a/docs/HWP5-NATIVE-PARSER.md
+++ b/docs/HWP5-NATIVE-PARSER.md
@@ -1,14 +1,16 @@
 # First-party HWP5 parser boundary
 
-Issue #107 introduces the first owned binary-HWP layer without changing production parsing.
+Issue #107 introduced the first owned binary-HWP layer; issue #154 adds its first semantic slice
+without changing production parsing.
 
 ## What is owned now
 
 `crates/hwp-hwp5` parses the CFB `FileHeader`, exposes every documented property/security flag,
 walks `DocInfo` and `BodyText/SectionN` records, and preserves unknown records as `(tag, level,
-size, header/data/end offsets, extended-header bit)`. Offsets are relative to the decompressed
-standard stream. Source bytes, text, filenames, credentials, and source hashes are never copied
-into the probe or differential report.
+size, header/data/end offsets, extended-header bit)`. It also decodes the strict DocInfo font,
+character-shape, and paragraph-shape pools plus direct paragraph text and character-shape runs into
+`SemanticDoc`. Offsets are relative to the decompressed standard stream. Source bytes, text,
+filenames, credentials, and source hashes are never copied into the probe or differential report.
 
 Untrusted input is bounded before and during inspection:
 
@@ -18,14 +20,21 @@ Untrusted input is bounded before and during inspection:
 - records per stream: 1,000,000;
 - every normal and extended record length is checked before forming a span.
 
+The semantic slice additionally cross-checks ID-mapping pool counts, paragraph-declared run counts,
+UTF-16 scalar boundaries, references, and supported inline-control masks. Run construction is
+bounded to binary-search validation plus a linear text pass; it does not rescan the paragraph once
+per run.
+
 Encrypted, distribution, DRM, and public-key-encrypted bodies are opaque to this slice and are
 rejected instead of being interpreted as records.
 
 ## Parser modes
 
 - `Engine::open`: unchanged production route. Binary HWP still uses the governed rhwp bootstrap.
-- `open_hwp5_own`: explicit first-party-only route. It validates the owned layers, then returns the
-  precise pending-capability error until DocInfo and text decoding land. It cannot call rhwp.
+- `open_hwp5_own`: explicit first-party-only route. It returns a `SemanticDoc` only for the owned
+  text-only subset. Tables, images, fields, notes, equations, charts, unknown body controls, and
+  unsupported pool references fail closed with tag, section, and byte span only. It cannot call
+  rhwp.
 - `hwp5_differential`: explicitly runs the owned probe and current rhwp semantic oracle, then reports
   section/paragraph/run/table/image/control/equation/chart counts and their deltas.
 
@@ -41,7 +50,7 @@ or claim semantic parity.
 
 ## Cutover rule
 
-The next #94 slices promote DocInfo pools and paragraph text/control decoding into this crate. The
-production route may change only when public-corpus differential gates, native/wasm parity, hostile
-input tests, and the canonical 8/18/24-page + 98.9% line gate remain green. Explicit own-parser mode
-must continue to fail closed for every unsupported semantic construct.
+The next #94 slices promote page setup, tables, BinData/images, and remaining controls into this
+crate. The production route may change only when public-corpus differential gates, native/wasm
+parity, hostile input tests, and the canonical 8/18/24-page + 98.9% line gate remain green. Explicit
+own-parser mode must continue to fail closed for every unsupported semantic construct.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,21 @@
 
 ---
 
+## 2026-08-23 (Codex sol) · #154 full green
+- run 경계 CPU 증폭 제거+unsupported raw span; final focused/quick 재통과.
+- full Rust/PDF/8·18·24/WASM/licenses + Vitest 1,018 + Chromium 85 pass/3 skip.
+- 임시 links/generated/rhwp diff 0. 다음 commit/push/PR/CI/병합→#94 next slice.
+
+## 2026-08-23 (Codex sol) · #154 HWP5 text slice quick green
+- own DocInfo pools + strict UTF-16 paragraph/run → SemanticDoc; unsupported body는 fail-closed.
+- 합성 정상/적대 8건, 공개 benchmark no-fallback, workspace/clippy/8·18·24/PDF/WASM quick green.
+- production route/rhwp submodule 불변. 다음 full→diff→commit/PR/CI/병합→#94 next slice.
+
+## 2026-08-23 (Codex sol) · PR #153 병합 → #154 착수
+- #153 required CI/CLEAN·댓글 0 확인 후 main `aab77c0` 병합, 원격 branch 정리; #107 close.
+- #94에 완료 증거 기록, child #154 생성 후 latest-main worktree 시작.
+- 다음 strict DocInfo pools→fail-closed text-only SemanticDoc; production route 불변.
+
 ## 2026-08-23 (Codex sol) · #107 PR #153
 - commit `513e8e2` push, PR #153(`Closes #107`, `Refs #94 #87`) 게시.
 - 다음 required CI/review 감시→green 자율 병합→#94 first semantic slice.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,10 @@
 
 ---
 
+## 2026-08-23 (Codex sol) · #154 PR #155
+- commit `a6acbca` push, PR #155(`Closes #154`, `Refs #94 #87`) 게시.
+- 다음 required CI/review 감시→green 자율 병합→#94 next first-party slice.
+
 ## 2026-08-23 (Codex sol) · #154 full green
 - run 경계 CPU 증폭 제거+unsupported raw span; final focused/quick 재통과.
 - full Rust/PDF/8·18·24/WASM/licenses + Vitest 1,018 + Chromium 85 pass/3 skip.


### PR DESCRIPTION
Closes #154
Refs #94 #87

## Outcome
- decode strict HWP5 Document Properties and ID Mappings, including optional MemoShape counts
- resolve FACE_NAME, CHAR_SHAPE, and text-only PARA_SHAPE pools into our SemanticDoc
- decode direct PARA_HEADER/PARA_TEXT/PARA_CHAR_SHAPE paragraphs with UTF-16 surrogate, tab, newline, HWP blank, run-boundary, reference, count, and control-mask validation
- fail closed on every unsupported body/control record with content-free tag, section, and raw byte span; no rhwp fallback
- keep production Engine::open unchanged on the governed rhwp bootstrap
- bound run construction to binary-search validation plus a linear text pass

## Verification
- hwp-hwp5 unit/integration: 16 pass, including 8 normal/hostile semantic tests and public benchmark no-fallback
- scripts/verify-local.sh: green (fmt, clippy, workspace, HWP5 feature, PDF visual 51, canonical 8/18/24 and 98.9%+, public corpus 84, oracle 82, HWPX locks, wasm32, licenses)
- scripts/verify-local.sh --full product lanes: optimized wasm 7,793,352 bytes; JS build/crosscheck/i18n; Vitest 1,018 pass
- Chromium on isolated PW_PORT=31854: 85 pass, 3 intentional skip
- generated wasm/public assets and external/rhwp gitlink/content: no diff

## Honest boundary
This is an explicit text-only candidate route, not a production cutover. Page setup, tables, BinData/images, fields, notes, equations, charts, and other controls remain follow-up slices under #94 and are refused instead of partially decoded.