### PR TITLE
feat: own HWP5 page setup and source line metrics

### DIFF
--- a/crates/hwp-hwp5/src/semantic.rs
+++ b/crates/hwp-hwp5/src/semantic.rs
@@ -17,6 +17,11 @@ const TAG_MEMO_SHAPE: u16 = 0x5c;
 const TAG_PARA_HEADER: u16 = 0x42;
 const TAG_PARA_TEXT: u16 = 0x43;
 const TAG_PARA_CHAR_SHAPE: u16 = 0x44;
+const TAG_PARA_LINE_SEG: u16 = 0x45;
+const TAG_CTRL_HEADER: u16 = 0x47;
+const TAG_PAGE_DEF: u16 = 0x49;
+
+const CTRL_SECTION_DEF: u32 = u32::from_be_bytes(*b"secd");
 
 #[derive(Clone, Copy, Debug, Default)]
 struct IdMappings {
@@ -359,6 +364,7 @@ fn parse_para_shape(bytes: &[u8], record: &Record) -> Result<ParaShape> {
 fn parse_section(stream: &StreamProbe, doc: &SemanticDoc) -> Result<Section> {
     let section = stream.section.expect("caller selected section streams");
     let mut blocks = Vec::new();
+    let mut page = None;
     let starts: Vec<usize> = stream
         .records
         .iter()
@@ -384,15 +390,21 @@ fn parse_section(stream: &StreamProbe, doc: &SemanticDoc) -> Result<Section> {
             .get(ordinal + 1)
             .copied()
             .unwrap_or(stream.records.len());
-        blocks.push(Block::Paragraph(parse_paragraph(
-            stream,
-            &stream.records[start..end],
-            doc,
-            section,
-        )?));
+        let parsed = parse_paragraph(stream, &stream.records[start..end], doc, section)?;
+        if let Some(parsed_page) = parsed.page {
+            if ordinal != 0 || page.replace(parsed_page).is_some() {
+                return Err(malformed(
+                    &stream.records[start],
+                    Some(section),
+                    "section definition may occur only once and only in the first paragraph",
+                ));
+            }
+        }
+        blocks.push(Block::Paragraph(parsed.paragraph));
     }
     Ok(Section {
         blocks,
+        page: page.unwrap_or_default(),
         provenance: Provenance {
             source: Some(SourceFormat::Hwp5),
             raw: None,
@@ -401,12 +413,17 @@ fn parse_section(stream: &StreamProbe, doc: &SemanticDoc) -> Result<Section> {
     })
 }
 
+struct ParsedParagraph {
+    paragraph: Paragraph,
+    page: Option<PageSetup>,
+}
+
 fn parse_paragraph(
     stream: &StreamProbe,
     records: &[Record],
     doc: &SemanticDoc,
     section: usize,
-) -> Result<Paragraph> {
+) -> Result<ParsedParagraph> {
     let header = records[0];
     let header_data = data(stream, &header);
     if header_data.len() < 22 {
@@ -424,11 +441,7 @@ fn parse_paragraph(
     let declared_char_shapes = read_u16(header_data, 12).expect("base length checked") as usize;
     let declared_range_tags = read_u16(header_data, 14).expect("base length checked");
     let declared_line_segments = read_u16(header_data, 16).expect("base length checked");
-    if style_id != 0
-        || break_type & !0x04 != 0
-        || declared_range_tags != 0
-        || declared_line_segments != 0
-    {
+    if style_id != 0 || break_type & !0x04 != 0 || declared_range_tags != 0 {
         return Err(unsupported(header, section));
     }
     if para_shape_id + 1 >= doc.para_shapes.len() {
@@ -443,15 +456,33 @@ fn parse_paragraph(
 
     let mut text_record = None;
     let mut shape_record = None;
-    for record in &records[1..] {
+    let mut line_record = None;
+    let mut section_control = None;
+    let mut cursor = 1usize;
+    while cursor < records.len() {
+        let record = records[cursor];
         if record.level != 1 {
-            return Err(unsupported(*record, section));
+            return Err(unsupported(record, section));
         }
         match record.tag {
-            TAG_PARA_TEXT if text_record.is_none() => text_record = Some(*record),
-            TAG_PARA_CHAR_SHAPE if shape_record.is_none() => shape_record = Some(*record),
-            _ => return Err(unsupported(*record, section)),
+            TAG_PARA_TEXT if text_record.is_none() => text_record = Some(record),
+            TAG_PARA_CHAR_SHAPE if shape_record.is_none() => shape_record = Some(record),
+            TAG_PARA_LINE_SEG if line_record.is_none() => line_record = Some(record),
+            TAG_CTRL_HEADER if section_control.is_none() => {
+                if read_u32(data(stream, &record), 0) != Some(CTRL_SECTION_DEF) {
+                    return Err(unsupported(record, section));
+                }
+                let start = cursor;
+                cursor += 1;
+                while cursor < records.len() && records[cursor].level > 1 {
+                    cursor += 1;
+                }
+                section_control = Some((&records[start], &records[start + 1..cursor]));
+                continue;
+            }
+            _ => return Err(unsupported(record, section)),
         }
+        cursor += 1;
     }
     let decoded = match text_record {
         Some(record) => decode_text(data(stream, &record), record, section)?,
@@ -478,6 +509,35 @@ fn parse_paragraph(
             "PARA_HEADER control mask differs from supported PARA_TEXT controls",
         ));
     }
+    let page = match (decoded.section_controls.as_slice(), section_control) {
+        ([], None) => None,
+        ([(marker_offset, marker_id)], Some((control, children)))
+            if *marker_id == CTRL_SECTION_DEF =>
+        {
+            if *marker_offset != 0 {
+                return Err(malformed(
+                    control,
+                    Some(section),
+                    "section definition marker is not at paragraph start",
+                ));
+            }
+            Some(parse_section_control(stream, control, children, section)?)
+        }
+        (_, Some((control, _))) => {
+            return Err(malformed(
+                control,
+                Some(section),
+                "section control header does not match PARA_TEXT marker",
+            ))
+        }
+        (_, None) => {
+            return Err(malformed(
+                &header,
+                Some(section),
+                "PARA_TEXT section marker has no section control header",
+            ))
+        }
+    };
     let refs = match shape_record {
         Some(record) => parse_shape_refs(data(stream, &record), record, section, doc)?,
         None => Vec::new(),
@@ -490,23 +550,247 @@ fn parse_paragraph(
         ));
     }
     let runs = make_runs(&decoded, &refs, shape_record, section)?;
-    Ok(Paragraph {
-        para_shape: para_shape_id + 1,
-        page_break_before: break_type & 0x04 != 0,
-        runs,
-        provenance: Provenance {
-            source: Some(SourceFormat::Hwp5),
-            raw: None,
+    let line_metrics = parse_line_metrics(
+        stream,
+        line_record,
+        declared_line_segments as usize,
+        &decoded,
+        &header,
+        section,
+    )?;
+    Ok(ParsedParagraph {
+        paragraph: Paragraph {
+            para_shape: para_shape_id + 1,
+            page_break_before: break_type & 0x04 != 0,
+            runs,
+            // Stored line boxes are only an authored-height hint for a true blank spacer.
+            // They never dictate line breaks for visible text or a control-host paragraph.
+            source_line_metrics: if decoded.chars.is_empty() && page.is_none() {
+                line_metrics
+            } else {
+                Vec::new()
+            },
+            provenance: Provenance {
+                source: Some(SourceFormat::Hwp5),
+                raw: None,
+            },
+            ..Paragraph::default()
         },
-        ..Paragraph::default()
+        page,
     })
+}
+
+fn parse_section_control(
+    stream: &StreamProbe,
+    control: &Record,
+    children: &[Record],
+    section: usize,
+) -> Result<PageSetup> {
+    let bytes = data(stream, control);
+    if bytes.len() != 28 {
+        return Err(malformed(
+            control,
+            Some(section),
+            "section CTRL_HEADER is not the owned 28-byte base record",
+        ));
+    }
+    if read_u32(bytes, 0) != Some(CTRL_SECTION_DEF) {
+        return Err(unsupported(*control, section));
+    }
+    if children.len() != 1 || children[0].tag != TAG_PAGE_DEF || children[0].level != 2 {
+        let offending = children.first().copied().unwrap_or(*control);
+        return Err(unsupported(offending, section));
+    }
+    parse_page_def(data(stream, &children[0]), &children[0], section)
+}
+
+fn parse_page_def(bytes: &[u8], record: &Record, section: usize) -> Result<PageSetup> {
+    if bytes.len() != 40 {
+        return Err(malformed(
+            record,
+            Some(section),
+            "PAGE_DEF is not exactly 40 bytes",
+        ));
+    }
+    let mut values = [0i32; 9];
+    for (index, value) in values.iter_mut().enumerate() {
+        let raw = read_u32(bytes, index * 4).expect("exact length checked");
+        *value = i32::try_from(raw).map_err(|_| {
+            malformed(
+                record,
+                Some(section),
+                "PAGE_DEF dimension exceeds signed HWPUNIT range",
+            )
+        })?;
+    }
+    let attr = read_u32(bytes, 36).expect("exact length checked");
+    if attr & !0x07 != 0 {
+        return Err(malformed(
+            record,
+            Some(section),
+            "PAGE_DEF has unsupported attribute bits",
+        ));
+    }
+    // Alternating inside/outside margins need a page-parity model that PageSetup does not yet own.
+    // Refuse instead of pretending duplex/top-flip are single-sided.
+    if (attr >> 1) & 0x03 != 0 {
+        return Err(malformed(
+            record,
+            Some(section),
+            "PAGE_DEF binding mode is not yet supported",
+        ));
+    }
+    let landscape = attr & 0x01 != 0;
+    let [width, height, margin_left, margin_right, margin_top, margin_bottom, margin_header, margin_footer, margin_gutter] =
+        values;
+    if width == 0 || height == 0 {
+        return Err(malformed(
+            record,
+            Some(section),
+            "PAGE_DEF paper dimensions are zero",
+        ));
+    }
+    let (display_width, display_height) = if landscape && width < height {
+        (height as i64, width as i64)
+    } else {
+        (width as i64, height as i64)
+    };
+    let horizontal = margin_left as i64 + margin_gutter as i64 + margin_right as i64;
+    let vertical =
+        margin_top as i64 + margin_header as i64 + margin_bottom as i64 + margin_footer as i64;
+    if horizontal >= display_width || vertical >= display_height {
+        return Err(malformed(
+            record,
+            Some(section),
+            "PAGE_DEF margins leave no positive body box",
+        ));
+    }
+    Ok(PageSetup {
+        width,
+        height,
+        margin_left,
+        margin_right,
+        margin_top,
+        margin_bottom,
+        margin_header,
+        margin_footer,
+        margin_gutter,
+        landscape,
+        columns: 1,
+    })
+}
+
+fn parse_line_metrics(
+    stream: &StreamProbe,
+    record: Option<Record>,
+    declared: usize,
+    decoded: &DecodedText,
+    header: &Record,
+    section: usize,
+) -> Result<Vec<SourceLineMetric>> {
+    let Some(record) = record else {
+        return if declared == 0 {
+            Ok(Vec::new())
+        } else {
+            Err(malformed(
+                header,
+                Some(section),
+                "PARA_HEADER declares line segments but PARA_LINE_SEG is missing",
+            ))
+        };
+    };
+    let bytes = data(stream, &record);
+    if !bytes.len().is_multiple_of(36) {
+        return Err(malformed(
+            &record,
+            Some(section),
+            "PARA_LINE_SEG length is not a multiple of 36",
+        ));
+    }
+    let actual = bytes.len() / 36;
+    if actual != declared {
+        return Err(malformed(
+            header,
+            Some(section),
+            "PARA_HEADER line-segment count differs from PARA_LINE_SEG",
+        ));
+    }
+    let mut prior_start = None;
+    let mut metrics = Vec::with_capacity(actual);
+    let mut all_zero_height = true;
+    for entry in bytes.chunks_exact(36) {
+        let text_start = read_u32(entry, 0).expect("chunk length checked");
+        if prior_start.is_some_and(|prior| prior > text_start) {
+            return Err(malformed(
+                &record,
+                Some(section),
+                "PARA_LINE_SEG text starts are not ordered",
+            ));
+        }
+        if !decoded.is_boundary(text_start) {
+            return Err(malformed(
+                &record,
+                Some(section),
+                "PARA_LINE_SEG text start is not a scalar/control boundary",
+            ));
+        }
+        prior_start = Some(text_start);
+        let vertical_pos = read_i32(entry, 4).expect("chunk length checked");
+        let height = read_i32(entry, 8).expect("chunk length checked");
+        let text_height = read_i32(entry, 12).expect("chunk length checked");
+        let baseline = read_i32(entry, 16).expect("chunk length checked");
+        let line_spacing = read_i32(entry, 20).expect("chunk length checked");
+        let segment_width = read_i32(entry, 28).expect("chunk length checked");
+        if [
+            vertical_pos,
+            height,
+            text_height,
+            baseline,
+            line_spacing,
+            segment_width,
+        ]
+        .into_iter()
+        .any(|value| value < 0)
+        {
+            return Err(malformed(
+                &record,
+                Some(section),
+                "PARA_LINE_SEG has a negative geometry field",
+            ));
+        }
+        all_zero_height &= height == 0 && text_height == 0;
+        metrics.push(SourceLineMetric {
+            height,
+            text_height,
+            baseline,
+        });
+    }
+    if all_zero_height {
+        metrics.clear();
+    }
+    Ok(metrics)
 }
 
 #[derive(Default)]
 struct DecodedText {
     chars: Vec<(u32, char)>,
+    section_controls: Vec<(u32, u32)>,
     stored_units: u32,
     inline_control_mask: u32,
+}
+
+impl DecodedText {
+    fn is_boundary(&self, offset: u32) -> bool {
+        offset == 0
+            || self
+                .chars
+                .binary_search_by_key(&offset, |(start, _)| *start)
+                .is_ok()
+            || self
+                .section_controls
+                .binary_search_by_key(&offset, |(start, _)| *start)
+                .is_ok()
+    }
 }
 
 fn decode_text(bytes: &[u8], record: Record, section: usize) -> Result<DecodedText> {
@@ -522,6 +806,7 @@ fn decode_text(bytes: &[u8], record: Record, section: usize) -> Result<DecodedTe
         .map(|pair| u16::from_le_bytes([pair[0], pair[1]]))
         .collect();
     let mut chars = Vec::new();
+    let mut section_controls = Vec::new();
     let mut cursor = 0usize;
     let mut ended = false;
     let mut inline_control_mask = 0u32;
@@ -551,6 +836,31 @@ fn decode_text(bytes: &[u8], record: Record, section: usize) -> Result<DecodedTe
                 }
                 chars.push((start, '\t'));
                 inline_control_mask |= 1 << 0x0009;
+                cursor += 8;
+            }
+            0x0002 => {
+                if cursor + 8 > units.len() {
+                    return Err(malformed(
+                        &record,
+                        Some(section),
+                        "PARA_TEXT section control is truncated",
+                    ));
+                }
+                if units[cursor + 7] != unit || units[cursor + 3..cursor + 7] != [0; 4] {
+                    return Err(malformed(
+                        &record,
+                        Some(section),
+                        "PARA_TEXT section control framing is invalid",
+                    ));
+                }
+                let lo = units[cursor + 1].to_le_bytes();
+                let hi = units[cursor + 2].to_le_bytes();
+                let control_id = u32::from_le_bytes([lo[0], lo[1], hi[0], hi[1]]);
+                if control_id != CTRL_SECTION_DEF {
+                    return Err(unsupported(record, section));
+                }
+                section_controls.push((start, control_id));
+                inline_control_mask |= 1 << 0x0002;
                 cursor += 8;
             }
             0x000a => {
@@ -620,6 +930,7 @@ fn decode_text(bytes: &[u8], record: Record, section: usize) -> Result<DecodedTe
     }
     Ok(DecodedText {
         chars,
+        section_controls,
         stored_units: units.len() as u32,
         inline_control_mask,
     })
@@ -697,37 +1008,38 @@ fn make_runs(
     } else {
         refs.to_vec()
     };
-    let mut boundaries = Vec::with_capacity(effective.len() + 1);
     for (start, _) in &effective {
-        let index = decoded
-            .chars
-            .binary_search_by_key(start, |(offset, _)| *offset)
-            .map_err(|_| {
-                malformed(
-                    &record.expect("styled boundaries have a source record"),
-                    Some(section),
-                    "PARA_CHAR_SHAPE boundary is not a scalar start",
-                )
-            })?;
-        boundaries.push(index);
-    }
-    boundaries.push(decoded.chars.len());
-    let mut runs = Vec::new();
-    for (index, (_, shape)) in effective.iter().copied().enumerate() {
-        let text: String = decoded.chars[boundaries[index]..boundaries[index + 1]]
-            .iter()
-            .map(|(_, value)| *value)
-            .collect();
-        if text.is_empty() {
+        if !decoded.is_boundary(*start) {
             return Err(malformed(
-                &record.expect("styled run has a source record"),
+                &record.expect("styled boundaries have a source record"),
                 Some(section),
-                "PARA_CHAR_SHAPE creates an empty run",
+                "PARA_CHAR_SHAPE boundary is not a scalar start",
             ));
         }
+    }
+    let mut runs = Vec::new();
+    let mut ref_index = 0usize;
+    let mut current_shape = effective[0].1;
+    let mut current_text = String::new();
+    for (offset, value) in &decoded.chars {
+        while ref_index + 1 < effective.len() && effective[ref_index + 1].0 <= *offset {
+            ref_index += 1;
+            let next_shape = effective[ref_index].1;
+            if next_shape != current_shape && !current_text.is_empty() {
+                runs.push(Run {
+                    char_shape: current_shape,
+                    content: vec![Inline::Text(std::mem::take(&mut current_text))],
+                    ..Run::default()
+                });
+            }
+            current_shape = next_shape;
+        }
+        current_text.push(*value);
+    }
+    if !current_text.is_empty() {
         runs.push(Run {
-            char_shape: shape,
-            content: vec![Inline::Text(text)],
+            char_shape: current_shape,
+            content: vec![Inline::Text(current_text)],
             ..Run::default()
         });
     }

--- a/crates/hwp-hwp5/tests/layout_semantic.rs
+++ b/crates/hwp-hwp5/tests/layout_semantic.rs
@@ -1,0 +1,377 @@
+use cfb::CompoundFile;
+use hwp_hwp5::{Error, OwnHwp5Parser, HWP_SIGNATURE};
+use hwp_model::document::Block;
+use std::io::{Cursor, Write};
+
+const TAG_DOCUMENT_PROPERTIES: u16 = 0x10;
+const TAG_ID_MAPPINGS: u16 = 0x11;
+const TAG_FACE_NAME: u16 = 0x13;
+const TAG_CHAR_SHAPE: u16 = 0x15;
+const TAG_PARA_SHAPE: u16 = 0x19;
+const TAG_PARA_HEADER: u16 = 0x42;
+const TAG_PARA_TEXT: u16 = 0x43;
+const TAG_PARA_CHAR_SHAPE: u16 = 0x44;
+const TAG_PARA_LINE_SEG: u16 = 0x45;
+const TAG_CTRL_HEADER: u16 = 0x47;
+const TAG_PAGE_DEF: u16 = 0x49;
+const TAG_FOOTNOTE_SHAPE: u16 = 0x4a;
+const CTRL_SECTION_DEF: u32 = u32::from_be_bytes(*b"secd");
+
+#[derive(Clone, Copy)]
+enum Mutation {
+    None,
+    Landscape,
+    NoBodyBox,
+    BadLineCount,
+    BadLineBoundary,
+    BadLineLength,
+    ZeroHeightLine,
+    UnsupportedSectionChild,
+    DuplicatePageDef,
+    BadControlFrame,
+    UnsupportedBinding,
+}
+
+#[test]
+fn parses_page_setup_and_blank_source_line_metrics() {
+    let doc = OwnHwp5Parser::new()
+        .parse(&fixture(Mutation::None))
+        .unwrap();
+    let page = doc.sections[0].page;
+    assert_eq!((page.width, page.height), (59_528, 84_188));
+    assert_eq!((page.margin_left, page.margin_right), (8_504, 8_504));
+    assert_eq!((page.margin_top, page.margin_bottom), (5_669, 4_252));
+    assert_eq!((page.margin_header, page.margin_footer), (4_252, 4_252));
+    assert_eq!(page.margin_gutter, 0);
+    assert!(!page.landscape);
+
+    let Block::Paragraph(blank) = &doc.sections[0].blocks[1] else {
+        panic!("expected blank paragraph")
+    };
+    assert_eq!(blank.source_line_metrics.len(), 1);
+    assert_eq!(blank.source_line_metrics[0].height, 1_500);
+    assert_eq!(blank.source_line_metrics[0].text_height, 1_200);
+    assert_eq!(blank.source_line_metrics[0].baseline, 900);
+}
+
+#[test]
+fn preserves_hwp5_landscape_flag_without_pre_swapping_paper() {
+    let doc = OwnHwp5Parser::new()
+        .parse(&fixture(Mutation::Landscape))
+        .unwrap();
+    let page = doc.sections[0].page;
+    assert_eq!((page.width, page.height), (59_528, 84_188));
+    assert!(page.landscape);
+}
+
+#[test]
+fn rejects_page_margins_that_remove_the_body_box() {
+    assert!(matches!(
+        OwnHwp5Parser::new().parse(&fixture(Mutation::NoBodyBox)),
+        Err(Error::MalformedRecord {
+            tag: TAG_PAGE_DEF,
+            section: Some(0),
+            reason: "PAGE_DEF margins leave no positive body box",
+            ..
+        })
+    ));
+}
+
+#[test]
+fn enforces_declared_line_segment_count() {
+    assert!(matches!(
+        OwnHwp5Parser::new().parse(&fixture(Mutation::BadLineCount)),
+        Err(Error::MalformedRecord {
+            tag: TAG_PARA_HEADER,
+            section: Some(0),
+            reason: "PARA_HEADER line-segment count differs from PARA_LINE_SEG",
+            ..
+        })
+    ));
+}
+
+#[test]
+fn rejects_line_start_outside_a_scalar_or_control_boundary() {
+    assert!(matches!(
+        OwnHwp5Parser::new().parse(&fixture(Mutation::BadLineBoundary)),
+        Err(Error::MalformedRecord {
+            tag: TAG_PARA_LINE_SEG,
+            section: Some(0),
+            reason: "PARA_LINE_SEG text start is not a scalar/control boundary",
+            ..
+        })
+    ));
+}
+
+#[test]
+fn zero_height_line_segments_are_non_authoritative() {
+    let doc = OwnHwp5Parser::new()
+        .parse(&fixture(Mutation::ZeroHeightLine))
+        .unwrap();
+    let Block::Paragraph(blank) = &doc.sections[0].blocks[1] else {
+        panic!("expected blank paragraph")
+    };
+    assert!(blank.source_line_metrics.is_empty());
+}
+
+#[test]
+fn refuses_unsupported_section_children_with_a_content_free_span() {
+    assert!(matches!(
+        OwnHwp5Parser::new().parse(&fixture(Mutation::UnsupportedSectionChild)),
+        Err(Error::UnsupportedBodyRecord {
+            tag: TAG_FOOTNOTE_SHAPE,
+            section: 0,
+            ..
+        })
+    ));
+}
+
+#[test]
+fn rejects_duplicate_page_def_records() {
+    assert!(matches!(
+        OwnHwp5Parser::new().parse(&fixture(Mutation::DuplicatePageDef)),
+        Err(Error::UnsupportedBodyRecord {
+            tag: TAG_PAGE_DEF,
+            section: 0,
+            ..
+        })
+    ));
+}
+
+#[test]
+fn rejects_invalid_extended_control_framing() {
+    assert!(matches!(
+        OwnHwp5Parser::new().parse(&fixture(Mutation::BadControlFrame)),
+        Err(Error::MalformedRecord {
+            tag: TAG_PARA_TEXT,
+            section: Some(0),
+            reason: "PARA_TEXT section control framing is invalid",
+            ..
+        })
+    ));
+}
+
+#[test]
+fn refuses_binding_modes_until_page_parity_is_owned() {
+    assert!(matches!(
+        OwnHwp5Parser::new().parse(&fixture(Mutation::UnsupportedBinding)),
+        Err(Error::MalformedRecord {
+            tag: TAG_PAGE_DEF,
+            section: Some(0),
+            reason: "PAGE_DEF binding mode is not yet supported",
+            ..
+        })
+    ));
+}
+
+#[test]
+fn rejects_non_integral_line_segment_payload() {
+    assert!(matches!(
+        OwnHwp5Parser::new().parse(&fixture(Mutation::BadLineLength)),
+        Err(Error::MalformedRecord {
+            tag: TAG_PARA_LINE_SEG,
+            section: Some(0),
+            reason: "PARA_LINE_SEG length is not a multiple of 36",
+            ..
+        })
+    ));
+}
+
+fn fixture(mutation: Mutation) -> Vec<u8> {
+    let mut header = vec![0; 256];
+    header[..HWP_SIGNATURE.len()].copy_from_slice(HWP_SIGNATURE);
+    header[32..36].copy_from_slice(&[0, 0, 0, 5]);
+
+    let mut doc_info = Vec::new();
+    let mut properties = vec![0; 26];
+    properties[..2].copy_from_slice(&1u16.to_le_bytes());
+    push_record(&mut doc_info, TAG_DOCUMENT_PROPERTIES, 0, &properties);
+    let mut mappings = Vec::new();
+    for count in [0, 1, 1, 1, 1, 1, 1, 1, 0, 1, 0, 0, 0, 1, 0] {
+        mappings.extend_from_slice(&(count as u32).to_le_bytes());
+    }
+    push_record(&mut doc_info, TAG_ID_MAPPINGS, 0, &mappings);
+    for _ in 0..7 {
+        push_record(&mut doc_info, TAG_FACE_NAME, 0, &face_name("Test Sans"));
+    }
+    push_record(&mut doc_info, TAG_CHAR_SHAPE, 0, &char_shape());
+    push_record(&mut doc_info, TAG_PARA_SHAPE, 0, &para_shape());
+
+    let mut body = Vec::new();
+    let mut section_text = extended_control(0x0002, CTRL_SECTION_DEF);
+    if matches!(mutation, Mutation::BadControlFrame) {
+        section_text[7] = 0;
+    }
+    section_text.push(0x000d);
+    push_para_header(&mut body, section_text.len() as u32, 1 << 2, 1, 0);
+    push_record(&mut body, TAG_PARA_TEXT, 1, &utf16_bytes(&section_text));
+    push_record(&mut body, TAG_PARA_CHAR_SHAPE, 1, &shape_refs(&[(0, 0)]));
+    let mut section_control = Vec::with_capacity(28);
+    section_control.extend_from_slice(&CTRL_SECTION_DEF.to_le_bytes());
+    section_control.extend([0; 24]);
+    push_record(&mut body, TAG_CTRL_HEADER, 1, &section_control);
+    if matches!(mutation, Mutation::UnsupportedSectionChild) {
+        push_record(&mut body, TAG_FOOTNOTE_SHAPE, 2, &[0; 28]);
+    } else {
+        push_record(&mut body, TAG_PAGE_DEF, 2, &page_def(mutation));
+        if matches!(mutation, Mutation::DuplicatePageDef) {
+            push_record(&mut body, TAG_PAGE_DEF, 2, &page_def(mutation));
+        }
+    }
+
+    let declared_lines = if matches!(mutation, Mutation::BadLineCount) {
+        2
+    } else {
+        1
+    };
+    push_para_header(&mut body, 1, 0, 1, declared_lines);
+    push_record(&mut body, TAG_PARA_TEXT, 1, &utf16_bytes(&[0x000d]));
+    push_record(&mut body, TAG_PARA_CHAR_SHAPE, 1, &shape_refs(&[(0, 0)]));
+    let start = if matches!(mutation, Mutation::BadLineBoundary) {
+        1
+    } else {
+        0
+    };
+    let (height, text_height, baseline) = if matches!(mutation, Mutation::ZeroHeightLine) {
+        (0, 0, 0)
+    } else {
+        (1_500, 1_200, 900)
+    };
+    let mut line = line_seg(start, height, text_height, baseline);
+    if matches!(mutation, Mutation::BadLineLength) {
+        line.pop();
+    }
+    push_record(&mut body, TAG_PARA_LINE_SEG, 1, &line);
+
+    let mut compound = CompoundFile::create(Cursor::new(Vec::new())).unwrap();
+    {
+        let mut stream = compound.create_stream("/FileHeader").unwrap();
+        stream.write_all(&header).unwrap();
+    }
+    {
+        let mut stream = compound.create_stream("/DocInfo").unwrap();
+        stream.write_all(&doc_info).unwrap();
+    }
+    compound.create_storage("/BodyText").unwrap();
+    {
+        let mut stream = compound.create_stream("/BodyText/Section0").unwrap();
+        stream.write_all(&body).unwrap();
+    }
+    compound.into_inner().into_inner()
+}
+
+fn page_def(mutation: Mutation) -> Vec<u8> {
+    let width = if matches!(mutation, Mutation::NoBodyBox) {
+        100
+    } else {
+        59_528
+    };
+    let mut bytes = Vec::with_capacity(40);
+    for value in [width, 84_188, 8_504, 8_504, 5_669, 4_252, 4_252, 4_252, 0] {
+        bytes.extend_from_slice(&(value as u32).to_le_bytes());
+    }
+    let attr = if matches!(mutation, Mutation::UnsupportedBinding) {
+        0x02
+    } else {
+        u32::from(matches!(mutation, Mutation::Landscape))
+    };
+    bytes.extend_from_slice(&attr.to_le_bytes());
+    bytes
+}
+
+fn line_seg(start: u32, height: i32, text_height: i32, baseline: i32) -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(36);
+    bytes.extend_from_slice(&start.to_le_bytes());
+    for value in [100, height, text_height, baseline, 300, 0, 40_000] {
+        bytes.extend_from_slice(&value.to_le_bytes());
+    }
+    bytes.extend_from_slice(&0u32.to_le_bytes());
+    bytes
+}
+
+fn extended_control(code: u16, id: u32) -> Vec<u16> {
+    let bytes = id.to_le_bytes();
+    vec![
+        code,
+        u16::from_le_bytes([bytes[0], bytes[1]]),
+        u16::from_le_bytes([bytes[2], bytes[3]]),
+        0,
+        0,
+        0,
+        0,
+        code,
+    ]
+}
+
+fn push_para_header(
+    out: &mut Vec<u8>,
+    char_count: u32,
+    control_mask: u32,
+    char_shapes: u16,
+    line_segments: u16,
+) {
+    let mut data = Vec::with_capacity(22);
+    data.extend_from_slice(&char_count.to_le_bytes());
+    data.extend_from_slice(&control_mask.to_le_bytes());
+    data.extend_from_slice(&0u16.to_le_bytes());
+    data.push(0);
+    data.push(0);
+    data.extend_from_slice(&char_shapes.to_le_bytes());
+    data.extend_from_slice(&0u16.to_le_bytes());
+    data.extend_from_slice(&line_segments.to_le_bytes());
+    data.extend_from_slice(&0u32.to_le_bytes());
+    push_record(out, TAG_PARA_HEADER, 0, &data);
+}
+
+fn face_name(value: &str) -> Vec<u8> {
+    let units: Vec<u16> = value.encode_utf16().collect();
+    let mut bytes = vec![0];
+    bytes.extend_from_slice(&(units.len() as u16).to_le_bytes());
+    bytes.extend(utf16_bytes(&units));
+    bytes
+}
+
+fn char_shape() -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(68);
+    for _ in 0..7 {
+        bytes.extend_from_slice(&0u16.to_le_bytes());
+    }
+    bytes.extend([100; 7]);
+    bytes.extend([0; 7]);
+    bytes.extend([100; 7]);
+    bytes.extend([0; 7]);
+    bytes.extend_from_slice(&1_200i32.to_le_bytes());
+    bytes.extend_from_slice(&0u32.to_le_bytes());
+    bytes.extend_from_slice(&0u16.to_le_bytes());
+    bytes.extend_from_slice(&0u32.to_le_bytes());
+    bytes.extend_from_slice(&0u32.to_le_bytes());
+    bytes.extend_from_slice(&0x00ff_ffffu32.to_le_bytes());
+    bytes.extend_from_slice(&0u32.to_le_bytes());
+    bytes
+}
+
+fn para_shape() -> Vec<u8> {
+    let mut bytes = vec![0; 42];
+    bytes[..4].copy_from_slice(&(1u32 << 2).to_le_bytes());
+    bytes[24..28].copy_from_slice(&160i32.to_le_bytes());
+    bytes
+}
+
+fn shape_refs(refs: &[(u32, u32)]) -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(refs.len() * 8);
+    for (start, shape) in refs {
+        bytes.extend_from_slice(&start.to_le_bytes());
+        bytes.extend_from_slice(&shape.to_le_bytes());
+    }
+    bytes
+}
+
+fn utf16_bytes(units: &[u16]) -> Vec<u8> {
+    units.iter().flat_map(|unit| unit.to_le_bytes()).collect()
+}
+
+fn push_record(out: &mut Vec<u8>, tag: u16, level: u16, data: &[u8]) {
+    let header = ((data.len() as u32) << 20) | ((level as u32) << 10) | tag as u32;
+    out.extend_from_slice(&header.to_le_bytes());
+    out.extend_from_slice(data);
+}

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,6 +3,32 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
+- 갱신: 2026-08-23 · Codex(sol) — **#156 전체 검증 완료 · PR 준비**.
+  strict secd/PAGE_DEF와 blank-only PARA_LINE_SEG 구현을 최종 보안/diff review했고 오류 진단은
+  content-free tag·section·span만 유지한다. focused hwp-hwp5 **27 tests**, clippy, wasm32와 quick 전체
+  게이트가 green이며 canonical 8/18/24·98.9%+, PDF 51, corpus 84, oracle 82, HWPX locks, licenses를
+  보존했다. full의 Rust/PDF/wasm/JS/Vitest 1,018도 green; 샌드박스 포트 EPERM만 분리해 전용
+  `PW_PORT=31856` 실제 Chromium을 재실행한 결과 **85 pass/3 intentional skip/0 fail**. generated asset와
+  `external/rhwp` diff 0, production route 무변경. **다음:** commit/push/PR #156→필수 CI·댓글 확인→green
+  자율 병합→#94 완료 근거와 다음 first-party child를 issue-first로 착수한다.
+
+- 갱신: 2026-08-23 · Codex(sol) — **#156 PAGE_DEF/source metrics focused green**.
+  first-party lane이 첫 문단 `0x0002/secd` marker↔CTRL_HEADER↔단일 PAGE_DEF 계층을 대조하고,
+  40B page size·6 margins·gutter·landscape·positive body box를 `Section.page`로 만든다. duplex/top-flip,
+  column/deco/border/note/unknown child는 거짓 지원 없이 거부한다. 36B PARA_LINE_SEG는 declared count,
+  scalar/control boundary, ordered start, nonnegative geometry를 검증하고 true blank에만 source metric을
+  주며 zero-height/visible text/control-host에는 권위를 주지 않는다. 합성 정상/적대 11건 포함
+  hwp-hwp5 **27 tests**, clippy `-D warnings`, wasm32 green. **다음:** security/diff review→quick 전체 게이트→
+  full 검증→commit/push/PR #156→필수 CI·자율 병합. production route/rhwp는 불변이다.
+
+- 갱신: 2026-08-23 · Codex(sol) — **PR #155 병합 · #156 HWP5 source-layout slice 착수**.
+  #155는 head `d4eb9df`에서 issue-link·build-test 9m52s·licenses green, CLEAN/MERGEABLE,
+  리뷰/일반/인라인 댓글 0을 확인한 뒤 main `c16e231`로 squash 병합했고 #154가 close됐다.
+  #94에 완료 근거를 동기화하고 child #156을 만든 뒤 정확한 최신 main에서
+  `codex/issue-156-hwp5-layout`을 시작했다. **다음:** section-definition/PAGE_DEF와
+  non-authoritative PARA_LINE_SEG source metrics를 strict hierarchy/count/span 검증으로 구현한다.
+  production HWP5 route와 `external/rhwp`는 바꾸지 않는다.
+
 - 갱신: 2026-08-23 · Codex(sol) — **#154 PR #155 게시**.
   검증 완료 commit `a6acbca`를 push하고 PR #155(`Closes #154`, `Refs #94 #87`)를 만들었다.
   PR 본문에 text-only candidate/no production cutover, unsupported fail-closed, no rhwp fallback,

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,6 +3,13 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
+- 갱신: 2026-08-23 · Codex(sol) — **#156 PR #157 게시**.
+  검증 완료 commit `01b637c`를 push하고 PR #157(`Closes #156`, `Refs #94 #87`)을 만들었다.
+  strict PAGE_DEF/source metrics, unsupported fail-closed, no production cutover/no rhwp fallback과
+  quick/full/Chromium 85 pass·3 intentional skip·generated/rhwp diff 0을 본문에 명시했다.
+  **다음:** 이 상태 문서 commit push→issue-link/build-test/licenses·mergeability·review/comment를 추적하고
+  전부 green이면 자율 병합·원격 브랜치 정리→#94 다음 first-party child를 issue-first로 착수한다.
+
 - 갱신: 2026-08-23 · Codex(sol) — **#156 전체 검증 완료 · PR 준비**.
   strict secd/PAGE_DEF와 blank-only PARA_LINE_SEG 구현을 최종 보안/diff review했고 오류 진단은
   content-free tag·section·span만 유지한다. focused hwp-hwp5 **27 tests**, clippy, wasm32와 quick 전체

--- a/docs/HWP5-NATIVE-PARSER.md
+++ b/docs/HWP5-NATIVE-PARSER.md
@@ -1,7 +1,8 @@
 # First-party HWP5 parser boundary
 
-Issue #107 introduced the first owned binary-HWP layer; issue #154 adds its first semantic slice
-without changing production parsing.
+Issue #107 introduced the first owned binary-HWP layer; issue #154 added its first semantic slice,
+and issue #156 adds the minimum source-layout facts needed by the shared typesetter. None of these
+slices changes production parsing.
 
 ## What is owned now
 
@@ -9,7 +10,12 @@ without changing production parsing.
 walks `DocInfo` and `BodyText/SectionN` records, and preserves unknown records as `(tag, level,
 size, header/data/end offsets, extended-header bit)`. It also decodes the strict DocInfo font,
 character-shape, and paragraph-shape pools plus direct paragraph text and character-shape runs into
-`SemanticDoc`. Offsets are relative to the decompressed standard stream. Source bytes, text,
+`SemanticDoc`. The owned section-definition boundary maps a strict 40-byte `PAGE_DEF` to
+`Section.page`, including all six margins, gutter, and HWP5 landscape orientation. A strict
+`PARA_LINE_SEG` reader validates declared counts and UTF-16 scalar/control starts, but exposes stored
+line-box metrics only for true blank spacer paragraphs. Stored line breaks never override our
+typesetter and zero-height segments are non-authoritative. Offsets are relative to the decompressed
+standard stream. Source bytes, text,
 filenames, credentials, and source hashes are never copied into the probe or differential report.
 
 Untrusted input is bounded before and during inspection:
@@ -20,10 +26,10 @@ Untrusted input is bounded before and during inspection:
 - records per stream: 1,000,000;
 - every normal and extended record length is checked before forming a span.
 
-The semantic slice additionally cross-checks ID-mapping pool counts, paragraph-declared run counts,
-UTF-16 scalar boundaries, references, and supported inline-control masks. Run construction is
-bounded to binary-search validation plus a linear text pass; it does not rescan the paragraph once
-per run.
+The semantic slices additionally cross-check ID-mapping pool counts, paragraph-declared run and line
+counts, UTF-16 scalar/control boundaries, references, supported inline-control masks, record
+hierarchy, page dimensions, and positive body-box geometry. Run construction is bounded to
+binary-search validation plus a linear text pass; it does not rescan the paragraph once per run.
 
 Encrypted, distribution, DRM, and public-key-encrypted bodies are opaque to this slice and are
 rejected instead of being interpreted as records.
@@ -32,9 +38,9 @@ rejected instead of being interpreted as records.
 
 - `Engine::open`: unchanged production route. Binary HWP still uses the governed rhwp bootstrap.
 - `open_hwp5_own`: explicit first-party-only route. It returns a `SemanticDoc` only for the owned
-  text-only subset. Tables, images, fields, notes, equations, charts, unknown body controls, and
-  unsupported pool references fail closed with tag, section, and byte span only. It cannot call
-  rhwp.
+  text plus single-sided page-setup subset. Tables, images, fields, notes, equations, charts,
+  columns, decorations, page border/fill, duplex binding, unknown body controls, and unsupported
+  pool references fail closed with tag, section, and byte span only. It cannot call rhwp.
 - `hwp5_differential`: explicitly runs the owned probe and current rhwp semantic oracle, then reports
   section/paragraph/run/table/image/control/equation/chart counts and their deltas.
 
@@ -50,7 +56,7 @@ or claim semantic parity.
 
 ## Cutover rule
 
-The next #94 slices promote page setup, tables, BinData/images, and remaining controls into this
-crate. The production route may change only when public-corpus differential gates, native/wasm
+The next #94 slices promote tables, BinData/images, columns/decorations, and remaining controls into
+this crate. The production route may change only when public-corpus differential gates, native/wasm
 parity, hostile input tests, and the canonical 8/18/24-page + 98.9% line gate remain green. Explicit
 own-parser mode must continue to fail closed for every unsupported semantic construct.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,10 @@
 
 ---
 
+## 2026-08-23 (Codex sol) · #156 PR #157
+- commit `01b637c` push, PR #157(`Closes #156`, `Refs #94 #87`) 게시.
+- 다음 required CI/review 감시→green 자율 병합→#94 next first-party child.
+
 ## 2026-08-23 (Codex sol) · #156 full green
 - secd/PAGE_DEF + blank source metrics final diff/security review; production/rhwp 불변.
 - focused 27 + quick 전체 + full Rust/PDF/wasm/JS/Vitest 1,018 green.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,21 @@
 
 ---
 
+## 2026-08-23 (Codex sol) · #156 full green
+- secd/PAGE_DEF + blank source metrics final diff/security review; production/rhwp 불변.
+- focused 27 + quick 전체 + full Rust/PDF/wasm/JS/Vitest 1,018 green.
+- Chromium 85 pass/3 intentional skip/0 fail. 다음 commit/PR/CI/병합→#94 next child.
+
+## 2026-08-23 (Codex sol) · #156 source-layout focused green
+- strict secd/PAGE_DEF + blank-only PARA_LINE_SEG metrics; unsupported constructs fail closed.
+- 합성 정상/적대 11건 포함 hwp-hwp5 27 tests, clippy, wasm32 green.
+- 다음 security review→quick/full→commit/PR/CI/병합; production/rhwp 불변.
+
+## 2026-08-23 (Codex sol) · PR #155 병합 → #156 착수
+- #155 required CI/CLEAN·댓글 0 확인 후 main `c16e231` 병합; #154 close.
+- #94 완료 근거 동기화, child #156 생성 후 latest-main worktree 시작.
+- 다음 strict PAGE_DEF + source line metrics; production route/rhwp 불변.
+
 ## 2026-08-23 (Codex sol) · #154 PR #155
 - commit `a6acbca` push, PR #155(`Closes #154`, `Refs #94 #87`) 게시.
 - 다음 required CI/review 감시→green 자율 병합→#94 next first-party slice.


### PR DESCRIPTION
## Summary
- parse the first-section secd control hierarchy and a single strict 40-byte PAGE_DEF into our Section.page
- validate 36-byte PARA_LINE_SEG records and use source metrics only for true blank paragraphs
- fail closed on duplicate, malformed, unknown, duplex, and top-flip structures with content-free provenance

## Boundaries
- no production HWP5 route cutover
- no rhwp fallback or external/rhwp modification
- visible text and control-host paragraphs do not trust stored line breaks

## Verification
- hwp-hwp5: 27 tests, clippy -D warnings, wasm32 green
- verify-local quick: canonical 8/18/24 and 98.9%+, PDF 51, corpus 84, oracle 82, HWPX locks, licenses green
- verify-local full: Rust/PDF/wasm/JS builds and Vitest 1,018 green
- Playwright Chromium: 85 passed, 3 intentional skips, 0 failed on isolated port
- generated assets and external/rhwp diff: 0

Closes #156
Refs #94 #87