### PR TITLE
feat: own HWP5 paragraph support pools

### DIFF
--- a/crates/hwp-hwp5/src/semantic.rs
+++ b/crates/hwp-hwp5/src/semantic.rs
@@ -47,6 +47,31 @@ struct Pools {
     section_count: usize,
     char_shapes: Vec<CharShape>,
     para_shapes: Vec<ParaShape>,
+    para_usage: Vec<ParaUsage>,
+    border_fills: Vec<BorderFillDef>,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct ParaUsage {
+    has_custom_tabs: bool,
+    numbering: u16,
+    border_fill: u16,
+    head_type: u8,
+}
+
+#[derive(Clone, Debug, Default)]
+struct TabDef {
+    custom_count: usize,
+}
+
+#[derive(Clone, Debug, Default)]
+struct NumberingDef {
+    char_shape_refs: Vec<u32>,
+}
+
+#[derive(Clone, Debug, Default)]
+struct BulletDef {
+    char_shape_ref: u32,
 }
 
 pub(crate) fn parse_text_only(bytes: &[u8]) -> Result<SemanticDoc> {
@@ -79,8 +104,12 @@ pub(crate) fn parse_text_only(bytes: &[u8]) -> Result<SemanticDoc> {
         doc.header_pools.para.insert(index as u64, shape.clone());
         doc.para_shapes.push(shape);
     }
+    for (index, border) in pools.border_fills.into_iter().enumerate() {
+        doc.header_pools.border.insert((index + 1) as u64, border);
+    }
     for stream in section_streams {
-        doc.sections.push(parse_section(stream, &doc)?);
+        doc.sections
+            .push(parse_section(stream, &doc, &pools.para_usage)?);
     }
     Ok(doc)
 }
@@ -142,17 +171,54 @@ fn parse_pools(inspected: &Hwp5Probe) -> Result<Pools> {
         .filter(|record| record.tag == TAG_CHAR_SHAPE)
         .map(|record| parse_char_shape(data(stream, record), record, &faces))
         .collect::<Result<Vec<_>>>()?;
-    let para_shapes = stream
+    let border_fills = stream
+        .records
+        .iter()
+        .filter(|record| record.tag == TAG_BORDER_FILL)
+        .map(|record| parse_border_fill(data(stream, record), record))
+        .collect::<Result<Vec<_>>>()?;
+    let tab_defs = stream
+        .records
+        .iter()
+        .filter(|record| record.tag == TAG_TAB_DEF)
+        .map(|record| parse_tab_def(data(stream, record), record))
+        .collect::<Result<Vec<_>>>()?;
+    let numberings = stream
+        .records
+        .iter()
+        .filter(|record| record.tag == TAG_NUMBERING)
+        .map(|record| parse_numbering(data(stream, record), record))
+        .collect::<Result<Vec<_>>>()?;
+    let bullets = stream
+        .records
+        .iter()
+        .filter(|record| record.tag == TAG_BULLET)
+        .map(|record| parse_bullet(data(stream, record), record))
+        .collect::<Result<Vec<_>>>()?;
+    validate_support_refs(&numberings, &bullets, char_shapes.len(), stream)?;
+    let parsed_para_shapes = stream
         .records
         .iter()
         .filter(|record| record.tag == TAG_PARA_SHAPE)
-        .map(|record| parse_para_shape(data(stream, record), record))
+        .map(|record| {
+            parse_para_shape(
+                data(stream, record),
+                record,
+                &tab_defs,
+                numberings.len(),
+                bullets.len(),
+                border_fills.len(),
+            )
+        })
         .collect::<Result<Vec<_>>>()?;
+    let (para_shapes, para_usage): (Vec<_>, Vec<_>) = parsed_para_shapes.into_iter().unzip();
 
     Ok(Pools {
         section_count,
         char_shapes,
         para_shapes,
+        para_usage,
+        border_fills,
     })
 }
 
@@ -316,7 +382,341 @@ fn parse_char_shape(bytes: &[u8], record: &Record, faces: &[Vec<FontFace>]) -> R
     })
 }
 
