### PR TITLE
feat: own HWP5 STYLE pool and content-free header diagnostics

### DIFF
--- a/crates/hwp-hwp5/src/lib.rs
+++ b/crates/hwp-hwp5/src/lib.rs
@@ -62,13 +62,14 @@ pub enum Error {
         offset: usize,
     },
     #[error(
-        "unsupported text-only HWP5 record tag {tag:#x} at section {section} bytes {start}..{end}"
+        "unsupported text-only HWP5 record tag {tag:#x} at section {section} bytes {start}..{end}: {reason}"
     )]
     UnsupportedBodyRecord {
         tag: u16,
         section: usize,
         start: usize,
         end: usize,
+        reason: &'static str,
     },
     #[error("decompressed HWP5 data exceeds {limit}-byte limit")]
     DecompressedLimit { limit: u64 },

--- a/crates/hwp-hwp5/src/semantic.rs
+++ b/crates/hwp-hwp5/src/semantic.rs
@@ -49,6 +49,7 @@ struct Pools {
     para_shapes: Vec<ParaShape>,
     para_usage: Vec<ParaUsage>,
     border_fills: Vec<BorderFillDef>,
+    styles: Vec<StyleDef>,
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -72,6 +73,14 @@ struct NumberingDef {
 #[derive(Clone, Debug, Default)]
 struct BulletDef {
     char_shape_ref: u32,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct StyleDef {
+    kind: u8,
+    next_style: u8,
+    para_shape: u16,
+    char_shape: u16,
 }
 
 pub(crate) fn parse_text_only(bytes: &[u8]) -> Result<SemanticDoc> {
@@ -108,8 +117,12 @@ pub(crate) fn parse_text_only(bytes: &[u8]) -> Result<SemanticDoc> {
         doc.header_pools.border.insert((index + 1) as u64, border);
     }
     for stream in section_streams {
-        doc.sections
-            .push(parse_section(stream, &doc, &pools.para_usage)?);
+        doc.sections.push(parse_section(
+            stream,
+            &doc,
+            &pools.para_usage,
+            &pools.styles,
+        )?);
     }
     Ok(doc)
 }
@@ -212,6 +225,21 @@ fn parse_pools(inspected: &Hwp5Probe) -> Result<Pools> {
         })
         .collect::<Result<Vec<_>>>()?;
     let (para_shapes, para_usage): (Vec<_>, Vec<_>) = parsed_para_shapes.into_iter().unzip();
+    let style_records: Vec<&Record> = stream
+        .records
+        .iter()
+        .filter(|record| record.tag == TAG_STYLE)
+        .collect();
+    let styles = style_records
+        .iter()
+        .map(|record| parse_style(data(stream, record), record))
+        .collect::<Result<Vec<_>>>()?;
+    validate_style_refs(
+        &styles,
+        &style_records,
+        para_shapes.len(),
+        char_shapes.len(),
+    )?;
 
     Ok(Pools {
         section_count,
@@ -219,7 +247,90 @@ fn parse_pools(inspected: &Hwp5Probe) -> Result<Pools> {
         para_shapes,
         para_usage,
         border_fills,
+        styles,
     })
+}
+
+fn parse_style(bytes: &[u8], record: &Record) -> Result<StyleDef> {
+    let mut reader = Reader::new(bytes);
+    reader
+        .hwp_string()
+        .ok_or_else(|| malformed(record, None, "STYLE local name is invalid UTF-16"))?;
+    reader
+        .hwp_string()
+        .ok_or_else(|| malformed(record, None, "STYLE English name is invalid UTF-16"))?;
+    let attr = reader
+        .u8()
+        .ok_or_else(|| malformed(record, None, "STYLE metadata is truncated"))?;
+    if attr & !0x07 != 0 || attr & 0x07 > 1 {
+        return Err(malformed(
+            record,
+            None,
+            "STYLE has an unknown kind or attributes",
+        ));
+    }
+    let next_style = reader
+        .u8()
+        .ok_or_else(|| malformed(record, None, "STYLE metadata is truncated"))?;
+    reader
+        .u16()
+        .ok_or_else(|| malformed(record, None, "STYLE language id is truncated"))?;
+    let para_shape = reader
+        .u16()
+        .ok_or_else(|| malformed(record, None, "STYLE paragraph-shape ref is truncated"))?;
+    let char_shape = reader
+        .u16()
+        .ok_or_else(|| malformed(record, None, "STYLE character-shape ref is truncated"))?;
+    match reader.remaining() {
+        0 => {}
+        2 if reader.u16() == Some(0) => {}
+        2 => return Err(malformed(record, None, "STYLE reserved tail is nonzero")),
+        _ => return Err(malformed(record, None, "STYLE has unknown trailing bytes")),
+    }
+    Ok(StyleDef {
+        kind: attr & 0x07,
+        next_style,
+        para_shape,
+        char_shape,
+    })
+}
+
+fn validate_style_refs(
+    styles: &[StyleDef],
+    records: &[&Record],
+    para_shapes: usize,
+    char_shapes: usize,
+) -> Result<()> {
+    for (style, record) in styles.iter().zip(records.iter().copied()) {
+        if style.next_style as usize >= styles.len() {
+            return Err(invalid_pool_ref(
+                "next style",
+                style.next_style as usize,
+                styles.len(),
+                record,
+            ));
+        }
+        match style.kind {
+            0 if style.para_shape as usize >= para_shapes => {
+                return Err(invalid_pool_ref(
+                    "style paragraph shape",
+                    style.para_shape as usize,
+                    para_shapes,
+                    record,
+                ));
+            }
+            1 if style.char_shape as usize >= char_shapes => {
+                return Err(invalid_pool_ref(
+                    "style character shape",
+                    style.char_shape as usize,
+                    char_shapes,
+                    record,
+                ));
+            }
+            _ => {}
+        }
+    }
+    Ok(())
 }
 
 fn parse_id_mappings(bytes: &[u8], record: &Record) -> Result<IdMappings> {
@@ -813,6 +924,7 @@ fn parse_section(
     stream: &StreamProbe,
     doc: &SemanticDoc,
     para_usage: &[ParaUsage],
+    styles: &[StyleDef],
 ) -> Result<Section> {
     let section = stream.section.expect("caller selected section streams");
     let mut blocks = Vec::new();
@@ -831,6 +943,7 @@ fn parse_section(
             section,
             start: stream.records.first().map_or(0, |record| record.head),
             end: stream.records.first().map_or(0, |record| record.end),
+            reason: "section has no top-level paragraph header",
         });
     }
     if starts[0] != 0 {
@@ -847,6 +960,7 @@ fn parse_section(
             &stream.records[start..end],
             doc,
             para_usage,
+            styles,
             section,
         )?;
         if let Some(parsed_page) = parsed.page {
@@ -881,6 +995,7 @@ fn parse_paragraph(
     records: &[Record],
     doc: &SemanticDoc,
     para_usage: &[ParaUsage],
+    styles: &[StyleDef],
     section: usize,
 ) -> Result<ParsedParagraph> {
     let header = records[0];
@@ -900,8 +1015,44 @@ fn parse_paragraph(
     let declared_char_shapes = read_u16(header_data, 12).expect("base length checked") as usize;
     let declared_range_tags = read_u16(header_data, 14).expect("base length checked");
     let declared_line_segments = read_u16(header_data, 16).expect("base length checked");
-    if style_id != 0 || break_type & !0x04 != 0 || declared_range_tags != 0 {
-        return Err(unsupported(header, section));
+    if (styles.is_empty() && style_id != 0)
+        || (!styles.is_empty() && style_id as usize >= styles.len())
+    {
+        return Err(Error::InvalidReference {
+            kind: "paragraph style",
+            index: style_id as usize,
+            pool_len: styles.len(),
+            section: Some(section),
+            offset: header.head,
+        });
+    }
+    if break_type & 0x02 != 0 {
+        return Err(unsupported_reason(
+            header,
+            section,
+            "multi-column break is not owned",
+        ));
+    }
+    if break_type & 0x08 != 0 {
+        return Err(unsupported_reason(
+            header,
+            section,
+            "column break is not owned",
+        ));
+    }
+    if break_type & !0x0f != 0 {
+        return Err(unsupported_reason(
+            header,
+            section,
+            "paragraph break type has unknown bits",
+        ));
+    }
+    if declared_range_tags != 0 {
+        return Err(unsupported_reason(
+            header,
+            section,
+            "paragraph range tags are not owned",
+        ));
     }
     if para_shape_id + 1 >= doc.para_shapes.len() {
         return Err(Error::InvalidReference {
@@ -1007,6 +1158,13 @@ fn parse_paragraph(
             ))
         }
     };
+    if break_type & 0x01 != 0 && page.is_none() {
+        return Err(unsupported_reason(
+            header,
+            section,
+            "section break has no matching section definition",
+        ));
+    }
     let refs = match shape_record {
         Some(record) => parse_shape_refs(data(stream, &record), record, section, doc)?,
         None => Vec::new(),
@@ -1614,11 +1772,16 @@ fn malformed(record: &Record, section: Option<usize>, reason: &'static str) -> E
 }
 
 fn unsupported(record: Record, section: usize) -> Error {
+    unsupported_reason(record, section, "record semantics are not owned")
+}
+
+fn unsupported_reason(record: Record, section: usize, reason: &'static str) -> Error {
     Error::UnsupportedBodyRecord {
         tag: record.tag,
         section,
         start: record.head,
         end: record.end,
+        reason,
     }
 }
 
@@ -1846,6 +2009,94 @@ mod support_pool_tests {
             bytes.extend_from_slice(&1u32.to_le_bytes());
         }
         bytes
+    }
+
+    fn style(kind: u8, next_style: u8, para_shape: u16, char_shape: u16) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&1u16.to_le_bytes());
+        bytes.extend_from_slice(&('가' as u16).to_le_bytes());
+        bytes.extend_from_slice(&1u16.to_le_bytes());
+        bytes.extend_from_slice(&('A' as u16).to_le_bytes());
+        bytes.push(kind);
+        bytes.push(next_style);
+        bytes.extend_from_slice(&1042u16.to_le_bytes());
+        bytes.extend_from_slice(&para_shape.to_le_bytes());
+        bytes.extend_from_slice(&char_shape.to_le_bytes());
+        bytes
+    }
+
+    #[test]
+    fn style_parses_exact_base_and_observed_zero_tail() {
+        let bytes = style(0, 0, 0, 0);
+        let parsed = parse_style(&bytes, &record(TAG_STYLE, bytes.len())).unwrap();
+        assert_eq!(parsed.kind, 0);
+        assert_eq!(parsed.next_style, 0);
+        assert_eq!(parsed.para_shape, 0);
+
+        let mut tailed = bytes;
+        tailed.extend_from_slice(&0u16.to_le_bytes());
+        assert!(parse_style(&tailed, &record(TAG_STYLE, tailed.len())).is_ok());
+        let last = tailed.len() - 1;
+        tailed[last] = 1;
+        assert!(matches!(
+            parse_style(&tailed, &record(TAG_STYLE, tailed.len())),
+            Err(Error::MalformedRecord {
+                reason: "STYLE reserved tail is nonzero",
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn style_rejects_hostile_lengths_unknown_kinds_and_bad_refs() {
+        let hostile = [0xff, 0xff];
+        assert!(matches!(
+            parse_style(&hostile, &record(TAG_STYLE, hostile.len())),
+            Err(Error::MalformedRecord {
+                reason: "STYLE local name is invalid UTF-16",
+                ..
+            })
+        ));
+
+        let unknown = style(2, 0, 0, 0);
+        assert!(matches!(
+            parse_style(&unknown, &record(TAG_STYLE, unknown.len())),
+            Err(Error::MalformedRecord {
+                reason: "STYLE has an unknown kind or attributes",
+                ..
+            })
+        ));
+
+        let source = record(TAG_STYLE, 0);
+        assert!(validate_style_refs(
+            &[StyleDef {
+                kind: 0,
+                next_style: 0,
+                para_shape: 0,
+                char_shape: 0,
+            }],
+            &[&source],
+            1,
+            1,
+        )
+        .is_ok());
+        assert!(matches!(
+            validate_style_refs(
+                &[StyleDef {
+                    kind: 1,
+                    next_style: 2,
+                    para_shape: 0,
+                    char_shape: 0,
+                }],
+                &[&source],
+                1,
+                1,
+            ),
+            Err(Error::InvalidReference {
+                kind: "next style",
+                ..
+            })
+        ));
     }
 
     #[test]

--- a/crates/hwp-hwp5/tests/public_probe.rs
+++ b/crates/hwp-hwp5/tests/public_probe.rs
@@ -36,6 +36,9 @@ fn explicit_own_parser_never_falls_back() {
         Error::UnsupportedBodyRecord {
             tag: 0x42,
             section: 0,
+            start: 0,
+            end: 28,
+            reason: "multi-column break is not owned",
             ..
         }
     ));

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,6 +3,41 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
+- 갱신: 2026-08-23 · Codex(sol) — **#160 전체 검증 완료 · PR 준비**.
+  strict STYLE/content-free header diagnostics와 #161 다단 blocker 분리를 최종 security/diff review했다.
+  STYLE 이름은 strict UTF-16 확인 후 폐기하고, 참조는 linear 검증하며 unsupported reason은 정적 문자열과
+  tag·section·span만 포함한다. focused hwp-hwp5 **36 tests**, clippy, wasm32와 quick 전체가 green이고,
+  full은 Rust/PDF51/canonical **8/18/24·98.9%+**/corpus84/oracle82/HWPX/wasm/licenses, JS build,
+  Vitest **1,018**, 실제 Chromium **85 pass/3 intentional skip/0 fail**을 통과했다. 임시 링크 제거 후
+  production route, generated asset, `external/rhwp` diff 0. **다음:** commit/push/PR #160→필수 CI·댓글
+  확인→green 자율 병합→#161 column IR/LOCKSTEP 구현.
+
+- 갱신: 2026-08-23 · Codex(sol) — **#160 quick 전체 green**.
+  strict STYLE/ref와 content-free break reason의 security/diff review에서 STYLE 문자열은 검증 후 폐기되고,
+  next/active shape ref는 linear pass로 범위 확인하며 unknown attr/tail·standalone/compound multi-column·column·
+  range tag는 거부한다. 첫 quick은 코드가 아닌 완료 worktree build cache 누적으로 117MiB만 남아 PDF parity
+  compile에서 ENOSPC였고, 병합 완료 #156/#158의 Cargo 산출물만 `cargo clean`해 21GiB를 회수했다.
+  재실행한 quick 전체는 workspace tests, PDF 51/parity, canonical **8/18/24·98.9%+**, corpus 84,
+  oracle 82, HWPX locks, wasm32, licenses가 green이다. `external/rhwp`/generated/production route diff 0.
+  **다음:** full→final diff→commit/PR/CI/병합; 이후 #161 column IR/LOCKSTEP.
+
+- 갱신: 2026-08-23 · Codex(sol) — **#160 STYLE focused green · 다단 blocker #161 분리**.
+  공개 benchmark의 `PARA_HEADER 0x42/section0/0..28` 원인은 content-free 분해 결과
+  `multi-column break`다. 현재 `PageSetup.columns`를 두 paginator가 소비하지 않아 rhwp의 section-priority를
+  모방하는 것은 거짓 지원이므로 거부를 유지하고, shared IR·`place_doc`/`NaiveLayout` LOCKSTEP 범위를
+  #161로 issue-first 분리했다. #160은 strict UTF-16 STYLE, kind/next/active shape ref, 기본 record와
+  실측 optional zero tail을 소유하고 paragraph style ref 및 break/range 사유를 정적으로 분류한다.
+  hwp-hwp5 **36 tests** green, 공개 경계는 정확한 reason으로 잠겼다. **다음:** clippy/wasm→quick/security/full→
+  commit/PR/CI/병합. production route와 `external/rhwp`는 불변이다.
+
+- 갱신: 2026-08-23 · Codex(sol) — **PR #159 병합 · #160 STYLE/PARA_HEADER slice 착수**.
+  #159는 head `1df8e2f`에서 issue-link·build-test 6m37s·licenses green, CLEAN/MERGEABLE,
+  리뷰/일반/인라인 댓글 0을 확인한 뒤 main `40026f6`으로 squash 병합했고 #158이 close됐다.
+  원격 브랜치를 정리하고 #94에 완료 근거를 동기화했다. 공개 benchmark의 다음 경계
+  `PARA_HEADER tag 0x42 start 0 end 28`을 계약으로 child #160을 만들고 정확한 최신 main에서
+  `codex/issue-160-hwp5-style`을 시작했다. **다음:** content-free 원인 분해→strict STYLE pool과
+  owned style/break refs; columns/range tags는 fail-closed. production route와 `external/rhwp`는 불변이다.
+
 - 갱신: 2026-08-23 · Codex(sol) — **#158 PR #159 게시**.
   검증 완료 commit `5b57498`을 push하고 PR #159(`Closes #158`, `Refs #94 #87 #95`)을 만들었다.
   exact support-pool parsing, active unsupported fail-closed, public boundary `0x19→0x42`, no production

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,6 +3,13 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
+- 갱신: 2026-08-23 · Codex(sol) — **#160 PR #162 게시**.
+  검증 완료 commit `75f5ad5`를 push하고 PR #162(`Closes #160`, `Refs #94 #158 #161`)를 만들었다.
+  strict STYLE, content-free failure reasons, public multi-column boundary, #161 faithful column dependency,
+  no production cutover/no rhwp fallback과 quick/full/Chromium 85 pass·3 intentional skip·generated/rhwp
+  diff 0을 본문에 명시했다. **다음:** 이 상태 commit push→issue-link/build-test/licenses·mergeability·
+  review/comment를 추적하고 전부 green이면 자율 병합·원격 브랜치 정리→#161 구현을 시작한다.
+
 - 갱신: 2026-08-23 · Codex(sol) — **#160 전체 검증 완료 · PR 준비**.
   strict STYLE/content-free header diagnostics와 #161 다단 blocker 분리를 최종 security/diff review했다.
   STYLE 이름은 strict UTF-16 확인 후 폐기하고, 참조는 linear 검증하며 unsupported reason은 정적 문자열과

--- a/docs/HWP5-NATIVE-PARSER.md
+++ b/docs/HWP5-NATIVE-PARSER.md
@@ -1,16 +1,20 @@
 # First-party HWP5 parser boundary
 
 Issue #107 introduced the first owned binary-HWP layer; issue #154 added its first semantic slice,
-issue #156 added the minimum source-layout facts needed by the shared typesetter, and issue #158
-owns the paragraph support-pool boundary. None of these slices changes production parsing.
+issue #156 added the minimum source-layout facts needed by the shared typesetter, issue #158 owns
+the paragraph support-pool boundary, and issue #160 owns DocInfo styles plus content-free paragraph
+header refusal reasons. None of these slices changes production parsing.
 
 ## What is owned now
 
 `crates/hwp-hwp5` parses the CFB `FileHeader`, exposes every documented property/security flag,
 walks `DocInfo` and `BodyText/SectionN` records, and preserves unknown records as `(tag, level,
 size, header/data/end offsets, extended-header bit)`. It also decodes the strict DocInfo font,
-character-shape, paragraph-shape, border-fill, tab-definition, numbering, and bullet pools plus direct
-paragraph text and character-shape runs into `SemanticDoc`. Known binary border edges, solid shade,
+character-shape, paragraph-shape, border-fill, tab-definition, numbering, bullet, and style pools plus
+direct paragraph text and character-shape runs into `SemanticDoc`. STYLE names are validated as strict
+UTF-16 but not copied into telemetry; kind, next-style, and the active para/character-shape reference
+are range checked. The documented STYLE base and the observed optional zero reserved tail are accepted;
+nonzero or unknown tails fail closed. Known binary border edges, solid shade,
 and diagonal directions map to the shared `BorderFillDef`; unknown line values and image, gradient,
 patterned, alpha, or mixed fills are refused rather than flattened. Paragraph references are range
 checked. A pool that is merely present is not treated as active: custom tabs, numbering/bullets, and
@@ -45,8 +49,11 @@ rejected instead of being interpreted as records.
 - `open_hwp5_own`: explicit first-party-only route. It returns a `SemanticDoc` only for the owned
   text plus single-sided page-setup subset. Tables, images, fields, notes, equations, charts,
   columns, decorations, page border/fill, duplex binding, active custom tabs/lists/paragraph borders,
-  unknown body controls, and unsupported pool values fail closed with tag, section, and byte span
-  only. It cannot call rhwp.
+  unknown body controls, and unsupported pool values fail closed with a static reason plus tag,
+  section, and byte span only. It cannot call rhwp. The public benchmark currently stops at a
+  multi-column paragraph header (`0x42`, section 0, bytes 0..28): accepting it would be dishonest
+  because section columns are not yet consumed by both paginators. Issue #161 owns that IR and
+  LOCKSTEP typesetting dependency.
 - `hwp5_differential`: explicitly runs the owned probe and current rhwp semantic oracle, then reports
   section/paragraph/run/table/image/control/equation/chart counts and their deltas.
 

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,10 @@
 
 ---
 
+## 2026-08-23 (Codex sol) · #160 PR #162
+- commit `75f5ad5` push, PR #162(`Closes #160`, `Refs #94 #158 #161`) 게시.
+- 다음 required CI/review 감시→green 자율 병합→#161 column IR/LOCKSTEP.
+
 ## 2026-08-23 (Codex sol) · #160 full green
 - strict STYLE/content-free diagnostics final review; production/rhwp/generated diff 0.
 - full Rust/PDF/8·18·24/wasm/JS/Vitest 1,018 + Chromium 85 pass/3 skip/0 fail.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,26 @@
 
 ---
 
+## 2026-08-23 (Codex sol) · #160 full green
+- strict STYLE/content-free diagnostics final review; production/rhwp/generated diff 0.
+- full Rust/PDF/8·18·24/wasm/JS/Vitest 1,018 + Chromium 85 pass/3 skip/0 fail.
+- 다음 commit/push/PR/CI/병합→#161 column IR/LOCKSTEP.
+
+## 2026-08-23 (Codex sol) · #160 quick green
+- 완료 worktree Cargo cache만 clean해 ENOSPC 해소; 사용자/소스 파일 불변.
+- workspace/PDF51/8·18·24+98.9/corpus84/oracle82/HWPX/wasm/licenses green.
+- 다음 full→final diff→commit/PR/CI/병합; 이후 #161 column IR/LOCKSTEP.
+
+## 2026-08-23 (Codex sol) · #160 STYLE focused green
+- public PARA_HEADER 원인은 multi-column; 거짓 허용 없이 shared IR/LOCKSTEP #161로 분리.
+- strict STYLE + content-free reason/ref gates, hwp-hwp5 36 tests green.
+- 다음 clippy/wasm→quick/security/full→commit/PR/CI/병합; production/rhwp 불변.
+
+## 2026-08-23 (Codex sol) · PR #159 병합 → #160 착수
+- #159 required CI/CLEAN·댓글 0 확인 후 main `40026f6` 병합; #158 close·원격 branch 정리.
+- #94 완료 근거 동기화, benchmark PARA_HEADER 0x42 기준 child #160 생성·latest-main 시작.
+- 다음 content-free 원인 분해→strict STYLE/owned break refs; production/rhwp 불변.
+
 ## 2026-08-23 (Codex sol) · #158 PR #159
 - commit `5b57498` push, PR #159(`Closes #158`, `Refs #94 #87 #95`) 게시.
 - 다음 required CI/review 감시→green 자율 병합→PARA_HEADER 0x42 child issue.


### PR DESCRIPTION
## Summary
- strictly parse HWP5 STYLE records, validate UTF-16 names without retaining them in telemetry, and range-check next-style plus active shape references
- accept only the documented base or the observed optional zero reserved tail; reject unknown attributes, hostile lengths, bad refs, nonzero tails, and trailing bytes
- add static content-free reasons to unsupported body records and lock the public benchmark boundary as a multi-column PARA_HEADER at section 0 bytes 0..28
- split faithful column IR and place_doc/NaiveLayout LOCKSTEP work into #161 instead of silently treating multi-column content as one column

## Boundaries
- no production HWP5 route cutover
- no external/rhwp modification or fallback
- multi-column, column, and range-tag semantics remain fail-closed
- errors contain only static reason plus tag/section/offset/span metadata

## Verification
- cargo test -p hwp-hwp5: 36 passed
- cargo clippy -p hwp-hwp5 --all-targets -- -D warnings
- cargo check -p hwp-hwp5 --target wasm32-unknown-unknown
- scripts/verify-local.sh: green
- PW_PORT=31860 scripts/verify-local.sh --full: green
- canonical 8/18/24 and line accuracy 98.9%+; PDF visual 51; corpus safety 84; oracle 82
- Vitest 1,018 passed; Chromium 85 passed, 3 intentional skipped, 0 failed
- production route, generated assets, and external/rhwp diff: 0

Closes #160
Refs #94 #158 #161