-fn parse_para_shape(bytes: &[u8], record: &Record) -> Result<ParaShape> {
+fn parse_border_fill(bytes: &[u8], record: &Record) -> Result<BorderFillDef> {
+    let mut reader = Reader::new(bytes);
+    let attr = reader
+        .u16()
+        .ok_or_else(|| malformed(record, None, "BORDER_FILL has no attributes"))?;
+    let mut borders = [None; 4];
+    let mut has_border = false;
+    for edge in &mut borders {
+        let line_type = reader
+            .u8()
+            .ok_or_else(|| malformed(record, None, "BORDER_FILL edge is truncated"))?;
+        let width = reader
+            .u8()
+            .ok_or_else(|| malformed(record, None, "BORDER_FILL edge is truncated"))?;
+        let color = reader
+            .u32()
+            .ok_or_else(|| malformed(record, None, "BORDER_FILL edge is truncated"))?;
+        let style = border_line_style(line_type)
+            .ok_or_else(|| malformed(record, None, "BORDER_FILL has an unknown line type"))?;
+        if width > 15 {
+            return Err(malformed(
+                record,
+                None,
+                "BORDER_FILL has an unknown line width",
+            ));
+        }
+        has_border |= style != LineStyle::None;
+        *edge = Some(CellEdge {
+            color: opaque_bgr(color),
+            style,
+            width_px: border_width_px(width),
+        });
+    }
+    let diagonal_type = reader
+        .u8()
+        .ok_or_else(|| malformed(record, None, "BORDER_FILL diagonal is truncated"))?;
+    let diagonal_width = reader
+        .u8()
+        .ok_or_else(|| malformed(record, None, "BORDER_FILL diagonal is truncated"))?;
+    let diagonal_color = reader
+        .u32()
+        .ok_or_else(|| malformed(record, None, "BORDER_FILL diagonal is truncated"))?;
+    let diagonal_style = border_line_style(diagonal_type)
+        .ok_or_else(|| malformed(record, None, "BORDER_FILL has an unknown diagonal type"))?;
+    if diagonal_width > 15 {
+        return Err(malformed(
+            record,
+            None,
+            "BORDER_FILL has an unknown diagonal width",
+        ));
+    }
+    let diagonal = diagonal_kind(attr, diagonal_style).map(|kind| CellDiagonal {
+        kind,
+        color: opaque_bgr(diagonal_color),
+        width_px: border_width_px(diagonal_width),
+    });
+
+    let fill_type = reader
+        .u32()
+        .ok_or_else(|| malformed(record, None, "BORDER_FILL has no fill type"))?;
+    let shade = match fill_type {
+        0 => {
+            let reserved = reader
+                .u32()
+                .ok_or_else(|| malformed(record, None, "BORDER_FILL no-fill tail is truncated"))?;
+            if reserved != 0 {
+                return Err(malformed(
+                    record,
+                    None,
+                    "BORDER_FILL no-fill tail is not zero",
+                ));
+            }
+            None
+        }
+        1 => {
+            let face = reader
+                .u32()
+                .ok_or_else(|| malformed(record, None, "BORDER_FILL solid fill is truncated"))?;
+            let _pattern_color = reader
+                .u32()
+                .ok_or_else(|| malformed(record, None, "BORDER_FILL solid fill is truncated"))?;
+            let pattern = reader
+                .i32()
+                .ok_or_else(|| malformed(record, None, "BORDER_FILL solid fill is truncated"))?;
+            if pattern != -1 {
+                return Err(malformed(
+                    record,
+                    None,
+                    "BORDER_FILL pattern semantics are not supported",
+                ));
+            }
+            let additional = reader.u32().ok_or_else(|| {
+                malformed(record, None, "BORDER_FILL additional property is truncated")
+            })?;
+            if additional != 0 {
+                return Err(malformed(
+                    record,
+                    None,
+                    "BORDER_FILL additional property is not supported",
+                ));
+            }
+            let alpha = reader
+                .u8()
+                .ok_or_else(|| malformed(record, None, "BORDER_FILL alpha is truncated"))?;
+            if alpha != 0 {
+                return Err(malformed(
+                    record,
+                    None,
+                    "BORDER_FILL alpha is not supported",
+                ));
+            }
+            nondefault_shade(face)
+        }
+        value if value & !0x07 != 0 => {
+            return Err(malformed(record, None, "BORDER_FILL has unknown fill bits"))
+        }
+        _ => {
+            return Err(malformed(
+                record,
+                None,
+                "BORDER_FILL image, gradient, or mixed fill is not supported",
+            ))
+        }
+    };
+    if !reader.is_finished() {
+        return Err(malformed(
+            record,
+            None,
+            "BORDER_FILL has an unowned trailing payload",
+        ));
+    }
+    Ok(BorderFillDef {
+        borders,
+        shade,
+        diagonal,
+        has_border,
+    })
+}
+
+fn parse_tab_def(bytes: &[u8], record: &Record) -> Result<TabDef> {
+    let mut reader = Reader::new(bytes);
+    let attr = reader
+        .u32()
+        .ok_or_else(|| malformed(record, None, "TAB_DEF header is truncated"))?;
+    if attr & !0x03 != 0 {
+        return Err(malformed(
+            record,
+            None,
+            "TAB_DEF has unsupported attribute bits",
+        ));
+    }
+    let count = reader
+        .u32()
+        .ok_or_else(|| malformed(record, None, "TAB_DEF count is truncated"))?
+        as usize;
+    let payload = count.checked_mul(8).ok_or_else(|| {
+        malformed(
+            record,
+            None,
+            "TAB_DEF item count exceeds the bounded payload",
+        )
+    })?;
+    if reader.remaining() != payload {
+        return Err(malformed(
+            record,
+            None,
+            "TAB_DEF count differs from its item payload",
+        ));
+    }
+    for _ in 0..count {
+        let _position = reader.u32().expect("payload length checked");
+        let tab_type = reader.u8().expect("payload length checked");
+        let fill_type = reader.u8().expect("payload length checked");
+        let reserved = reader.u16().expect("payload length checked");
+        if tab_type > 3 || fill_type > 16 || reserved != 0 {
+            return Err(malformed(
+                record,
+                None,
+                "TAB_DEF item has an unsupported type or reserved value",
+            ));
+        }
+    }
+    Ok(TabDef {
+        custom_count: count,
+    })
+}
+
+fn parse_numbering(bytes: &[u8], record: &Record) -> Result<NumberingDef> {
+    let mut reader = Reader::new(bytes);
+    let mut char_shape_refs = Vec::with_capacity(7);
+    for _ in 0..7 {
+        reader
+            .u32()
+            .ok_or_else(|| malformed(record, None, "NUMBERING head is truncated"))?;
+        reader
+            .skip(4)
+            .ok_or_else(|| malformed(record, None, "NUMBERING head is truncated"))?;
+        char_shape_refs.push(
+            reader
+                .u32()
+                .ok_or_else(|| malformed(record, None, "NUMBERING head is truncated"))?,
+        );
+        reader
+            .hwp_string()
+            .ok_or_else(|| malformed(record, None, "NUMBERING format string is invalid"))?;
+    }
+    reader
+        .u16()
+        .ok_or_else(|| malformed(record, None, "NUMBERING start value is truncated"))?;
+    if reader.remaining() != 0 {
+        if reader.remaining() < 28 {
+            return Err(malformed(
+                record,
+                None,
+                "NUMBERING has a partial level-start extension",
+            ));
+        }
+        for _ in 0..7 {
+            reader.u32().expect("extension length checked");
+        }
+        if reader.remaining() != 0 {
+            // HWP 5.1 stores levels 8–10 as three interleaved extended
+            // heads, format strings, and start values. We consume that
+            // structure exactly but keep active numbering fail-closed until
+            // the extended head semantics are independently owned.
+            for _ in 0..3 {
+                reader.u32().ok_or_else(|| {
+                    malformed(record, None, "NUMBERING extended head is truncated")
+                })?;
+                reader.skip(8).ok_or_else(|| {
+                    malformed(record, None, "NUMBERING extended head is truncated")
+                })?;
+                reader.hwp_string().ok_or_else(|| {
+                    malformed(record, None, "NUMBERING extended format string is invalid")
+                })?;
+                reader.u32().ok_or_else(|| {
+                    malformed(record, None, "NUMBERING extended start value is truncated")
+                })?;
+            }
+            if !reader.is_finished() {
+                return Err(malformed(
+                    record,
+                    None,
+                    "NUMBERING has an unknown trailing extension",
+                ));
+            }
+        }
+    }
+    Ok(NumberingDef { char_shape_refs })
+}
+
+fn parse_bullet(bytes: &[u8], record: &Record) -> Result<BulletDef> {
+    let mut reader = Reader::new(bytes);
+    reader
+        .u32()
+        .ok_or_else(|| malformed(record, None, "BULLET head is truncated"))?;
+    reader
+        .skip(4)
+        .ok_or_else(|| malformed(record, None, "BULLET head is truncated"))?;
+    let char_shape_ref = reader
+        .u32()
+        .ok_or_else(|| malformed(record, None, "BULLET head is truncated"))?;
+    reader
+        .u16()
+        .ok_or_else(|| malformed(record, None, "BULLET character is truncated"))?;
+    match reader.remaining() {
+        0 => false,
+        10 => {
+            let image = reader.u32().expect("extension length checked") != 0;
+            reader.skip(4).expect("extension length checked");
+            reader.u16().expect("extension length checked");
+            image
+        }
+        _ => {
+            return Err(malformed(
+                record,
+                None,
+                "BULLET has a partial or unknown extension",
+            ))
+        }
+    };
+    Ok(BulletDef { char_shape_ref })
+}
+
+fn validate_support_refs(
+    numberings: &[NumberingDef],
+    bullets: &[BulletDef],
+    char_shapes: usize,
+    stream: &StreamProbe,
+) -> Result<()> {
+    let numbering_records: Vec<_> = stream
+        .records
+        .iter()
+        .filter(|record| record.tag == TAG_NUMBERING)
+        .collect();
+    for (definition, record) in numberings.iter().zip(numbering_records) {
+        for &reference in &definition.char_shape_refs {
+            if reference != u32::MAX && reference as usize >= char_shapes {
+                return Err(invalid_pool_ref(
+                    "numbering character shape",
+                    reference as usize,
+                    char_shapes,
+                    record,
+                ));
+            }
+        }
+    }
+    let bullet_records: Vec<_> = stream
+        .records
+        .iter()
+        .filter(|record| record.tag == TAG_BULLET)
+        .collect();
+    for (definition, record) in bullets.iter().zip(bullet_records) {
+        if definition.char_shape_ref != u32::MAX
+            && definition.char_shape_ref as usize >= char_shapes
+        {
+            return Err(invalid_pool_ref(
+                "bullet character shape",
+                definition.char_shape_ref as usize,
+                char_shapes,
+                record,
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn parse_para_shape(
+    bytes: &[u8],
+    record: &Record,
+    tab_defs: &[TabDef],
+    numberings: usize,
+    bullets: usize,
+    border_fills: usize,
+) -> Result<(ParaShape, ParaUsage)> {
     if bytes.len() < 42 {
         return Err(malformed(
             record,
@@ -328,14 +728,46 @@ fn parse_para_shape(bytes: &[u8], record: &Record) -> Result<ParaShape> {
     let tab_def = read_u16(bytes, 28).expect("base length checked");
     let numbering = read_u16(bytes, 30).expect("base length checked");
     let border = read_u16(bytes, 32).expect("base length checked");
-    if tab_def != 0 || numbering != 0 || border != 0 {
-        return Err(malformed(
+    if tab_defs.is_empty() {
+        if tab_def != 0 {
+            return Err(invalid_pool_ref(
+                "tab definition",
+                tab_def as usize,
+                0,
+                record,
+            ));
+        }
+    } else if tab_def as usize >= tab_defs.len() {
+        return Err(invalid_pool_ref(
+            "tab definition",
+            tab_def as usize,
+            tab_defs.len(),
             record,
-            None,
-            "text-only PARA_SHAPE references an unsupported pool",
         ));
     }
-    Ok(ParaShape {
+    let head_type = ((attr >> 23) & 0x03) as u8;
+    let head_pool = if head_type == 3 { bullets } else { numberings };
+    if numbering != 0 && numbering as usize > head_pool {
+        return Err(invalid_pool_ref(
+            if head_type == 3 {
+                "bullet"
+            } else {
+                "numbering"
+            },
+            numbering as usize,
+            head_pool,
+            record,
+        ));
+    }
+    if border != 0 && border as usize > border_fills {
+        return Err(invalid_pool_ref(
+            "border fill",
+            border as usize,
+            border_fills,
+            record,
+        ));
+    }
+    let shape = ParaShape {
         align: match (attr >> 2) & 0x07 {
             1 => HorizontalAlign::Left,
             2 => HorizontalAlign::Right,
@@ -356,12 +788,32 @@ fn parse_para_shape(bytes: &[u8], record: &Record) -> Result<ParaShape> {
         space_before: read_i32(bytes, 16).expect("base length checked"),
         space_after: read_i32(bytes, 20).expect("base length checked"),
         line_spacing_value: read_i32(bytes, 24).expect("base length checked"),
+        widow_orphan: attr & (1 << 16) != 0,
+        keep_with_next: attr & (1 << 17) != 0,
+        keep_lines: attr & (1 << 18) != 0,
         page_break_before: attr & (1 << 19) != 0,
+        numbering_id: numbering,
+        border_fill_id: border,
         ..ParaShape::default()
-    })
+    };
+    Ok((
+        shape,
+        ParaUsage {
+            has_custom_tabs: tab_defs
+                .get(tab_def as usize)
+                .is_some_and(|definition| definition.custom_count != 0),
+            numbering,
+            border_fill: border,
+            head_type,
+        },
+    ))
 }
 
-fn parse_section(stream: &StreamProbe, doc: &SemanticDoc) -> Result<Section> {
+fn parse_section(
+    stream: &StreamProbe,
+    doc: &SemanticDoc,
+    para_usage: &[ParaUsage],
+) -> Result<Section> {
     let section = stream.section.expect("caller selected section streams");
     let mut blocks = Vec::new();
     let mut page = None;
@@ -390,7 +842,13 @@ fn parse_section(stream: &StreamProbe, doc: &SemanticDoc) -> Result<Section> {
             .get(ordinal + 1)
             .copied()
             .unwrap_or(stream.records.len());
-        let parsed = parse_paragraph(stream, &stream.records[start..end], doc, section)?;
+        let parsed = parse_paragraph(
+            stream,
+            &stream.records[start..end],
+            doc,
+            para_usage,
+            section,
+        )?;
         if let Some(parsed_page) = parsed.page {
             if ordinal != 0 || page.replace(parsed_page).is_some() {
                 return Err(malformed(
@@ -422,6 +880,7 @@ fn parse_paragraph(
     stream: &StreamProbe,
     records: &[Record],
     doc: &SemanticDoc,
+    para_usage: &[ParaUsage],
     section: usize,
 ) -> Result<ParsedParagraph> {
     let header = records[0];
@@ -453,6 +912,15 @@ fn parse_paragraph(
             offset: header.head,
         });
     }
+    let usage = para_usage
+        .get(para_shape_id)
+        .ok_or(Error::InvalidReference {
+            kind: "paragraph usage",
+            index: para_shape_id,
+            pool_len: para_usage.len(),
+            section: Some(section),
+            offset: header.head,
+        })?;
 
     let mut text_record = None;
     let mut shape_record = None;
@@ -509,6 +977,7 @@ fn parse_paragraph(
             "PARA_HEADER control mask differs from supported PARA_TEXT controls",
         ));
     }
+    validate_para_usage(usage, &decoded, doc, &header, section)?;
     let page = match (decoded.section_controls.as_slice(), section_control) {
         ([], None) => None,
         ([(marker_offset, marker_id)], Some((control, children)))
@@ -578,6 +1047,54 @@ fn parse_paragraph(
         },
         page,
     })
+}
+
+fn validate_para_usage(
+    usage: &ParaUsage,
+    decoded: &DecodedText,
+    doc: &SemanticDoc,
+    header: &Record,
+    section: usize,
+) -> Result<()> {
+    if usage.has_custom_tabs && decoded.chars.iter().any(|(_, value)| *value == '\t') {
+        return Err(malformed(
+            header,
+            Some(section),
+            "active custom tab semantics are not supported",
+        ));
+    }
+    if usage.head_type != 0 {
+        return Err(malformed(
+            header,
+            Some(section),
+            if usage.numbering == 0 {
+                "active paragraph head has no numbering or bullet reference"
+            } else {
+                "active numbering and bullet semantics are not supported"
+            },
+        ));
+    }
+    if usage.border_fill != 0 {
+        let border = doc
+            .header_pools
+            .border
+            .get(&(usage.border_fill as u64))
+            .ok_or(Error::InvalidReference {
+                kind: "paragraph border fill",
+                index: usage.border_fill as usize,
+                pool_len: doc.header_pools.border.len(),
+                section: Some(section),
+                offset: header.head,
+            })?;
+        if border.has_border || border.shade.is_some() || border.diagonal.is_some() {
+            return Err(malformed(
+                header,
+                Some(section),
+                "active paragraph border or fill semantics are not supported",
+            ));
+        }
+    }
+    Ok(())
 }
 
 fn parse_section_control(
@@ -1105,6 +1622,16 @@ fn unsupported(record: Record, section: usize) -> Error {
     }
 }
 
+fn invalid_pool_ref(kind: &'static str, index: usize, pool_len: usize, record: &Record) -> Error {
+    Error::InvalidReference {
+        kind,
+        index,
+        pool_len,
+        section: None,
+        offset: record.head,
+    }
+}
+
 fn read_u16(bytes: &[u8], offset: usize) -> Option<u16> {
     Some(u16::from_le_bytes(
         bytes.get(offset..offset + 2)?.try_into().ok()?,
@@ -1134,6 +1661,51 @@ fn bgr(value: u32) -> Color {
             a: 255,
         }
     }
+}
+
+fn opaque_bgr(value: u32) -> Color {
+    Color {
+        a: 255,
+        ..bgr(value)
+    }
+}
+
+fn nondefault_shade(value: u32) -> Option<Color> {
+    let color = opaque_bgr(value);
+    ((color.r, color.g, color.b) != (0, 0, 0) && (color.r, color.g, color.b) != (255, 255, 255))
+        .then_some(color)
+}
+
+fn border_line_style(value: u8) -> Option<LineStyle> {
+    Some(match value {
+        0 => LineStyle::None,
+        2 | 4 | 5 | 6 => LineStyle::Dashed,
+        3 | 7 => LineStyle::Dotted,
+        8..=11 => LineStyle::Double,
+        1 | 12..=16 => LineStyle::Solid,
+        _ => return None,
+    })
+}
+
+fn diagonal_kind(attr: u16, style: LineStyle) -> Option<DiagonalKind> {
+    if style == LineStyle::None {
+        return None;
+    }
+    let slash = (attr >> 2) & 0x07 != 0;
+    let backslash = (attr >> 5) & 0x07 != 0;
+    match (slash, backslash) {
+        (true, true) => Some(DiagonalKind::Cross),
+        (true, false) => Some(DiagonalKind::Slash),
+        (false, true) => Some(DiagonalKind::BackSlash),
+        (false, false) => None,
+    }
+}
+
+fn border_width_px(value: u8) -> f64 {
+    const WIDTHS: [f64; 16] = [
+        0.5, 0.5, 0.6, 0.75, 1.0, 1.1, 1.5, 1.9, 2.3, 2.6, 3.8, 5.7, 7.6, 11.3, 15.1, 18.9,
+    ];
+    WIDTHS[value as usize]
 }
 
 struct Reader<'a> {
@@ -1178,6 +1750,14 @@ impl<'a> Reader<'a> {
         Some(())
     }
 
+    fn remaining(&self) -> usize {
+        self.bytes.len().saturating_sub(self.cursor)
+    }
+
+    fn is_finished(&self) -> bool {
+        self.cursor == self.bytes.len()
+    }
+
     fn array10(&mut self) -> Option<[u8; 10]> {
         let value = self.bytes.get(self.cursor..self.cursor + 10)?;
         self.cursor += 10;
@@ -1195,5 +1775,247 @@ impl<'a> Reader<'a> {
             .map(|pair| u16::from_le_bytes([pair[0], pair[1]]))
             .collect();
         String::from_utf16(&units).ok()
+    }
+}
+
+#[cfg(test)]
+mod support_pool_tests {
+    use super::*;
+
+    fn record(tag: u16, size: usize) -> Record {
+        Record {
+            tag,
+            level: 0,
+            size,
+            head: 17,
+            data: 21,
+            end: 21 + size,
+            extended: false,
+        }
+    }
+
+    fn border_fill(fill_type: u32) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&(1u16 << 2).to_le_bytes()); // slash direction
+        for (kind, width, color) in [
+            (1u8, 0u8, 0x0000_00ffu32),
+            (2, 1, 0x0000_ff00),
+            (3, 2, 0x00ff_0000),
+            (8, 3, 0),
+        ] {
+            bytes.push(kind);
+            bytes.push(width);
+            bytes.extend_from_slice(&color.to_le_bytes());
+        }
+        bytes.push(1); // diagonal solid
+        bytes.push(0);
+        bytes.extend_from_slice(&0x0000_ff00u32.to_le_bytes());
+        bytes.extend_from_slice(&fill_type.to_le_bytes());
+        match fill_type {
+            0 => bytes.extend_from_slice(&0u32.to_le_bytes()),
+            1 => {
+                bytes.extend_from_slice(&0x00ff_0000u32.to_le_bytes());
+                bytes.extend_from_slice(&0u32.to_le_bytes());
+                bytes.extend_from_slice(&(-1i32).to_le_bytes());
+                bytes.extend_from_slice(&0u32.to_le_bytes());
+                bytes.push(0);
+            }
+            _ => {}
+        }
+        bytes
+    }
+
+    fn numbering() -> Vec<u8> {
+        let mut bytes = Vec::new();
+        for _ in 0..7 {
+            bytes.extend_from_slice(&0u32.to_le_bytes());
+            bytes.extend_from_slice(&0i16.to_le_bytes());
+            bytes.extend_from_slice(&0i16.to_le_bytes());
+            bytes.extend_from_slice(&0u32.to_le_bytes());
+            bytes.extend_from_slice(&0u16.to_le_bytes());
+        }
+        bytes.extend_from_slice(&1u16.to_le_bytes());
+        for _ in 0..7 {
+            bytes.extend_from_slice(&1u32.to_le_bytes());
+        }
+        for _ in 0..3 {
+            bytes.extend_from_slice(&0u32.to_le_bytes());
+            bytes.extend_from_slice(&0u32.to_le_bytes());
+            bytes.extend_from_slice(&0u32.to_le_bytes());
+            bytes.extend_from_slice(&0u16.to_le_bytes());
+            bytes.extend_from_slice(&1u32.to_le_bytes());
+        }
+        bytes
+    }
+
+    #[test]
+    fn border_fill_maps_known_edges_shade_and_diagonal() {
+        let bytes = border_fill(1);
+        let parsed = parse_border_fill(&bytes, &record(TAG_BORDER_FILL, bytes.len())).unwrap();
+        assert!(parsed.has_border);
+        assert_eq!(parsed.borders[0].unwrap().style, LineStyle::Solid);
+        assert_eq!(parsed.borders[1].unwrap().style, LineStyle::Dashed);
+        assert_eq!(parsed.borders[2].unwrap().style, LineStyle::Dotted);
+        assert_eq!(parsed.borders[3].unwrap().style, LineStyle::Double);
+        assert_eq!(parsed.borders[0].unwrap().color.r, 255);
+        assert_eq!(parsed.shade.unwrap().b, 255);
+        assert_eq!(parsed.diagonal.unwrap().kind, DiagonalKind::Slash);
+    }
+
+    #[test]
+    fn border_fill_refuses_unknown_lines_and_unowned_fills() {
+        let mut bad_line = border_fill(0);
+        bad_line[2] = 17;
+        assert!(matches!(
+            parse_border_fill(&bad_line, &record(TAG_BORDER_FILL, bad_line.len())),
+            Err(Error::MalformedRecord {
+                reason: "BORDER_FILL has an unknown line type",
+                ..
+            })
+        ));
+
+        let image = border_fill(2);
+        assert!(matches!(
+            parse_border_fill(&image, &record(TAG_BORDER_FILL, image.len())),
+            Err(Error::MalformedRecord {
+                reason: "BORDER_FILL image, gradient, or mixed fill is not supported",
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn tab_definition_count_is_exact_and_bounded() {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&0u32.to_le_bytes());
+        bytes.extend_from_slice(&1u32.to_le_bytes());
+        bytes.extend_from_slice(&7200u32.to_le_bytes());
+        bytes.extend_from_slice(&0u8.to_le_bytes());
+        bytes.extend_from_slice(&1u8.to_le_bytes());
+        bytes.extend_from_slice(&0u16.to_le_bytes());
+        assert_eq!(
+            parse_tab_def(&bytes, &record(TAG_TAB_DEF, bytes.len()))
+                .unwrap()
+                .custom_count,
+            1
+        );
+        bytes.pop();
+        assert!(parse_tab_def(&bytes, &record(TAG_TAB_DEF, bytes.len())).is_err());
+    }
+
+    #[test]
+    fn numbering_510_extension_is_fully_consumed() {
+        let bytes = numbering();
+        let parsed = parse_numbering(&bytes, &record(TAG_NUMBERING, bytes.len())).unwrap();
+        assert_eq!(parsed.char_shape_refs.len(), 7);
+        let mut truncated = bytes;
+        truncated.pop();
+        assert!(parse_numbering(&truncated, &record(TAG_NUMBERING, truncated.len())).is_err());
+    }
+
+    #[test]
+    fn paragraph_refs_are_range_checked_but_inert_refs_survive() {
+        let mut bytes = vec![0; 42];
+        bytes[28..30].copy_from_slice(&0u16.to_le_bytes());
+        bytes[30..32].copy_from_slice(&1u16.to_le_bytes());
+        bytes[32..34].copy_from_slice(&1u16.to_le_bytes());
+        let (shape, usage) = parse_para_shape(
+            &bytes,
+            &record(TAG_PARA_SHAPE, bytes.len()),
+            &[TabDef::default()],
+            1,
+            0,
+            1,
+        )
+        .unwrap();
+        assert_eq!(shape.numbering_id, 1);
+        assert_eq!(shape.border_fill_id, 1);
+        assert_eq!(usage.head_type, 0);
+
+        bytes[30..32].copy_from_slice(&2u16.to_le_bytes());
+        assert!(matches!(
+            parse_para_shape(
+                &bytes,
+                &record(TAG_PARA_SHAPE, bytes.len()),
+                &[TabDef::default()],
+                1,
+                0,
+                1,
+            ),
+            Err(Error::InvalidReference {
+                kind: "numbering",
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn active_custom_tabs_lists_and_paragraph_borders_fail_closed() {
+        let header = record(TAG_PARA_HEADER, 22);
+        let mut doc = SemanticDoc::default();
+        doc.header_pools.border.insert(
+            1,
+            BorderFillDef {
+                has_border: true,
+                ..BorderFillDef::default()
+            },
+        );
+        let tab = DecodedText {
+            chars: vec![(0, '\t')],
+            ..DecodedText::default()
+        };
+        assert!(validate_para_usage(
+            &ParaUsage {
+                has_custom_tabs: true,
+                ..ParaUsage::default()
+            },
+            &tab,
+            &doc,
+            &header,
+            0,
+        )
+        .is_err());
+        assert!(validate_para_usage(
+            &ParaUsage {
+                numbering: 1,
+                head_type: 2,
+                ..ParaUsage::default()
+            },
+            &DecodedText::default(),
+            &doc,
+            &header,
+            0,
+        )
+        .is_err());
+        assert!(validate_para_usage(
+            &ParaUsage {
+                border_fill: 1,
+                ..ParaUsage::default()
+            },
+            &DecodedText::default(),
+            &doc,
+            &header,
+            0,
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn bullet_base_and_extension_are_exact() {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&0u32.to_le_bytes());
+        bytes.extend_from_slice(&0i16.to_le_bytes());
+        bytes.extend_from_slice(&0i16.to_le_bytes());
+        bytes.extend_from_slice(&0u32.to_le_bytes());
+        bytes.extend_from_slice(&0x2022u16.to_le_bytes());
+        let parsed = parse_bullet(&bytes, &record(TAG_BULLET, bytes.len())).unwrap();
+        assert_eq!(parsed.char_shape_ref, 0);
+
+        bytes.extend_from_slice(&0u32.to_le_bytes());
+        bytes.extend_from_slice(&[0; 4]);
+        bytes.extend_from_slice(&0u16.to_le_bytes());
+        assert!(parse_bullet(&bytes, &record(TAG_BULLET, bytes.len())).is_ok());
+        bytes.pop();
+        assert!(parse_bullet(&bytes, &record(TAG_BULLET, bytes.len())).is_err());
     }
 }

--- a/crates/hwp-hwp5/tests/public_probe.rs
+++ b/crates/hwp-hwp5/tests/public_probe.rs
@@ -33,8 +33,10 @@ fn explicit_own_parser_never_falls_back() {
     eprintln!("{error:?}");
     assert!(matches!(
         error,
-        Error::UnsupportedBodyRecord { .. }
-            | Error::InvalidReference { .. }
-            | Error::MalformedRecord { .. }
+        Error::UnsupportedBodyRecord {
+            tag: 0x42,
+            section: 0,
+            ..
+        }
     ));
 }

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,6 +3,42 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
+- 갱신: 2026-08-23 · Codex(sol) — **#158 전체 검증 완료 · PR 준비**.
+  first-party support-pool slice의 최종 보안/diff review에서 HWP 5.1 numbering 확장은 실측 구조를
+  정확히 소비하되 의미 소유 전 active use를 계속 fail-closed하는 경계를 명시했다. focused
+  hwp-hwp5 **34 tests**, clippy, wasm32와 quick 전체가 green이고, full은 Rust/PDF51/canonical
+  **8/18/24·98.9%+**/corpus84/oracle82/HWPX/wasm/licenses, JS build, Vitest **1,018**, 실제 Chromium
+  **85 pass/3 intentional skip/0 fail**을 통과했다. 임시 의존성 링크 제거 후 production route,
+  generated asset, `external/rhwp` diff 0. **다음:** commit/push/PR #158→필수 CI·댓글 확인→green
+  자율 병합→공개 benchmark `PARA_HEADER 0x42` 경계를 다음 child issue로 분리한다.
+
+- 갱신: 2026-08-23 · Codex(sol) — **#158 quick 전체 green**.
+  support-pool parser의 모든 count×payload는 overflow/정확 길이를 먼저 검증하고, base numbering/bullet
+  char-shape 및 para tab/numbering/border refs는 범위를 확인한다. known border style만 축약 매핑하며 unknown,
+  pattern/image/gradient/alpha/mixed fill은 거부한다. hostile 경로의 `expect`는 앞선 exact-bound 검사 뒤뿐이고
+  오류는 tag·section·offset 정적 문구만 담는다. quick 전체에서 workspace tests, PDF 51, canonical
+  **8/18/24·98.9%+**, corpus 84, PDF parity, oracle 82, HWPX locks, wasm32, licenses가 green이다.
+  `external/rhwp`/generated/production route diff 0. **다음:** `verify-local --full`→final diff→commit/PR/CI/병합.
+
+- 갱신: 2026-08-23 · Codex(sol) — **#158 support pools focused green**.
+  first-party lane이 BORDER_FILL의 4 edge·solid shade·diagonal을 shared `BorderFillDef`로 옮기고,
+  TAB_DEF/NUMBERING(5.1 확장 8–10레벨 포함)/BULLET 가변 payload와 모든 pool ref를 strict 검증한다.
+  pool 존재와 active use를 분리해 기본 tab/비활성 ref는 보존하되 custom tab·목록/글머리·가시 paragraph
+  border/fill은 거짓 렌더 없이 content-free fail-closed한다. 공개 benchmark의 첫 경계는 기존
+  DocInfo PARA_SHAPE(tag 0x19) pool-ref 실패에서 BodyText PARA_HEADER(tag 0x42)로 전진했다.
+  합성 정상/적대 7건 추가, hwp-hwp5 **34 tests**, clippy `-D warnings`, wasm32 green.
+  **다음:** quick 전체 게이트→security/diff review→full→commit/push/PR #158→필수 CI·자율 병합.
+  production route와 `external/rhwp`는 불변이다.
+
+- 갱신: 2026-08-23 · Codex(sol) — **PR #157 병합 · #158 support-pool slice 착수**.
+  #157은 head `60cc790`에서 issue-link·build-test 8m02s·licenses green, CLEAN/MERGEABLE,
+  리뷰/일반/인라인 댓글 0을 확인한 뒤 main `82ca4e6`로 squash 병합했고 #156이 close됐다.
+  원격 브랜치를 정리하고 #94에 완료 근거를 동기화했다. 공개 benchmark의 다음 실패점이
+  PARA_SHAPE support-pool 참조임을 재현해 child #158을 만들고 정확한 최신 main에서
+  `codex/issue-158-hwp5-support-pools`를 시작했다. **다음:** BORDER_FILL/TAB_DEF/NUMBERING/BULLET를
+  strict parse하되 inert presence와 active semantics를 나눠, 표현 불가능한 탭·목록·border는 계속
+  fail-closed한다. production route와 `external/rhwp`는 바꾸지 않는다.
+
 - 갱신: 2026-08-23 · Codex(sol) — **#156 PR #157 게시**.
   검증 완료 commit `01b637c`를 push하고 PR #157(`Closes #156`, `Refs #94 #87`)을 만들었다.
   strict PAGE_DEF/source metrics, unsupported fail-closed, no production cutover/no rhwp fallback과

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,6 +3,13 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
+- 갱신: 2026-08-23 · Codex(sol) — **#158 PR #159 게시**.
+  검증 완료 commit `5b57498`을 push하고 PR #159(`Closes #158`, `Refs #94 #87 #95`)을 만들었다.
+  exact support-pool parsing, active unsupported fail-closed, public boundary `0x19→0x42`, no production
+  cutover/no rhwp fallback과 quick/full/Chromium 85 pass·3 intentional skip·generated/rhwp diff 0을
+  본문에 명시했다. **다음:** 이 상태 commit push→issue-link/build-test/licenses·mergeability·review/comment를
+  추적하고 전부 green이면 자율 병합·원격 브랜치 정리→`PARA_HEADER 0x42` child를 issue-first로 착수한다.
+
 - 갱신: 2026-08-23 · Codex(sol) — **#158 전체 검증 완료 · PR 준비**.
   first-party support-pool slice의 최종 보안/diff review에서 HWP 5.1 numbering 확장은 실측 구조를
   정확히 소비하되 의미 소유 전 active use를 계속 fail-closed하는 경계를 명시했다. focused

--- a/docs/HWP5-NATIVE-PARSER.md
+++ b/docs/HWP5-NATIVE-PARSER.md
@@ -1,16 +1,21 @@
 # First-party HWP5 parser boundary
 
 Issue #107 introduced the first owned binary-HWP layer; issue #154 added its first semantic slice,
-and issue #156 adds the minimum source-layout facts needed by the shared typesetter. None of these
-slices changes production parsing.
+issue #156 added the minimum source-layout facts needed by the shared typesetter, and issue #158
+owns the paragraph support-pool boundary. None of these slices changes production parsing.
 
 ## What is owned now
 
 `crates/hwp-hwp5` parses the CFB `FileHeader`, exposes every documented property/security flag,
 walks `DocInfo` and `BodyText/SectionN` records, and preserves unknown records as `(tag, level,
 size, header/data/end offsets, extended-header bit)`. It also decodes the strict DocInfo font,
-character-shape, and paragraph-shape pools plus direct paragraph text and character-shape runs into
-`SemanticDoc`. The owned section-definition boundary maps a strict 40-byte `PAGE_DEF` to
+character-shape, paragraph-shape, border-fill, tab-definition, numbering, and bullet pools plus direct
+paragraph text and character-shape runs into `SemanticDoc`. Known binary border edges, solid shade,
+and diagonal directions map to the shared `BorderFillDef`; unknown line values and image, gradient,
+patterned, alpha, or mixed fills are refused rather than flattened. Paragraph references are range
+checked. A pool that is merely present is not treated as active: custom tabs, numbering/bullets, and
+visible paragraph border/fill still fail closed when a paragraph would depend on semantics the shared
+typesetter does not yet own. The owned section-definition boundary maps a strict 40-byte `PAGE_DEF` to
 `Section.page`, including all six margins, gutter, and HWP5 landscape orientation. A strict
 `PARA_LINE_SEG` reader validates declared counts and UTF-16 scalar/control starts, but exposes stored
 line-box metrics only for true blank spacer paragraphs. Stored line breaks never override our
@@ -27,8 +32,8 @@ Untrusted input is bounded before and during inspection:
 - every normal and extended record length is checked before forming a span.
 
 The semantic slices additionally cross-check ID-mapping pool counts, paragraph-declared run and line
-counts, UTF-16 scalar/control boundaries, references, supported inline-control masks, record
-hierarchy, page dimensions, and positive body-box geometry. Run construction is bounded to
+counts, UTF-16 scalar/control boundaries, references, support-pool variable lengths, supported
+inline-control masks, record hierarchy, page dimensions, and positive body-box geometry. Run construction is bounded to
 binary-search validation plus a linear text pass; it does not rescan the paragraph once per run.
 
 Encrypted, distribution, DRM, and public-key-encrypted bodies are opaque to this slice and are
@@ -39,8 +44,9 @@ rejected instead of being interpreted as records.
 - `Engine::open`: unchanged production route. Binary HWP still uses the governed rhwp bootstrap.
 - `open_hwp5_own`: explicit first-party-only route. It returns a `SemanticDoc` only for the owned
   text plus single-sided page-setup subset. Tables, images, fields, notes, equations, charts,
-  columns, decorations, page border/fill, duplex binding, unknown body controls, and unsupported
-  pool references fail closed with tag, section, and byte span only. It cannot call rhwp.
+  columns, decorations, page border/fill, duplex binding, active custom tabs/lists/paragraph borders,
+  unknown body controls, and unsupported pool values fail closed with tag, section, and byte span
+  only. It cannot call rhwp.
 - `hwp5_differential`: explicitly runs the owned probe and current rhwp semantic oracle, then reports
   section/paragraph/run/table/image/control/equation/chart counts and their deltas.
 

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,10 @@
 
 ---
 
+## 2026-08-23 (Codex sol) · #158 PR #159
+- commit `5b57498` push, PR #159(`Closes #158`, `Refs #94 #87 #95`) 게시.
+- 다음 required CI/review 감시→green 자율 병합→PARA_HEADER 0x42 child issue.
+
 ## 2026-08-23 (Codex sol) · #158 full green
 - support-pool final security/diff review; production/rhwp/generated diff 0.
 - full Rust/PDF/8·18·24/wasm/JS/Vitest 1,018 + Chromium 85 pass/3 skip/0 fail.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,26 @@
 
 ---
 
+## 2026-08-23 (Codex sol) · #158 full green
+- support-pool final security/diff review; production/rhwp/generated diff 0.
+- full Rust/PDF/8·18·24/wasm/JS/Vitest 1,018 + Chromium 85 pass/3 skip/0 fail.
+- 다음 commit/push/PR/CI/병합→benchmark PARA_HEADER 0x42 child issue.
+
+## 2026-08-23 (Codex sol) · #158 quick green
+- strict length/ref/security review; unknown fill/style and active unsupported semantics fail closed.
+- workspace/PDF51/8·18·24+98.9/corpus84/oracle82/HWPX/wasm/licenses quick green.
+- 다음 full→final diff→commit/PR/CI/병합; production/rhwp/generated diff 0.
+
+## 2026-08-23 (Codex sol) · #158 support pools focused green
+- strict BORDER_FILL/TAB_DEF/NUMBERING/BULLET + inert/active usage gates; benchmark 0x19→0x42.
+- 합성 정상/적대 7건 추가, hwp-hwp5 34 tests, clippy, wasm32 green.
+- 다음 quick/security/full→commit/PR/CI/병합; production/rhwp 불변.
+
+## 2026-08-23 (Codex sol) · PR #157 병합 → #158 착수
+- #157 required CI/CLEAN·댓글 0 확인 후 main `82ca4e6` 병합; #156 close·원격 브랜치 정리.
+- #94 완료 근거 동기화, benchmark 다음 경계 기준 child #158 생성·latest-main worktree 시작.
+- 다음 strict support pools + honest active-use gates; production/rhwp 불변.
+
 ## 2026-08-23 (Codex sol) · #156 PR #157
 - commit `01b637c` push, PR #157(`Closes #156`, `Refs #94 #87`) 게시.
 - 다음 required CI/review 감시→green 자율 병합→#94 next first-party child.


### PR DESCRIPTION
## Summary
- parse HWP5 BORDER_FILL, TAB_DEF, NUMBERING, and BULLET pools in the first-party lane with exact payload and reference validation
- map only owned border/shade/diagonal semantics into the shared IR; refuse unknown fills and active custom tabs/lists instead of flattening them
- advance the public benchmark own-parser boundary from DocInfo PARA_SHAPE tag 0x19 to BodyText PARA_HEADER tag 0x42 without rhwp fallback

## Boundaries
- no production HWP5 route cutover
- no external/rhwp modification or fallback
- HWP 5.1 levels 8-10 are structurally consumed; active numbering remains fail-closed until those semantics are independently owned
- errors remain content-free and contain only tag/section/offset/span context

## Verification
- cargo test -p hwp-hwp5: 34 passed
- cargo clippy -p hwp-hwp5 --all-targets -- -D warnings
- scripts/verify-local.sh: green
- PW_PORT=31858 scripts/verify-local.sh --full: green
- canonical 8/18/24 and line accuracy 98.9%+; PDF visual 51; corpus safety 84; oracle 82
- Vitest 1,018 passed; Chromium 85 passed, 3 intentional skipped, 0 failed
- production route, generated assets, and external/rhwp diff: 0

Closes #158
Refs #94 #87 #95