### PR TITLE
feat: own HWP5 multi-column layout

### DIFF
--- a/crates/hwp-export/src/pdf.rs
+++ b/crates/hwp-export/src/pdf.rs
@@ -1160,6 +1160,33 @@ mod tests {
     }
 
     #[test]
+    fn column_separator_replays_from_the_same_paint_tree_in_pdf() {
+        let mut paragraph = para("왼쪽 단");
+        paragraph.column_layout_before = Some(ColumnLayout {
+            widths: vec![20_000, 20_000],
+            gaps: vec![2_000],
+            separator: Some(ColumnSeparator {
+                color: Color {
+                    r: 12,
+                    g: 34,
+                    b: 56,
+                    a: 255,
+                },
+                style: LineStyle::Dashed,
+                width_px: 0.5,
+            }),
+            ..ColumnLayout::default()
+        });
+        let doc = doc_with(vec![Block::Paragraph(paragraph)]);
+
+        let out = export_pdf(&doc, &ApproxFontMetrics, &PdfOptions::default()).unwrap();
+        assert_eq!(out.pages, 1);
+        assert_eq!(out.replay[0].table_geometry.produced, 1);
+        assert_eq!(out.replay[0].table_geometry.replayed, 1);
+        assert_eq!(out.replay[0].table_geometry.stubbed, 0);
+    }
+
+    #[test]
     fn empty_doc_still_makes_a_pdf() {
         let doc = doc_with(vec![Block::Paragraph(para(""))]);
         let out = export_pdf(&doc, &ApproxFontMetrics, &PdfOptions::default()).unwrap();

--- a/crates/hwp-hwp5/src/semantic.rs
+++ b/crates/hwp-hwp5/src/semantic.rs
@@ -22,6 +22,7 @@ const TAG_CTRL_HEADER: u16 = 0x47;
 const TAG_PAGE_DEF: u16 = 0x49;
 
 const CTRL_SECTION_DEF: u32 = u32::from_be_bytes(*b"secd");
+const CTRL_COLUMN_DEF: u32 = u32::from_be_bytes(*b"cold");
 
 #[derive(Clone, Copy, Debug, Default)]
 struct IdMappings {
@@ -929,6 +930,9 @@ fn parse_section(
     let section = stream.section.expect("caller selected section streams");
     let mut blocks = Vec::new();
     let mut page = None;
+    let mut has_active_columns = false;
+    let mut column_zone_count = 0usize;
+    let mut separator_zone_seen = false;
     let starts: Vec<usize> = stream
         .records
         .iter()
@@ -962,6 +966,7 @@ fn parse_section(
             para_usage,
             styles,
             section,
+            page.as_ref(),
         )?;
         if let Some(parsed_page) = parsed.page {
             if ordinal != 0 || page.replace(parsed_page).is_some() {
@@ -971,6 +976,36 @@ fn parse_section(
                     "section definition may occur only once and only in the first paragraph",
                 ));
             }
+        }
+        if parsed.paragraph.column_break_before
+            && parsed.paragraph.column_layout_before.is_none()
+            && !has_active_columns
+        {
+            return Err(malformed(
+                &stream.records[start],
+                Some(section),
+                "column break appears before an owned column definition",
+            ));
+        }
+        if let Some(layout) = &parsed.paragraph.column_layout_before {
+            let has_separator = layout.separator.is_some();
+            if has_separator && ordinal != 0 {
+                return Err(malformed(
+                    &stream.records[start],
+                    Some(section),
+                    "column separator zone must begin with its section",
+                ));
+            }
+            if column_zone_count != 0 && (separator_zone_seen || has_separator) {
+                return Err(malformed(
+                    &stream.records[start],
+                    Some(section),
+                    "multiple column zones with separators are not yet supported",
+                ));
+            }
+            column_zone_count += 1;
+            separator_zone_seen |= has_separator;
+            has_active_columns = true;
         }
         blocks.push(Block::Paragraph(parsed.paragraph));
     }
@@ -997,6 +1032,7 @@ fn parse_paragraph(
     para_usage: &[ParaUsage],
     styles: &[StyleDef],
     section: usize,
+    _current_page: Option<&PageSetup>,
 ) -> Result<ParsedParagraph> {
     let header = records[0];
     let header_data = data(stream, &header);
@@ -1025,20 +1061,6 @@ fn parse_paragraph(
             section: Some(section),
             offset: header.head,
         });
-    }
-    if break_type & 0x02 != 0 {
-        return Err(unsupported_reason(
-            header,
-            section,
-            "multi-column break is not owned",
-        ));
-    }
-    if break_type & 0x08 != 0 {
-        return Err(unsupported_reason(
-            header,
-            section,
-            "column break is not owned",
-        ));
     }
     if break_type & !0x0f != 0 {
         return Err(unsupported_reason(
@@ -1076,7 +1098,7 @@ fn parse_paragraph(
     let mut text_record = None;
     let mut shape_record = None;
     let mut line_record = None;
-    let mut section_control = None;
+    let mut structural_controls = Vec::new();
     let mut cursor = 1usize;
     while cursor < records.len() {
         let record = records[cursor];
@@ -1087,8 +1109,15 @@ fn parse_paragraph(
             TAG_PARA_TEXT if text_record.is_none() => text_record = Some(record),
             TAG_PARA_CHAR_SHAPE if shape_record.is_none() => shape_record = Some(record),
             TAG_PARA_LINE_SEG if line_record.is_none() => line_record = Some(record),
-            TAG_CTRL_HEADER if section_control.is_none() => {
-                if read_u32(data(stream, &record), 0) != Some(CTRL_SECTION_DEF) {
+            TAG_CTRL_HEADER => {
+                let Some(control_id) = read_u32(data(stream, &record), 0) else {
+                    return Err(malformed(
+                        &record,
+                        Some(section),
+                        "structural CTRL_HEADER is shorter than its control id",
+                    ));
+                };
+                if !matches!(control_id, CTRL_SECTION_DEF | CTRL_COLUMN_DEF) {
                     return Err(unsupported(record, section));
                 }
                 let start = cursor;
@@ -1096,7 +1125,7 @@ fn parse_paragraph(
                 while cursor < records.len() && records[cursor].level > 1 {
                     cursor += 1;
                 }
-                section_control = Some((&records[start], &records[start + 1..cursor]));
+                structural_controls.push((&records[start], &records[start + 1..cursor]));
                 continue;
             }
             _ => return Err(unsupported(record, section)),
@@ -1129,35 +1158,54 @@ fn parse_paragraph(
         ));
     }
     validate_para_usage(usage, &decoded, doc, &header, section)?;
-    let page = match (decoded.section_controls.as_slice(), section_control) {
-        ([], None) => None,
-        ([(marker_offset, marker_id)], Some((control, children)))
-            if *marker_id == CTRL_SECTION_DEF =>
-        {
-            if *marker_offset != 0 {
-                return Err(malformed(
-                    control,
-                    Some(section),
-                    "section definition marker is not at paragraph start",
-                ));
-            }
-            Some(parse_section_control(stream, control, children, section)?)
-        }
-        (_, Some((control, _))) => {
+    if decoded.structural_controls.len() != structural_controls.len() {
+        return Err(malformed(
+            &header,
+            Some(section),
+            "PARA_TEXT structural markers do not match CTRL_HEADER records",
+        ));
+    }
+    let mut page = None;
+    let mut raw_columns = None;
+    for ((marker_offset, marker_id), (control, children)) in
+        decoded.structural_controls.iter().zip(structural_controls)
+    {
+        let actual_id = read_u32(data(stream, control), 0).expect("control id checked above");
+        if *marker_id != actual_id {
             return Err(malformed(
                 control,
                 Some(section),
-                "section control header does not match PARA_TEXT marker",
-            ))
+                "structural control header does not match PARA_TEXT marker",
+            ));
         }
-        (_, None) => {
-            return Err(malformed(
-                &header,
-                Some(section),
-                "PARA_TEXT section marker has no section control header",
-            ))
+        match actual_id {
+            CTRL_SECTION_DEF => {
+                if *marker_offset != 0 || page.is_some() {
+                    return Err(malformed(
+                        control,
+                        Some(section),
+                        "section definition marker is duplicate or not at paragraph start",
+                    ));
+                }
+                page = Some(parse_section_control(stream, control, children, section)?);
+            }
+            CTRL_COLUMN_DEF => {
+                if !children.is_empty() || raw_columns.is_some() {
+                    return Err(malformed(
+                        control,
+                        Some(section),
+                        "column definition has children or is duplicated",
+                    ));
+                }
+                raw_columns = Some(parse_column_control(
+                    data(stream, control),
+                    control,
+                    section,
+                )?);
+            }
+            _ => unreachable!("structural control id filtered above"),
         }
-    };
+    }
     if break_type & 0x01 != 0 && page.is_none() {
         return Err(unsupported_reason(
             header,
@@ -1165,6 +1213,28 @@ fn parse_paragraph(
             "section break has no matching section definition",
         ));
     }
+    if break_type & 0x02 != 0 && raw_columns.is_none() {
+        return Err(unsupported_reason(
+            header,
+            section,
+            "multi-column break has no owned column definition",
+        ));
+    }
+    let column_layout = match raw_columns {
+        Some(raw) => Some(resolve_columns(
+            raw,
+            page.as_ref().or(_current_page).ok_or_else(|| {
+                malformed(
+                    &header,
+                    Some(section),
+                    "column definition appears before page geometry",
+                )
+            })?,
+            &header,
+            section,
+        )?),
+        None => None,
+    };
     let refs = match shape_record {
         Some(record) => parse_shape_refs(data(stream, &record), record, section, doc)?,
         None => Vec::new(),
@@ -1185,26 +1255,29 @@ fn parse_paragraph(
         &header,
         section,
     )?;
-    Ok(ParsedParagraph {
-        paragraph: Paragraph {
-            para_shape: para_shape_id + 1,
-            page_break_before: break_type & 0x04 != 0,
-            runs,
-            // Stored line boxes are only an authored-height hint for a true blank spacer.
-            // They never dictate line breaks for visible text or a control-host paragraph.
-            source_line_metrics: if decoded.chars.is_empty() && page.is_none() {
-                line_metrics
-            } else {
-                Vec::new()
-            },
-            provenance: Provenance {
-                source: Some(SourceFormat::Hwp5),
-                raw: None,
-            },
-            ..Paragraph::default()
+    let paragraph = Paragraph {
+        para_shape: para_shape_id + 1,
+        page_break_before: break_type & 0x04 != 0,
+        column_break_before: break_type & 0x08 != 0,
+        column_layout_before: column_layout,
+        runs,
+        // Stored line boxes are only an authored-height hint for a true blank spacer.
+        // They never dictate line breaks for visible text or a control-host paragraph.
+        source_line_metrics: if decoded.chars.is_empty() && page.is_none() {
+            line_metrics
+        } else {
+            Vec::new()
         },
-        page,
-    })
+        provenance: Provenance {
+            source: Some(SourceFormat::Hwp5),
+            raw: None,
+        },
+        ..Paragraph::default()
+    };
+    if let (Some(page), Some(layout)) = (&mut page, &paragraph.column_layout_before) {
+        page.columns = u8::try_from(layout.count()).unwrap_or(u8::MAX);
+    }
+    Ok(ParsedParagraph { paragraph, page })
 }
 
 fn validate_para_usage(
@@ -1277,6 +1350,298 @@ fn parse_section_control(
         return Err(unsupported(offending, section));
     }
     parse_page_def(data(stream, &children[0]), &children[0], section)
+}
+
+#[derive(Debug)]
+struct RawColumnLayout {
+    kind: ColumnKind,
+    direction: ColumnDirection,
+    count: usize,
+    equal_gap: Option<u16>,
+    width_weights: Vec<u16>,
+    gap_weights: Vec<u16>,
+    separator: Option<ColumnSeparator>,
+}
+
+/// Strict HWP5 `cold` control parser. The control id is part of `bytes`; all source-specific
+/// proportional values stay private to this stage and are resolved to absolute HWPUNIT by
+/// [`resolve_columns`] before entering the shared IR.
+fn parse_column_control(bytes: &[u8], record: &Record, section: usize) -> Result<RawColumnLayout> {
+    if read_u32(bytes, 0) != Some(CTRL_COLUMN_DEF) {
+        return Err(unsupported(*record, section));
+    }
+    let attr = read_u16(bytes, 4).ok_or_else(|| {
+        malformed(
+            record,
+            Some(section),
+            "column definition is shorter than its attributes",
+        )
+    })?;
+    if attr & 0xe000 != 0 {
+        return Err(malformed(
+            record,
+            Some(section),
+            "column definition has unknown attribute bits",
+        ));
+    }
+    let kind = match attr & 0x03 {
+        0 => ColumnKind::Normal,
+        1 | 2 => {
+            return Err(malformed(
+                record,
+                Some(section),
+                "column distribution kind is not yet supported",
+            ))
+        }
+        _ => {
+            return Err(malformed(
+                record,
+                Some(section),
+                "column definition has an unknown column kind",
+            ))
+        }
+    };
+    let count = ((attr >> 2) & 0xff) as usize;
+    if !(1..=32).contains(&count) {
+        return Err(malformed(
+            record,
+            Some(section),
+            "column definition count is outside the owned range",
+        ));
+    }
+    let direction = match (attr >> 10) & 0x03 {
+        0 => ColumnDirection::LeftToRight,
+        1 => ColumnDirection::RightToLeft,
+        _ => {
+            return Err(malformed(
+                record,
+                Some(section),
+                "column definition direction is not supported",
+            ))
+        }
+    };
+    let same_width = attr & (1 << 12) != 0;
+    let (equal_gap, width_weights, gap_weights, separator_at) = if same_width {
+        if bytes.len() != 16 {
+            return Err(malformed(
+                record,
+                Some(section),
+                "equal-width column definition is not exactly 16 bytes",
+            ));
+        }
+        let gap = read_u16(bytes, 6).expect("exact length checked");
+        if read_u16(bytes, 8) != Some(0) {
+            return Err(malformed(
+                record,
+                Some(section),
+                "column definition has unsupported upper attributes",
+            ));
+        }
+        (Some(gap), Vec::new(), Vec::new(), 10)
+    } else if count == 1 {
+        if bytes.len() != 16 {
+            return Err(malformed(
+                record,
+                Some(section),
+                "single-column definition is not exactly 16 bytes",
+            ));
+        }
+        let gap = read_u16(bytes, 6).expect("exact length checked");
+        if read_u16(bytes, 8) != Some(0) {
+            return Err(malformed(
+                record,
+                Some(section),
+                "column definition has unsupported upper attributes",
+            ));
+        }
+        (Some(gap), Vec::new(), Vec::new(), 10)
+    } else {
+        let expected = 14usize
+            .checked_add(count.checked_mul(4).ok_or_else(|| {
+                malformed(record, Some(section), "column definition length overflows")
+            })?)
+            .ok_or_else(|| {
+                malformed(record, Some(section), "column definition length overflows")
+            })?;
+        if bytes.len() != expected {
+            return Err(malformed(
+                record,
+                Some(section),
+                "unequal-width column definition has an unexpected length",
+            ));
+        }
+        if read_u16(bytes, 6) != Some(0) {
+            return Err(malformed(
+                record,
+                Some(section),
+                "column definition has unsupported upper attributes",
+            ));
+        }
+        let mut widths = Vec::with_capacity(count);
+        let mut gaps = Vec::with_capacity(count.saturating_sub(1));
+        for index in 0..count {
+            let at = 8 + index * 4;
+            let width = read_u16(bytes, at).expect("exact length checked");
+            let gap = read_u16(bytes, at + 2).expect("exact length checked");
+            if width == 0 {
+                return Err(malformed(
+                    record,
+                    Some(section),
+                    "column definition contains a zero width",
+                ));
+            }
+            widths.push(width);
+            if index + 1 == count {
+                if gap != 0 {
+                    return Err(malformed(
+                        record,
+                        Some(section),
+                        "column definition has a trailing gap after the last column",
+                    ));
+                }
+            } else {
+                gaps.push(gap);
+            }
+        }
+        (None, widths, gaps, 8 + count * 4)
+    };
+
+    let line_type = bytes[separator_at];
+    let line_width = bytes[separator_at + 1];
+    let line_color = read_u32(bytes, separator_at + 2).expect("exact length checked");
+    let separator = if line_type == 0 {
+        if line_width != 0 || line_color != 0 {
+            return Err(malformed(
+                record,
+                Some(section),
+                "disabled column separator has nonzero style data",
+            ));
+        }
+        None
+    } else {
+        let style = border_line_style(line_type).ok_or_else(|| {
+            malformed(
+                record,
+                Some(section),
+                "column separator has an unknown line type",
+            )
+        })?;
+        if style == LineStyle::None || line_width > 15 {
+            return Err(malformed(
+                record,
+                Some(section),
+                "column separator has an unknown line width",
+            ));
+        }
+        Some(ColumnSeparator {
+            color: opaque_bgr(line_color),
+            style,
+            width_px: border_width_px(line_width),
+        })
+    };
+    Ok(RawColumnLayout {
+        kind,
+        direction,
+        count,
+        equal_gap,
+        width_weights,
+        gap_weights,
+        separator,
+    })
+}
+
+fn resolve_columns(
+    raw: RawColumnLayout,
+    page: &PageSetup,
+    record: &Record,
+    section: usize,
+) -> Result<ColumnLayout> {
+    let display_width = if page.landscape && page.width < page.height {
+        page.height
+    } else {
+        page.width
+    };
+    let body_width = i64::from(display_width)
+        - i64::from(page.margin_left)
+        - i64::from(page.margin_gutter)
+        - i64::from(page.margin_right);
+    if body_width <= 0 {
+        return Err(malformed(
+            record,
+            Some(section),
+            "column definition has no positive page body width",
+        ));
+    }
+
+    let (mut widths, gaps) = if let Some(gap) = raw.equal_gap {
+        let count = raw.count;
+        let gaps = vec![i32::from(gap); count.saturating_sub(1)];
+        let gap_total = i64::from(gap) * count.saturating_sub(1) as i64;
+        let remaining = body_width - gap_total;
+        if remaining < count as i64 {
+            return Err(malformed(
+                record,
+                Some(section),
+                "column gaps leave no positive column width",
+            ));
+        }
+        let base = remaining / count as i64;
+        let mut widths = vec![base as i32; count];
+        *widths.last_mut().expect("positive count") += (remaining % count as i64) as i32;
+        (widths, gaps)
+    } else {
+        let weight_total = raw
+            .width_weights
+            .iter()
+            .chain(&raw.gap_weights)
+            .map(|value| u64::from(*value))
+            .sum::<u64>();
+        if weight_total == 0 {
+            return Err(malformed(
+                record,
+                Some(section),
+                "column definition has zero total weight",
+            ));
+        }
+        let scale =
+            |value: u16| -> i32 { ((u64::from(value) * body_width as u64) / weight_total) as i32 };
+        let widths = raw
+            .width_weights
+            .iter()
+            .copied()
+            .map(scale)
+            .collect::<Vec<_>>();
+        let gaps = raw
+            .gap_weights
+            .iter()
+            .copied()
+            .map(scale)
+            .collect::<Vec<_>>();
+        (widths, gaps)
+    };
+    let used = widths
+        .iter()
+        .chain(&gaps)
+        .map(|value| i64::from(*value))
+        .sum::<i64>();
+    let residue = body_width - used;
+    if let Some(last) = widths.last_mut() {
+        *last = last.saturating_add(residue as i32);
+    }
+    if widths.iter().any(|width| *width <= 0) {
+        return Err(malformed(
+            record,
+            Some(section),
+            "column definition resolves to a non-positive width",
+        ));
+    }
+    Ok(ColumnLayout {
+        kind: raw.kind,
+        direction: raw.direction,
+        widths,
+        gaps,
+        separator: raw.separator,
+    })
 }
 
 fn parse_page_def(bytes: &[u8], record: &Record, section: usize) -> Result<PageSetup> {
@@ -1449,7 +1814,7 @@ fn parse_line_metrics(
 #[derive(Default)]
 struct DecodedText {
     chars: Vec<(u32, char)>,
-    section_controls: Vec<(u32, u32)>,
+    structural_controls: Vec<(u32, u32)>,
     stored_units: u32,
     inline_control_mask: u32,
 }
@@ -1462,7 +1827,7 @@ impl DecodedText {
                 .binary_search_by_key(&offset, |(start, _)| *start)
                 .is_ok()
             || self
-                .section_controls
+                .structural_controls
                 .binary_search_by_key(&offset, |(start, _)| *start)
                 .is_ok()
     }
@@ -1481,7 +1846,7 @@ fn decode_text(bytes: &[u8], record: Record, section: usize) -> Result<DecodedTe
         .map(|pair| u16::from_le_bytes([pair[0], pair[1]]))
         .collect();
     let mut chars = Vec::new();
-    let mut section_controls = Vec::new();
+    let mut structural_controls = Vec::new();
     let mut cursor = 0usize;
     let mut ended = false;
     let mut inline_control_mask = 0u32;
@@ -1531,10 +1896,10 @@ fn decode_text(bytes: &[u8], record: Record, section: usize) -> Result<DecodedTe
                 let lo = units[cursor + 1].to_le_bytes();
                 let hi = units[cursor + 2].to_le_bytes();
                 let control_id = u32::from_le_bytes([lo[0], lo[1], hi[0], hi[1]]);
-                if control_id != CTRL_SECTION_DEF {
+                if !matches!(control_id, CTRL_SECTION_DEF | CTRL_COLUMN_DEF) {
                     return Err(unsupported(record, section));
                 }
-                section_controls.push((start, control_id));
+                structural_controls.push((start, control_id));
                 inline_control_mask |= 1 << 0x0002;
                 cursor += 8;
             }
@@ -1605,7 +1970,7 @@ fn decode_text(bytes: &[u8], record: Record, section: usize) -> Result<DecodedTe
     }
     Ok(DecodedText {
         chars,
-        section_controls,
+        structural_controls,
         stored_units: units.len() as u32,
         inline_control_mask,
     })

--- a/crates/hwp-hwp5/tests/layout_semantic.rs
+++ b/crates/hwp-hwp5/tests/layout_semantic.rs
@@ -30,6 +30,14 @@ enum Mutation {
     DuplicatePageDef,
     BadControlFrame,
     UnsupportedBinding,
+    Column2,
+    ColumnUnequal,
+    BadColumnPayload,
+    BadColumnTrailingGap,
+    BadColumnDirection,
+    BadColumnKind,
+    ColumnBreakWithoutDefinition,
+    MidSectionSeparator,
 }
 
 #[test]
@@ -177,6 +185,109 @@ fn rejects_non_integral_line_segment_payload() {
     ));
 }
 
+#[test]
+fn parses_equal_width_column_definition_into_absolute_shared_geometry() {
+    let doc = OwnHwp5Parser::new()
+        .parse(&fixture(Mutation::Column2))
+        .expect("owned column fixture parses");
+    let Block::Paragraph(paragraph) = &doc.sections[0].blocks[0] else {
+        panic!("expected paragraph")
+    };
+    let columns = paragraph
+        .column_layout_before
+        .as_ref()
+        .expect("cold control becomes shared geometry");
+    assert_eq!(columns.widths, vec![20_760, 20_760]);
+    assert_eq!(columns.gaps, vec![1_000]);
+    let separator = columns.separator.expect("separator parsed");
+    assert_eq!(separator.style, hwp_model::document::LineStyle::Solid);
+    assert_eq!(separator.color.r, 255);
+    assert_eq!(separator.width_px, 0.5);
+    assert_eq!(doc.sections[0].page.columns, 2);
+}
+
+#[test]
+fn rejects_truncated_column_definition_without_partial_semantics() {
+    assert!(matches!(
+        OwnHwp5Parser::new().parse(&fixture(Mutation::BadColumnPayload)),
+        Err(Error::MalformedRecord {
+            tag: TAG_CTRL_HEADER,
+            section: Some(0),
+            reason: "equal-width column definition is not exactly 16 bytes",
+            ..
+        })
+    ));
+}
+
+#[test]
+fn resolves_unequal_proportional_columns_without_leaking_raw_weights() {
+    let doc = OwnHwp5Parser::new()
+        .parse(&fixture(Mutation::ColumnUnequal))
+        .expect("owned unequal column fixture parses");
+    let Block::Paragraph(paragraph) = &doc.sections[0].blocks[0] else {
+        panic!("expected paragraph")
+    };
+    let columns = paragraph.column_layout_before.as_ref().expect("columns");
+    assert_eq!(columns.widths, vec![6_858, 13_716, 20_576]);
+    assert_eq!(columns.gaps, vec![685, 685]);
+    assert_eq!(
+        columns.widths.iter().sum::<i32>() + columns.gaps.iter().sum::<i32>(),
+        42_520,
+        "absolute geometry exactly fills the page body"
+    );
+}
+
+#[test]
+fn rejects_hostile_unequal_tail_and_unknown_direction() {
+    assert!(matches!(
+        OwnHwp5Parser::new().parse(&fixture(Mutation::BadColumnTrailingGap)),
+        Err(Error::MalformedRecord {
+            reason: "column definition has a trailing gap after the last column",
+            ..
+        })
+    ));
+    assert!(matches!(
+        OwnHwp5Parser::new().parse(&fixture(Mutation::BadColumnDirection)),
+        Err(Error::MalformedRecord {
+            reason: "column definition direction is not supported",
+            ..
+        })
+    ));
+    assert!(matches!(
+        OwnHwp5Parser::new().parse(&fixture(Mutation::BadColumnKind)),
+        Err(Error::MalformedRecord {
+            reason: "column distribution kind is not yet supported",
+            ..
+        })
+    ));
+}
+
+#[test]
+fn rejects_column_break_before_any_owned_column_zone() {
+    assert!(matches!(
+        OwnHwp5Parser::new().parse(&fixture(Mutation::ColumnBreakWithoutDefinition)),
+        Err(Error::MalformedRecord {
+            tag: TAG_PARA_HEADER,
+            section: Some(0),
+            reason: "column break appears before an owned column definition",
+            ..
+        })
+    ));
+}
+
+#[test]
+fn rejects_mid_section_separator_without_owned_vertical_span() {
+    assert!(matches!(
+        OwnHwp5Parser::new().parse(&fixture(Mutation::MidSectionSeparator)),
+        Err(Error::MalformedRecord {
+            tag: TAG_PARA_HEADER,
+            section: Some(0),
+            reason: "column separator zone must begin with its section",
+            ..
+        })
+    ));
+}
+
 fn fixture(mutation: Mutation) -> Vec<u8> {
     let mut header = vec![0; 256];
     header[..HWP_SIGNATURE.len()].copy_from_slice(HWP_SIGNATURE);
@@ -199,11 +310,36 @@ fn fixture(mutation: Mutation) -> Vec<u8> {
 
     let mut body = Vec::new();
     let mut section_text = extended_control(0x0002, CTRL_SECTION_DEF);
+    let has_columns = matches!(
+        mutation,
+        Mutation::Column2
+            | Mutation::ColumnUnequal
+            | Mutation::BadColumnPayload
+            | Mutation::BadColumnTrailingGap
+            | Mutation::BadColumnDirection
+            | Mutation::BadColumnKind
+    );
+    if has_columns {
+        section_text.extend(extended_control(0x0002, u32::from_be_bytes(*b"cold")));
+    }
     if matches!(mutation, Mutation::BadControlFrame) {
         section_text[7] = 0;
     }
     section_text.push(0x000d);
-    push_para_header(&mut body, section_text.len() as u32, 1 << 2, 1, 0);
+    push_para_header_with_break(
+        &mut body,
+        section_text.len() as u32,
+        1 << 2,
+        1,
+        0,
+        if has_columns {
+            0x03
+        } else if matches!(mutation, Mutation::ColumnBreakWithoutDefinition) {
+            0x08
+        } else {
+            0
+        },
+    );
     push_record(&mut body, TAG_PARA_TEXT, 1, &utf16_bytes(&section_text));
     push_record(&mut body, TAG_PARA_CHAR_SHAPE, 1, &shape_refs(&[(0, 0)]));
     let mut section_control = Vec::with_capacity(28);
@@ -218,30 +354,97 @@ fn fixture(mutation: Mutation) -> Vec<u8> {
             push_record(&mut body, TAG_PAGE_DEF, 2, &page_def(mutation));
         }
     }
-
-    let declared_lines = if matches!(mutation, Mutation::BadLineCount) {
-        2
-    } else {
-        1
-    };
-    push_para_header(&mut body, 1, 0, 1, declared_lines);
-    push_record(&mut body, TAG_PARA_TEXT, 1, &utf16_bytes(&[0x000d]));
-    push_record(&mut body, TAG_PARA_CHAR_SHAPE, 1, &shape_refs(&[(0, 0)]));
-    let start = if matches!(mutation, Mutation::BadLineBoundary) {
-        1
-    } else {
-        0
-    };
-    let (height, text_height, baseline) = if matches!(mutation, Mutation::ZeroHeightLine) {
-        (0, 0, 0)
-    } else {
-        (1_500, 1_200, 900)
-    };
-    let mut line = line_seg(start, height, text_height, baseline);
-    if matches!(mutation, Mutation::BadLineLength) {
-        line.pop();
+    if has_columns {
+        let mut column = Vec::new();
+        column.extend_from_slice(&u32::from_be_bytes(*b"cold").to_le_bytes());
+        if matches!(
+            mutation,
+            Mutation::ColumnUnequal | Mutation::BadColumnTrailingGap
+        ) {
+            column.extend_from_slice(&(3u16 << 2).to_le_bytes());
+            column.extend_from_slice(&0u16.to_le_bytes());
+            for (width, gap) in [
+                (10_000u16, 1_000u16),
+                (20_000, 1_000),
+                (
+                    30_000,
+                    u16::from(matches!(mutation, Mutation::BadColumnTrailingGap)),
+                ),
+            ] {
+                column.extend_from_slice(&width.to_le_bytes());
+                column.extend_from_slice(&gap.to_le_bytes());
+            }
+            column.extend([0; 6]);
+        } else {
+            let direction = if matches!(mutation, Mutation::BadColumnDirection) {
+                2u16 << 10
+            } else {
+                0
+            };
+            let kind = u16::from(matches!(mutation, Mutation::BadColumnKind));
+            column.extend_from_slice(&((2u16 << 2) | (1 << 12) | direction | kind).to_le_bytes());
+            column.extend_from_slice(&1_000u16.to_le_bytes());
+            column.extend_from_slice(&0u16.to_le_bytes());
+            column.push(if matches!(mutation, Mutation::Column2) {
+                1
+            } else {
+                0
+            });
+            column.push(0);
+            column.extend_from_slice(
+                &if matches!(mutation, Mutation::Column2) {
+                    0x0000_00ffu32
+                } else {
+                    0
+                }
+                .to_le_bytes(),
+            );
+        }
+        if matches!(mutation, Mutation::BadColumnPayload) {
+            column.pop();
+        }
+        push_record(&mut body, TAG_CTRL_HEADER, 1, &column);
     }
-    push_record(&mut body, TAG_PARA_LINE_SEG, 1, &line);
+
+    if matches!(mutation, Mutation::MidSectionSeparator) {
+        let mut text = extended_control(0x0002, u32::from_be_bytes(*b"cold"));
+        text.push(0x000d);
+        push_para_header_with_break(&mut body, text.len() as u32, 1 << 2, 1, 0, 0x02);
+        push_record(&mut body, TAG_PARA_TEXT, 1, &utf16_bytes(&text));
+        push_record(&mut body, TAG_PARA_CHAR_SHAPE, 1, &shape_refs(&[(0, 0)]));
+        let mut column = Vec::with_capacity(16);
+        column.extend_from_slice(&u32::from_be_bytes(*b"cold").to_le_bytes());
+        column.extend_from_slice(&((2u16 << 2) | (1 << 12)).to_le_bytes());
+        column.extend_from_slice(&1_000u16.to_le_bytes());
+        column.extend_from_slice(&0u16.to_le_bytes());
+        column.extend_from_slice(&[1, 0]);
+        column.extend_from_slice(&0x0000_00ffu32.to_le_bytes());
+        push_record(&mut body, TAG_CTRL_HEADER, 1, &column);
+    } else {
+        let declared_lines = if matches!(mutation, Mutation::BadLineCount) {
+            2
+        } else {
+            1
+        };
+        push_para_header(&mut body, 1, 0, 1, declared_lines);
+        push_record(&mut body, TAG_PARA_TEXT, 1, &utf16_bytes(&[0x000d]));
+        push_record(&mut body, TAG_PARA_CHAR_SHAPE, 1, &shape_refs(&[(0, 0)]));
+        let start = if matches!(mutation, Mutation::BadLineBoundary) {
+            1
+        } else {
+            0
+        };
+        let (height, text_height, baseline) = if matches!(mutation, Mutation::ZeroHeightLine) {
+            (0, 0, 0)
+        } else {
+            (1_500, 1_200, 900)
+        };
+        let mut line = line_seg(start, height, text_height, baseline);
+        if matches!(mutation, Mutation::BadLineLength) {
+            line.pop();
+        }
+        push_record(&mut body, TAG_PARA_LINE_SEG, 1, &line);
+    }
 
     let mut compound = CompoundFile::create(Cursor::new(Vec::new())).unwrap();
     {
@@ -310,12 +513,23 @@ fn push_para_header(
     char_shapes: u16,
     line_segments: u16,
 ) {
+    push_para_header_with_break(out, char_count, control_mask, char_shapes, line_segments, 0);
+}
+
+fn push_para_header_with_break(
+    out: &mut Vec<u8>,
+    char_count: u32,
+    control_mask: u32,
+    char_shapes: u16,
+    line_segments: u16,
+    break_type: u8,
+) {
     let mut data = Vec::with_capacity(22);
     data.extend_from_slice(&char_count.to_le_bytes());
     data.extend_from_slice(&control_mask.to_le_bytes());
     data.extend_from_slice(&0u16.to_le_bytes());
     data.push(0);
-    data.push(0);
+    data.push(break_type);
     data.extend_from_slice(&char_shapes.to_le_bytes());
     data.extend_from_slice(&0u16.to_le_bytes());
     data.extend_from_slice(&line_segments.to_le_bytes());

--- a/crates/hwp-hwp5/tests/public_probe.rs
+++ b/crates/hwp-hwp5/tests/public_probe.rs
@@ -34,11 +34,11 @@ fn explicit_own_parser_never_falls_back() {
     assert!(matches!(
         error,
         Error::UnsupportedBodyRecord {
-            tag: 0x42,
+            tag: 0x47,
             section: 0,
-            start: 0,
-            end: 28,
-            reason: "multi-column break is not owned",
+            start: 431,
+            end: 451,
+            reason: "record semantics are not owned",
             ..
         }
     ));

--- a/crates/hwp-jsx/src/lib.rs
+++ b/crates/hwp-jsx/src/lib.rs
@@ -887,9 +887,11 @@ fn parse_para(el: &JsxElement) -> Result<Paragraph> {
             .unwrap_or_default(),
         passthrough: parse_pass_attr(el)?,
         dirty: Dirty(el.attrs.contains_key("data-dirty")),
-        // Per-paragraph hard page break + table-anchor flag aren't carried through the HTML/JSX projection
-        // (own-render gets them from the rhwp lift); default false here.
+        // Structural page/column-zone breaks + table-anchor flag aren't carried through the HTML/JSX
+        // projection (own-render gets them from the binary parser); keep them explicitly absent here.
         page_break_before: false,
+        column_break_before: false,
+        column_layout_before: None,
         is_table_anchor: false,
         // Original paraPrIDRef, carried losslessly (mirrors run `data-cref`) so the round-trip is exact.
         para_ref: el.attrs.get("data-pref").cloned(),

--- a/crates/hwp-model/src/document.rs
+++ b/crates/hwp-model/src/document.rs
@@ -207,6 +207,14 @@ pub struct Paragraph {
     /// `column_type == Page/Section` (NOT the shared para_shape's attr1 bit19, which can't carry a
     /// per-paragraph break). Pagination forces a fresh page when set, OR'd with the para_shape flag.
     pub page_break_before: bool,
+    /// A hard 단 나누기 before this paragraph. In a multi-column zone this advances to the
+    /// next column, or to column zero on a fresh page when the current column is the last one.
+    pub column_break_before: bool,
+    /// A new source-neutral column zone beginning before this paragraph. HWP5 stores this as a
+    /// `cold` control and HWPX as a section/column property. Keeping the geometry on the paragraph
+    /// (rather than only on [`PageSetup`]) preserves documents that switch 1→2→1 columns inside a
+    /// section. `None` means the preceding zone remains active.
+    pub column_layout_before: Option<ColumnLayout>,
     /// This (empty) paragraph is a pure TABLE/object ANCHOR — in HWP a table control hangs off a host
     /// paragraph; the lift emits that host as an empty `Paragraph` immediately before the `Table` block.
     /// Hancom reserves NO line for such an anchor, so pagination skips its height (a genuine blank
@@ -655,6 +663,53 @@ pub enum DiagonalKind {
     Cross,
 }
 
+/// How content is distributed across a column zone.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum ColumnKind {
+    #[default]
+    Normal,
+    Distribute,
+    Parallel,
+}
+
+/// Physical order in which columns receive content.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum ColumnDirection {
+    #[default]
+    LeftToRight,
+    RightToLeft,
+}
+
+/// Optional rule drawn in the middle of every inter-column gap.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ColumnSeparator {
+    pub color: crate::types::Color,
+    pub style: LineStyle,
+    /// Device-pixel stroke width, shared by the SVG and PDF paint sinks.
+    pub width_px: f64,
+}
+
+/// Absolute, source-neutral column geometry in HWPUNIT.
+///
+/// `widths` has one positive entry per column and `gaps` has exactly `widths.len()-1` non-negative
+/// entries. Parsers must resolve source-specific proportional encodings before constructing this IR.
+/// The empty default is the implicit one-column body box and avoids baking a page width into a new
+/// document before its [`PageSetup`] is known.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct ColumnLayout {
+    pub kind: ColumnKind,
+    pub direction: ColumnDirection,
+    pub widths: Vec<HwpUnit>,
+    pub gaps: Vec<HwpUnit>,
+    pub separator: Option<ColumnSeparator>,
+}
+
+impl ColumnLayout {
+    pub fn count(&self) -> usize {
+        self.widths.len().max(1)
+    }
+}
+
 impl Cell {
     fn any_dirty(&self) -> bool {
         self.dirty.is_dirty() || self.blocks.iter().any(Block::any_dirty)
@@ -790,6 +845,9 @@ impl SemanticDoc {
         }
         fn para(p: &Paragraph) -> usize {
             os(&p.style_name)
+                + p.column_layout_before.as_ref().map_or(0, |columns| {
+                    (columns.widths.len() + columns.gaps.len()) * size_of::<HwpUnit>()
+                })
                 + p.source
                     .as_ref()
                     .map_or(0, |src| os(&src.para_pr) + os(&src.style) + os(&src.id))

--- a/crates/hwp-render/src/lib.rs
+++ b/crates/hwp-render/src/lib.rs
@@ -542,6 +542,53 @@ mod tests {
     }
 
     #[test]
+    fn column_separator_uses_the_shared_line_ir_and_svg_sink() {
+        let mut paragraph = para("두 단");
+        paragraph.column_layout_before = Some(ColumnLayout {
+            widths: vec![2_000, 2_000],
+            gaps: vec![1_000],
+            separator: Some(ColumnSeparator {
+                color: Color {
+                    r: 255,
+                    g: 0,
+                    b: 0,
+                    a: 255,
+                },
+                style: LineStyle::Dashed,
+                width_px: 0.7,
+            }),
+            ..ColumnLayout::default()
+        });
+        let mut doc = doc_with(vec![Block::Paragraph(paragraph)]);
+        doc.sections[0].page = PageSetup {
+            width: 5_000,
+            height: 6_000,
+            margin_left: 0,
+            margin_right: 0,
+            margin_top: 0,
+            margin_bottom: 0,
+            ..PageSetup::default()
+        };
+        let tree = render_page(&doc, &ApproxFontMetrics, 0).expect("column page renders");
+        assert!(tree.ops.iter().any(|operation| {
+            matches!(
+                operation,
+                PaintOp::Line {
+                    x1,
+                    x2,
+                    color,
+                    style: LineStyle::Dashed,
+                    width,
+                    ..
+                } if *x1 == 2_500.0 && *x2 == 2_500.0 && color.r == 255 && *width == 0.7
+            )
+        }));
+        let svg = &render_doc_svg(&doc, &ApproxFontMetrics)[0];
+        assert!(svg.contains("<line"));
+        assert!(svg.contains("stroke-dasharray"));
+    }
+
+    #[test]
     fn old_hangul_pua_svg_carries_jamo_cluster() {
         // Issue 062-2: U+E1A7 (Hanyang-PUA) renders as its 첫가끝 자모 시퀀스 ᄀᆞ (U+1100 U+119E),
         // NOT the raw PUA codepoint (needs 함초롬) and NOT the metric proxy '가'. The IR carries the

--- a/crates/hwp-typeset/src/lib.rs
+++ b/crates/hwp-typeset/src/lib.rs
@@ -75,6 +75,160 @@ pub fn body_box(page: &PageSetup) -> (f64, f64, f64, f64) {
     (left as f64, top as f64, w, h)
 }
 
+/// One column body box relative to the section body's left edge. Returned in **flow order**; an RTL
+/// layout therefore yields the physically rightmost box first while every `x` remains page-relative.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ColumnBox {
+    pub x: f64,
+    pub width: f64,
+}
+
+/// Resolve source-neutral absolute column geometry against the actual body width. The empty/default
+/// layout is exactly the historic single-column body. Invalid editor-created geometry degrades to a
+/// single bounded column; strict file parsers reject it before it reaches this defensive layer.
+pub fn column_boxes(layout: &ColumnLayout, body_w: f64) -> Vec<ColumnBox> {
+    if layout.widths.is_empty()
+        || layout.widths.iter().any(|width| *width <= 0)
+        || layout.gaps.len() + 1 != layout.widths.len()
+        || layout.gaps.iter().any(|gap| *gap < 0)
+    {
+        return vec![ColumnBox {
+            x: 0.0,
+            width: body_w.max(1.0),
+        }];
+    }
+
+    let raw_total = layout.widths.iter().map(|value| *value as f64).sum::<f64>()
+        + layout.gaps.iter().map(|value| *value as f64).sum::<f64>();
+    if raw_total <= 0.0 {
+        return vec![ColumnBox {
+            x: 0.0,
+            width: body_w.max(1.0),
+        }];
+    }
+    // Small integer-rounding residue is absorbed by the same scale as a defensive over-wide input;
+    // this guarantees the final box cannot escape the body right edge.
+    let scale = body_w.max(1.0) / raw_total;
+    let mut x = 0.0;
+    let mut boxes = Vec::with_capacity(layout.widths.len());
+    for (index, width) in layout.widths.iter().enumerate() {
+        let width = *width as f64 * scale;
+        boxes.push(ColumnBox { x, width });
+        if let Some(gap) = layout.gaps.get(index) {
+            x += width + *gap as f64 * scale;
+        }
+    }
+    if layout.direction == ColumnDirection::RightToLeft {
+        boxes.reverse();
+    }
+    boxes
+}
+
+/// Shared vertical/column cursor used by all three pagination paths. Keeping transitions here makes
+/// page-count LOCKSTEP structural instead of relying on three hand-copied interpretations.
+#[derive(Clone, Debug)]
+pub(crate) struct ColumnFlow {
+    boxes: Vec<ColumnBox>,
+    column: usize,
+    zone_top: f64,
+    vert: f64,
+    max_vert: f64,
+}
+
+impl ColumnFlow {
+    pub(crate) fn new(body_w: f64) -> Self {
+        Self {
+            boxes: column_boxes(&ColumnLayout::default(), body_w),
+            column: 0,
+            zone_top: 0.0,
+            vert: 0.0,
+            max_vert: 0.0,
+        }
+    }
+
+    pub(crate) fn box_now(&self) -> ColumnBox {
+        self.boxes[self.column]
+    }
+
+    pub(crate) fn column_index(&self) -> usize {
+        self.column
+    }
+
+    pub(crate) fn min_width(&self) -> f64 {
+        self.boxes
+            .iter()
+            .map(|column| column.width)
+            .fold(f64::INFINITY, f64::min)
+            .max(1.0)
+    }
+
+    pub(crate) fn y(&self) -> f64 {
+        self.zone_top + self.vert
+    }
+
+    pub(crate) fn vert(&self) -> f64 {
+        self.vert
+    }
+
+    pub(crate) fn add(&mut self, value: f64) {
+        self.vert += value;
+        self.max_vert = self.max_vert.max(self.vert);
+    }
+
+    pub(crate) fn available_height(&self, body_h: f64) -> f64 {
+        (body_h - self.zone_top).max(1.0)
+    }
+
+    /// Advance to the next flow column. Returns true when the caller must create a fresh page.
+    pub(crate) fn advance_column(&mut self) -> bool {
+        self.max_vert = self.max_vert.max(self.vert);
+        if self.column + 1 < self.boxes.len() {
+            self.column += 1;
+            self.vert = 0.0;
+            false
+        } else {
+            self.reset_page();
+            true
+        }
+    }
+
+    pub(crate) fn reset_page(&mut self) {
+        self.column = 0;
+        self.zone_top = 0.0;
+        self.vert = 0.0;
+        self.max_vert = 0.0;
+    }
+
+    /// Close the current column zone at its greatest consumed height and activate new geometry.
+    /// Returns true when the new zone cannot start on this page and must begin on a fresh page.
+    pub(crate) fn start_zone(&mut self, layout: &ColumnLayout, body_w: f64, body_h: f64) -> bool {
+        self.max_vert = self.max_vert.max(self.vert);
+        self.zone_top += self.max_vert;
+        self.boxes = column_boxes(layout, body_w);
+        self.column = 0;
+        self.vert = 0.0;
+        self.max_vert = 0.0;
+        if self.zone_top >= body_h {
+            self.reset_page();
+            true
+        } else {
+            false
+        }
+    }
+}
+
+fn uses_column_flow(doc: &SemanticDoc) -> bool {
+    doc.sections.iter().any(|section| {
+        section.blocks.iter().any(|block| {
+            matches!(
+                block,
+                Block::Paragraph(paragraph)
+                    if paragraph.column_layout_before.is_some() || paragraph.column_break_before
+            )
+        })
+    })
+}
+
 /// 강제 쪽 나누기("쪽 나누기 앞에서")의 **블록 단위 단일 진실** — `sec.blocks[i]` 앞에서 쪽을
 /// 넘겨야 하면 `out[i] == true`. `NaiveLayout`·[`place_doc`]·[`block_pages`] 셋이 전부 이 하나를
 /// 거쳐야 LOCKSTEP 이 구조적으로 보장된다(불변식 #2 — 세 경로에 같은 판정을 세 번 손으로 적으면
@@ -309,6 +463,9 @@ pub struct NaiveLayout;
 
 impl LayoutEngine for NaiveLayout {
     fn layout(&self, doc: &SemanticDoc, fonts: &dyn FontMetricsProvider) -> Result<LayoutResult> {
+        if uses_column_flow(doc) {
+            return Ok(layout_columns(doc, fonts));
+        }
         let mut pages = vec![PageLayout::default()];
         for sec in &doc.sections {
             let page = &sec.page;
@@ -400,6 +557,95 @@ impl LayoutEngine for NaiveLayout {
         }
         Ok(LayoutResult { pages })
     }
+}
+
+/// Column-enabled pagination lane. The historic lane above remains byte-for-byte untouched and is
+/// selected for every document without an explicit column-zone/break signal.
+fn layout_columns(doc: &SemanticDoc, fonts: &dyn FontMetricsProvider) -> LayoutResult {
+    let mut pages = vec![PageLayout::default()];
+    for section in &doc.sections {
+        let page = &section.page;
+        let (_, _, body_w, body_h) = body_box(page);
+        if !pages
+            .last()
+            .map(|value| value.lines.is_empty())
+            .unwrap_or(true)
+        {
+            pages.push(PageLayout::default());
+        }
+        if let Some(output) = pages.last_mut() {
+            let (width, height) = display_paper(page);
+            output.width = width as f64;
+            output.height = height as f64;
+        }
+        let breaks = section_page_breaks(section, doc);
+        let mut flow = ColumnFlow::new(body_w);
+        for (block_index, block) in section.blocks.iter().enumerate() {
+            match block {
+                Block::Paragraph(paragraph) => {
+                    let shape = doc.para_shapes.get(paragraph.para_shape);
+                    if let Some(columns) = &paragraph.column_layout_before {
+                        if flow.start_zone(columns, body_w, body_h) {
+                            pages.push(new_page(page));
+                        }
+                    }
+                    if breaks[block_index] && flow.y() > 0.0 {
+                        pages.push(new_page(page));
+                        flow.reset_page();
+                    } else if paragraph.column_break_before && flow.advance_column() {
+                        pages.push(new_page(page));
+                    }
+                    if paragraph.is_table_anchor {
+                        continue;
+                    }
+                    if flow.vert() > 0.0 {
+                        flow.add(shape.map(|value| value.space_before).unwrap_or(0).max(0) as f64);
+                    }
+                    let ratio = line_spacing_ratio(paragraph, doc);
+                    for mut line in layout_paragraph(paragraph, doc, flow.min_width(), fonts) {
+                        if flow.vert() + line.vert_size > flow.available_height(body_h)
+                            && flow.vert() > 0.0
+                            && flow.advance_column()
+                        {
+                            pages.push(new_page(page));
+                        }
+                        line.horz_pos += flow.box_now().x;
+                        let advance = line.vert_size * ratio;
+                        pages.last_mut().expect("page exists").lines.push(LineSeg {
+                            vert_pos: flow.y(),
+                            ..line
+                        });
+                        flow.add(advance);
+                    }
+                    flow.add(shape.map(|value| value.space_after).unwrap_or(0).max(0) as f64);
+                }
+                Block::Table(table) => {
+                    if breaks[block_index] && flow.y() > 0.0 {
+                        pages.push(new_page(page));
+                        flow.reset_page();
+                    }
+                    let promoted = unwrap_frame_table(table);
+                    let table = promoted.as_ref().map(|(inner, _)| inner).unwrap_or(table);
+                    if flow.vert() > 0.0 {
+                        flow.add(table.outer_margin_top.max(0) as f64);
+                    }
+                    for row_height in table_row_heights(table, flow.min_width(), doc, fonts) {
+                        let available = flow.available_height(body_h);
+                        if flow.vert() + row_height > available
+                            && flow.vert() > 0.0
+                            && row_height <= available
+                            && flow.advance_column()
+                        {
+                            pages.push(new_page(page));
+                        }
+                        flow.add(row_height);
+                    }
+                    flow.add(table.outer_margin_bottom.max(0) as f64);
+                }
+            }
+        }
+    }
+    LayoutResult { pages }
 }
 
 fn new_page(page: &PageSetup) -> PageLayout {

--- a/crates/hwp-typeset/src/place.rs
+++ b/crates/hwp-typeset/src/place.rs
@@ -349,6 +349,9 @@ pub struct PlacedDoc {
 /// `NaiveLayout` page count. `fonts` supplies advances (inject [`crate::RealFontMetrics`] under the
 /// `shaper` feature for real glyph widths; [`crate::ApproxFontMetrics`] otherwise).
 pub fn place_doc(doc: &SemanticDoc, fonts: &dyn FontMetricsProvider) -> PlacedDoc {
+    if crate::uses_column_flow(doc) {
+        return place_doc_columns(doc, fonts);
+    }
     let mut pages: Vec<PlacedPage> = vec![PlacedPage::default()];
     let mut started = false; // any content placed on the current page yet?
 
@@ -493,11 +496,193 @@ pub fn place_doc(doc: &SemanticDoc, fonts: &dyn FontMetricsProvider) -> PlacedDo
     PlacedDoc { pages }
 }
 
+/// Explicit-column placement lane. The established single-column implementation above is retained
+/// unchanged and remains the path for every document without a column-zone/break signal.
+fn place_doc_columns(doc: &SemanticDoc, fonts: &dyn FontMetricsProvider) -> PlacedDoc {
+    let mut pages = vec![PlacedPage::default()];
+    let mut started = false;
+    for (section_index, section) in doc.sections.iter().enumerate() {
+        let page = &section.page;
+        let (body_x, body_y, body_w, body_h) = crate::body_box(page);
+        if started {
+            pages.push(PlacedPage::default());
+        }
+        set_page_size(pages.last_mut().expect("page exists"), page);
+        let section_first_page = pages.len() - 1;
+        let breaks = crate::section_page_breaks(section, doc);
+        let mut flow = crate::ColumnFlow::new(body_w);
+
+        for (block_index, block) in section.blocks.iter().enumerate() {
+            match block {
+                Block::Paragraph(paragraph) => {
+                    let shape = doc.para_shapes.get(paragraph.para_shape);
+                    if let Some(columns) = &paragraph.column_layout_before {
+                        if flow.start_zone(columns, body_w, body_h) {
+                            new_page(&mut pages, page);
+                        }
+                    }
+                    if breaks[block_index] && flow.y() > 0.0 {
+                        new_page(&mut pages, page);
+                        flow.reset_page();
+                    } else if paragraph.column_break_before && flow.advance_column() {
+                        new_page(&mut pages, page);
+                    }
+                    if paragraph.is_table_anchor {
+                        started = true;
+                        continue;
+                    }
+                    if flow.vert() > 0.0 {
+                        flow.add(shape.map(|value| value.space_before).unwrap_or(0).max(0) as f64);
+                    }
+                    let start_page = pages.len() - 1;
+                    let start_column = flow.column_index();
+                    let start_box = flow.box_now();
+                    let start_y = body_y + flow.y();
+                    place_paragraph_columns(
+                        paragraph,
+                        doc,
+                        fonts,
+                        body_x,
+                        body_y,
+                        body_h,
+                        &mut flow,
+                        &mut pages,
+                        page,
+                        section_index,
+                        block_index,
+                    );
+                    let end_page = pages.len() - 1;
+                    let end_y = body_y + flow.y();
+                    let kind = if paragraph_object(paragraph).is_some() {
+                        BlockKind::Image
+                    } else {
+                        BlockKind::Paragraph
+                    };
+                    if start_page == end_page && start_column == flow.column_index() {
+                        pages[start_page].blocks.push(PlacedBlock {
+                            x: body_x + start_box.x,
+                            y: start_y,
+                            w: start_box.width,
+                            h: (end_y - start_y).max(0.0),
+                            section: section_index,
+                            block: block_index,
+                            kind,
+                        });
+                    }
+                    flow.add(shape.map(|value| value.space_after).unwrap_or(0).max(0) as f64);
+                    started = true;
+                }
+                Block::Table(table) => {
+                    if breaks[block_index] && flow.y() > 0.0 {
+                        new_page(&mut pages, page);
+                        flow.reset_page();
+                    }
+                    let promoted = crate::unwrap_frame_table(table);
+                    let (table, frame) = match &promoted {
+                        Some((inner, frame)) => (inner, *frame),
+                        None => (table, None),
+                    };
+                    if flow.vert() > 0.0 {
+                        flow.add(table.outer_margin_top.max(0) as f64);
+                    }
+                    let start_page = pages.len() - 1;
+                    place_table_columns(
+                        table,
+                        doc,
+                        fonts,
+                        body_x,
+                        body_y,
+                        body_h,
+                        &mut flow,
+                        &mut pages,
+                        page,
+                        section_index,
+                        block_index,
+                        frame,
+                    );
+                    let end_page = pages.len() - 1;
+                    for output in pages.iter_mut().take(end_page + 1).skip(start_page) {
+                        if let Some(placed) = output.tables.iter().rev().find(|placed| {
+                            placed.section == section_index
+                                && placed.block == block_index
+                                && placed.ancestors.is_empty()
+                        }) {
+                            output.blocks.push(PlacedBlock {
+                                x: placed.x,
+                                y: placed.y,
+                                w: placed.w,
+                                h: placed.h,
+                                section: section_index,
+                                block: block_index,
+                                kind: BlockKind::Table,
+                            });
+                        }
+                    }
+                    flow.add(table.outer_margin_bottom.max(0) as f64);
+                    started = true;
+                }
+            }
+        }
+        let separator_layouts = section
+            .blocks
+            .iter()
+            .filter_map(|block| match block {
+                Block::Paragraph(paragraph) => paragraph.column_layout_before.as_ref(),
+                Block::Table(_) => None,
+            })
+            .filter(|layout| layout.separator.is_some())
+            .collect::<Vec<_>>();
+        // The common HWP/HWPX contract is one column definition per section. For that exact case,
+        // emit the rule once per physical page; it is lowered through the same PaintOp::Line path to
+        // both SVG and PDF. Multiple separator-bearing zones need vertical span ownership and remain
+        // deliberately undrawn rather than overlapping contradictory rules.
+        if let [layout] = separator_layouts.as_slice() {
+            for output in pages.iter_mut().skip(section_first_page) {
+                emit_column_separators(output, layout, body_x, body_y, body_w, body_h);
+            }
+        }
+        place_section_decorations(&mut pages, section_first_page, section, doc, fonts);
+    }
+    PlacedDoc { pages }
+}
+
+fn emit_column_separators(
+    page: &mut PlacedPage,
+    layout: &ColumnLayout,
+    body_x: f64,
+    body_y: f64,
+    body_w: f64,
+    body_h: f64,
+) {
+    let Some(separator) = layout.separator else {
+        return;
+    };
+    let mut boxes = crate::column_boxes(layout, body_w);
+    boxes.sort_by(|left, right| left.x.total_cmp(&right.x));
+    for pair in boxes.windows(2) {
+        let gap_left = pair[0].x + pair[0].width;
+        let gap_right = pair[1].x;
+        let x = body_x + (gap_left + gap_right) / 2.0;
+        page.lines.push(PlacedLine {
+            x1: x,
+            y1: body_y,
+            x2: x,
+            y2: body_y + body_h,
+            color: separator.color,
+            style: separator.style,
+            width: separator.width_px,
+        });
+    }
+}
+
 /// Map each top-level block to the 0-based page index its first line/row STARTS on, re-driving the
 /// SAME vertical accounting as [`place_doc`] (fresh page per section, paragraph space-before/after,
 /// table outer margins + fit/overflow page breaks) WITHOUT placing glyphs. `out[section][block]` =
 /// page index. Lets a document-outline / page-nav panel scroll the page list to a heading's page.
 pub fn block_pages(doc: &SemanticDoc, fonts: &dyn FontMetricsProvider) -> Vec<Vec<usize>> {
+    if crate::uses_column_flow(doc) {
+        return block_pages_columns(doc, fonts);
+    }
     let mut out: Vec<Vec<usize>> = Vec::with_capacity(doc.sections.len());
     let mut page_idx = 0usize; // current (global) page index
     let mut started = false;
@@ -597,6 +782,108 @@ pub fn block_pages(doc: &SemanticDoc, fonts: &dyn FontMetricsProvider) -> Vec<Ve
         out.push(sec_pages);
     }
     out
+}
+
+fn block_pages_columns(doc: &SemanticDoc, fonts: &dyn FontMetricsProvider) -> Vec<Vec<usize>> {
+    let mut output = Vec::with_capacity(doc.sections.len());
+    let mut page_index = 0usize;
+    let mut started = false;
+    for section in &doc.sections {
+        let page = &section.page;
+        let (_, _, body_w, body_h) = crate::body_box(page);
+        if started {
+            page_index += 1;
+        }
+        let breaks = crate::section_page_breaks(section, doc);
+        let mut flow = crate::ColumnFlow::new(body_w);
+        let mut section_pages = Vec::with_capacity(section.blocks.len());
+        for (block_index, block) in section.blocks.iter().enumerate() {
+            match block {
+                Block::Paragraph(paragraph) => {
+                    let shape = doc.para_shapes.get(paragraph.para_shape);
+                    if let Some(columns) = &paragraph.column_layout_before {
+                        if flow.start_zone(columns, body_w, body_h) {
+                            page_index += 1;
+                        }
+                    }
+                    if breaks[block_index] && flow.y() > 0.0 {
+                        page_index += 1;
+                        flow.reset_page();
+                    } else if paragraph.column_break_before && flow.advance_column() {
+                        page_index += 1;
+                    }
+                    if paragraph.is_table_anchor {
+                        section_pages.push(page_index);
+                        started = true;
+                        continue;
+                    }
+                    if flow.vert() > 0.0 {
+                        flow.add(shape.map(|value| value.space_before).unwrap_or(0).max(0) as f64);
+                    }
+                    let ratio = line_spacing_ratio(paragraph, doc);
+                    let indent = indent_of(paragraph, doc, flow.min_width());
+                    let lines = layout_paragraph(paragraph, doc, indent.wrap_w, fonts);
+                    let mut recorded = false;
+                    for line in &lines {
+                        if flow.vert() + line.vert_size > flow.available_height(body_h)
+                            && flow.vert() > 0.0
+                            && flow.advance_column()
+                        {
+                            page_index += 1;
+                        }
+                        if !recorded {
+                            section_pages.push(page_index);
+                            recorded = true;
+                        }
+                        flow.add(line.vert_size * ratio);
+                    }
+                    if !recorded {
+                        section_pages.push(page_index);
+                    }
+                    flow.add(shape.map(|value| value.space_after).unwrap_or(0).max(0) as f64);
+                    started = true;
+                }
+                Block::Table(table) => {
+                    if breaks[block_index] && flow.y() > 0.0 {
+                        page_index += 1;
+                        flow.reset_page();
+                    }
+                    let promoted = crate::unwrap_frame_table(table);
+                    let table = promoted.as_ref().map(|(inner, _)| inner).unwrap_or(table);
+                    if flow.vert() > 0.0 {
+                        flow.add(table.outer_margin_top.max(0) as f64);
+                    }
+                    let rows = crate::table_row_heights(table, flow.min_width(), doc, fonts);
+                    if flow.vert() > 0.0
+                        && rows.first().is_some_and(|height| {
+                            let available = flow.available_height(body_h);
+                            flow.vert() + height > available && *height <= available
+                        })
+                        && flow.advance_column()
+                    {
+                        page_index += 1;
+                    }
+                    section_pages.push(page_index);
+                    for (row, height) in rows.iter().enumerate() {
+                        let available = flow.available_height(body_h);
+                        if row > 0
+                            && flow.vert() + height > available
+                            && flow.vert() > 0.0
+                            && *height <= available
+                            && flow.advance_column()
+                        {
+                            page_index += 1;
+                        }
+                        flow.add(*height);
+                    }
+                    flow.add(table.outer_margin_bottom.max(0) as f64);
+                    started = true;
+                }
+            }
+        }
+        output.push(section_pages);
+    }
+    output
 }
 
 /// 문단 들여쓰기/여백 (paragraph indent geometry) resolved from a [`ParaShape`].
@@ -753,6 +1040,117 @@ fn place_paragraph(
     }
 }
 
+/// Multi-column twin of [`place_paragraph`]. It uses the shared [`crate::ColumnFlow`] transition
+/// state and the narrowest active column as the wrap width, which guarantees that a paragraph that
+/// crosses into an unequal-width column never paints outside that column's body box.
+#[allow(clippy::too_many_arguments)]
+fn place_paragraph_columns(
+    p: &Paragraph,
+    doc: &SemanticDoc,
+    fonts: &dyn FontMetricsProvider,
+    ml: f64,
+    mt: f64,
+    body_h: f64,
+    flow: &mut crate::ColumnFlow,
+    pages: &mut Vec<PlacedPage>,
+    page: &PageSetup,
+    section: usize,
+    block: usize,
+) {
+    let glyphs = paragraph_glyphs(p, doc, fonts);
+    let align = doc
+        .para_shapes
+        .get(p.para_shape)
+        .map(|shape| shape.align)
+        .unwrap_or_default();
+    let ratio = line_spacing_ratio(p, doc);
+    let ind = indent_of(p, doc, flow.min_width());
+    let lines = layout_paragraph(p, doc, ind.wrap_w, fonts);
+    let obj = paragraph_object(p);
+
+    for (line_index, line) in lines.iter().enumerate() {
+        if flow.vert() + line.vert_size > flow.available_height(body_h)
+            && flow.vert() > 0.0
+            && flow.advance_column()
+        {
+            new_page(pages, page);
+        }
+        let column = flow.box_now();
+        let line_top = mt + flow.y();
+        let line_indent = ind.left
+            + if line_index == 0 {
+                ind.first_extra
+            } else {
+                0.0
+            };
+        let slack = (column.width
+            - ind.left
+            - if line_index == 0 {
+                ind.first_extra.max(0.0)
+            } else {
+                0.0
+            }
+            - line.horz_size)
+            .max(0.0);
+        let x0 = ml
+            + column.x
+            + line_indent
+            + match align {
+                HorizontalAlign::Right => slack,
+                HorizontalAlign::Center => slack / 2.0,
+                _ => 0.0,
+            };
+        let baseline = line_top + line.baseline;
+        let start = line.text_pos as usize;
+        let end = lines
+            .get(line_index + 1)
+            .map(|next| next.text_pos as usize)
+            .unwrap_or(glyphs.len());
+        let mut x = x0;
+        let plain = FontKey {
+            family: String::new(),
+            bold: false,
+            italic: false,
+        };
+        let page_out = pages.last_mut().expect("placed document always has a page");
+        for glyph in glyphs.get(start..end.min(glyphs.len())).unwrap_or(&[]) {
+            let advance = fonts.advance_width(&plain, glyph.ch, glyph.size as i32) * glyph.ratio
+                + glyph.spacing_em * glyph.size;
+            if glyph.ch != ' ' && glyph.ch != '\t' && glyph.ch != '\n' {
+                page_out.glyphs.push(PlacedGlyph {
+                    x,
+                    baseline,
+                    ch: glyph.ch,
+                    size: glyph.size,
+                    color: glyph.color,
+                    underline: glyph.underline,
+                    bold: glyph.bold,
+                    italic: glyph.italic,
+                    font: glyph.font.clone(),
+                    cluster: glyph.cluster.clone(),
+                });
+            }
+            x += advance;
+        }
+        if line_index == 0 {
+            if let Some((width, height, bin_ref, svg)) = &obj {
+                page_out.images.push(PlacedImage {
+                    x: x0,
+                    y: line_top,
+                    w: (*width).min(column.width),
+                    h: *height,
+                    bin_ref: bin_ref.clone(),
+                    svg: svg.clone(),
+                    is_background: false,
+                    section,
+                    block,
+                });
+            }
+        }
+        flow.add(line.vert_size * ratio);
+    }
+}
+
 /// Place a table, SPLITTING it across pages at row boundaries when it doesn't fit (한글식 표 나눔).
 /// Column widths come from `col_widths` (else an equal split, mirroring `table_height`). `vert` is the
 /// page-relative cursor where the table starts; `mt`/`body_h` frame the body. A first-row reserve moves
@@ -821,6 +1219,85 @@ fn place_table(
         frame,
     );
     y - mt // final page-relative cursor (bottom of the last fragment)
+}
+
+/// Column-aware row fragmentation twin of [`place_table`]. Row heights are measured at the
+/// narrowest active column, so a fragment remains bounded when unequal columns are traversed.
+#[allow(clippy::too_many_arguments)]
+fn place_table_columns(
+    t: &Table,
+    doc: &SemanticDoc,
+    fonts: &dyn FontMetricsProvider,
+    ml: f64,
+    mt: f64,
+    body_h: f64,
+    flow: &mut crate::ColumnFlow,
+    pages: &mut Vec<PlacedPage>,
+    page: &PageSetup,
+    section: usize,
+    block: usize,
+    frame: Option<CellEdge>,
+) {
+    if t.rows == 0 || t.cols == 0 {
+        return;
+    }
+    let table_width = flow.min_width();
+    let col_x = column_offsets(t, table_width);
+    let row_h = row_heights(t, table_width, doc, fonts);
+    let available = flow.available_height(body_h);
+    if flow.vert() > 0.0
+        && flow.vert() + row_h[0] > available
+        && row_h[0] <= available
+        && flow.advance_column()
+    {
+        new_page(pages, page);
+    }
+
+    let mut fragment_first = 0usize;
+    let mut fragment_x = ml + flow.box_now().x;
+    let mut fragment_top = mt + flow.y();
+    for row in 0..t.rows {
+        let available = flow.available_height(body_h);
+        if row > fragment_first && flow.vert() + row_h[row] > available && row_h[row] <= available {
+            flush_fragment(
+                pages,
+                t,
+                doc,
+                fonts,
+                fragment_x,
+                fragment_top,
+                &col_x,
+                &row_h,
+                fragment_first,
+                row,
+                section,
+                block,
+                frame,
+            );
+            if flow.advance_column() {
+                new_page(pages, page);
+            }
+            fragment_first = row;
+            fragment_x = ml + flow.box_now().x;
+            fragment_top = mt + flow.y();
+        }
+        flow.add(row_h[row]);
+    }
+    flush_fragment(
+        pages,
+        t,
+        doc,
+        fonts,
+        fragment_x,
+        fragment_top,
+        &col_x,
+        &row_h,
+        fragment_first,
+        t.rows,
+        section,
+        block,
+        frame,
+    );
 }
 
 /// Draw ONE page fragment of a table: rows `[first, last)` anchored at `frag_top` on the LAST page, as a
@@ -2327,6 +2804,157 @@ mod tests {
         };
         doc.sections.push(sec);
         doc
+    }
+
+    #[test]
+    fn explicit_columns_keep_all_three_layout_paths_in_lockstep_and_bounded() {
+        let columns = ColumnLayout {
+            widths: vec![2_000, 3_000],
+            gaps: vec![500],
+            separator: Some(ColumnSeparator {
+                color: Color {
+                    r: 255,
+                    g: 0,
+                    b: 0,
+                    a: 255,
+                },
+                style: LineStyle::Solid,
+                width_px: 0.5,
+            }),
+            ..ColumnLayout::default()
+        };
+        let mut first = para("가\n나\n다\n라\n마\n바\n사\n아\n자\n차");
+        first.column_layout_before = Some(columns);
+        let mut second = para("둘째 단");
+        second.column_break_before = true;
+        let mut table = Table {
+            rows: 2,
+            cols: 1,
+            ..Table::default()
+        };
+        for row in 0..2 {
+            table.cells.push(Cell {
+                row,
+                col: 0,
+                row_span: 1,
+                col_span: 1,
+                active: true,
+                blocks: vec![Block::Paragraph(para("표"))],
+                ..Cell::default()
+            });
+        }
+        let mut doc = doc_with(vec![
+            Block::Paragraph(first),
+            Block::Paragraph(second),
+            Block::Table(table),
+        ]);
+        doc.sections[0].page = PageSetup {
+            width: 5_500,
+            height: 5_000,
+            margin_left: 0,
+            margin_right: 0,
+            margin_top: 0,
+            margin_bottom: 0,
+            ..PageSetup::default()
+        };
+
+        let placed = place_doc(&doc, &ApproxFontMetrics);
+        let naive = crate::NaiveLayout
+            .layout(&doc, &ApproxFontMetrics)
+            .expect("column layout succeeds through the public engine");
+        let mapped = block_pages(&doc, &ApproxFontMetrics);
+        assert_eq!(placed.pages.len(), naive.pages.len(), "LOCKSTEP page count");
+        assert_eq!(mapped[0].len(), doc.sections[0].blocks.len());
+        for page in &placed.pages {
+            assert!(page.glyphs.iter().all(|glyph| {
+                (glyph.x >= 0.0 && glyph.x < 2_000.0) || (glyph.x >= 2_500.0 && glyph.x < 5_500.0)
+            }));
+            assert!(page.tables.iter().all(|table| {
+                (table.x >= 0.0 && table.x + table.w <= 2_000.0)
+                    || (table.x >= 2_500.0 && table.x + table.w <= 5_500.0)
+            }));
+            assert!(page.lines.iter().any(|line| {
+                line.x1 == 2_250.0 && line.x2 == 2_250.0 && line.color.r == 255 && line.width == 0.5
+            }));
+        }
+        let second_column_has_content = placed.pages.iter().any(|page| {
+            page.glyphs.iter().any(|glyph| glyph.x >= 2_500.0)
+                || page.tables.iter().any(|table| table.x >= 2_500.0)
+        });
+        assert!(
+            second_column_has_content,
+            "explicit column break advances flow"
+        );
+    }
+
+    #[test]
+    fn unequal_rtl_columns_page_break_zone_change_and_section_transition_are_lockstep() {
+        let rtl = ColumnLayout {
+            direction: ColumnDirection::RightToLeft,
+            widths: vec![1_000, 2_000, 3_000],
+            gaps: vec![500, 500],
+            ..ColumnLayout::default()
+        };
+        let mut first = para("첫");
+        first.column_layout_before = Some(rtl.clone());
+        let mut second = para("둘");
+        second.column_break_before = true;
+        let mut third = para("셋");
+        third.page_break_before = true;
+        let mut one_column = para("통단");
+        one_column.column_layout_before = Some(ColumnLayout {
+            widths: vec![7_000],
+            gaps: Vec::new(),
+            ..ColumnLayout::default()
+        });
+        let mut doc = doc_with(vec![
+            Block::Paragraph(first),
+            Block::Paragraph(second),
+            Block::Paragraph(third),
+            Block::Paragraph(one_column),
+        ]);
+        doc.sections[0].page = PageSetup {
+            width: 7_000,
+            height: 4_000,
+            margin_left: 0,
+            margin_right: 0,
+            margin_top: 0,
+            margin_bottom: 0,
+            ..PageSetup::default()
+        };
+        let mut next_section = Section {
+            blocks: vec![Block::Paragraph({
+                let mut paragraph = para("다음 구역");
+                paragraph.column_layout_before = Some(rtl);
+                paragraph
+            })],
+            page: doc.sections[0].page,
+            ..Section::default()
+        };
+        next_section.page.columns = 3;
+        doc.sections.push(next_section);
+
+        let placed = place_doc(&doc, &ApproxFontMetrics);
+        let naive = crate::NaiveLayout
+            .layout(&doc, &ApproxFontMetrics)
+            .expect("layout");
+        let mapped = block_pages(&doc, &ApproxFontMetrics);
+        assert_eq!(placed.pages.len(), naive.pages.len());
+        assert_eq!(mapped.len(), 2);
+        assert!(placed.pages[0]
+            .glyphs
+            .iter()
+            .any(|glyph| glyph.x >= 4_000.0));
+        assert!(placed.pages[0]
+            .glyphs
+            .iter()
+            .any(|glyph| (1_500.0..4_000.0).contains(&glyph.x)));
+        assert!(placed.pages.len() >= 3, "page break + section transition");
+        assert!(placed.pages[1]
+            .glyphs
+            .iter()
+            .any(|glyph| glyph.x >= 4_000.0));
+        assert!(placed.pages[1].glyphs.iter().any(|glyph| glyph.x < 1_000.0));
     }
 
     #[test]

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,6 +3,13 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
+- 갱신: 2026-08-23 · Codex(sol) — **#161 PR #163 게시**.
+  검증 완료 commit `c751833`을 push하고 PR #163(`Closes #161`, `Refs #94 #160`)을 만들었다.
+  normal 1~32단 strict subset, 3-path LOCKSTEP, SVG/PDF shared line, separator-span/distribution
+  fail-closed, public boundary 0x47/431..451, no production cutover/no rhwp/generated drift와
+  quick/full/Vitest 1,018/Chromium 85 pass·3 skip을 본문에 명시했다. **다음:** 이 상태 commit push→
+  issue-link/build-test/licenses·mergeability·review/comment 추적→전부 green이면 자율 병합·branch 정리.
+
 - 갱신: 2026-08-23 · Codex(sol) — **#161 게시 준비 완료**.
   최종 quick이 다시 전부 green이고, PDF export가 column separator `PaintOp::Line`을 같은 page tree에서
   produced=1/replayed=1/stubbed=0으로 소비하는 직접 회귀도 추가했다. 별도 demo proxy **11 tests**를

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,6 +3,56 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
+- 갱신: 2026-08-23 · Codex(sol) — **#161 게시 준비 완료**.
+  최종 quick이 다시 전부 green이고, PDF export가 column separator `PaintOp::Line`을 같은 page tree에서
+  produced=1/replayed=1/stubbed=0으로 소비하는 직접 회귀도 추가했다. 별도 demo proxy **11 tests**를
+  동일 lockfile 의존성으로 확인해 full Vitest 합계는 **1,018**, Chromium은 **85 pass/3 skip**이다.
+  final diff/security review에서 source content/path/hash/credential 노출·silent fallback·production route
+  변경이 없고 `external/rhwp`와 generated asset diff도 0이다. **다음:** commit/push→PR `Closes #161`/
+  `Refs #94 #160`→issue-link/build-test/licenses·mergeability·review/comment 확인→green 자율 병합.
+
+- 갱신: 2026-08-23 · Codex(sol) — **#161 full green · separator span 최종 하드닝**.
+  full의 Rust/PDF/canonical/public corpus/oracle/HWPX/wasm/JS build·crosscheck·i18n과 Vitest
+  **1,007**이 green이고, 샌드박스 포트 EPERM만 전용 `PW_PORT=31861`에서 분리 재실행해 실제
+  Chromium **85 pass/3 intentional skip/0 fail**을 확인했다. 이후 페이지 전체 구분선 렌더의
+  정직한 경계로 mid-section separator zone도 fail-closed하고 합성 회귀를 추가해 hwp-hwp5
+  **42 tests**·clippy·wasm32 green. demo proxy 11건은 별도 재실행 green으로 full 합계 **1,018**.
+  임시 dependency link 제거, route/rhwp/generated diff 0.
+  **다음:** final quick→security/diff→commit/push/PR #161→필수 CI·자율 병합.
+
+- 갱신: 2026-08-23 · Codex(sol) — **#161 quick 전체 green**.
+  strict normal-column subset과 shared LOCKSTEP column lane을 quick 전수 검증했다. rhwp governance,
+  fmt/clippy, workspace+rhwp tests, PDF visual 51/parity, canonical **8/18/24·98.9%+**, public corpus
+  계약 84, oracle 82, HWPX lock, wasm32, licenses가 전부 green이다. private `modu-startup`/정부양식
+  실물 gate만 로컬 corpus 부재로 기존 정책대로 skip됐다. production route, `external/rhwp`, generated
+  wasm diff 0. **다음:** `verify-local --full`→final security/diff→commit/push/PR #161→CI/자율 병합.
+
+- 갱신: 2026-08-23 · Codex(sol) — **#161 의미 경계 하드닝 · focused/wasm green**.
+  HWP5 `cold`의 normal 1~32단과 LTR/RTL만 owned로 한정하고 distribute/parallel은 정상 단처럼
+  흉내내지 않고 fail-closed한다. 최초 owned zone 전 단나누기와 구분선이 포함된 복수 zone도
+  정확한 의미/세로 span을 소유할 때까지 정적·content-free 오류로 거부한다. hwp-hwp5 **41 tests**,
+  hwp-typeset **90+4**, hwp-render **17+3**, touched-crate clippy `-D warnings`, hwp-hwp5/typeset wasm32,
+  production route/rhwp/generated diff 0. 전체 workspace clippy는 기존 hwp-foreign·hwp-jsx-test의
+  Rust 1.95 신규 lint 기준선에서만 실패. **다음:** quick→full→최종 diff/PR #161/CI/자율 병합.
+
+- 갱신: 2026-08-23 · Codex(sol) — **#161 column IR/parser/LOCKSTEP 1차 focused green**.
+  `Paragraph` 열 zone/단나누기 + 절대 HWPUNIT `ColumnLayout`(종류·LTR/RTL·폭·간격·구분선)을
+  source-neutral IR로 추가했다. HWP5 `cold`는 1~32단, exact 16B equal/관측 proportional unequal,
+  upper attr·direction·zero width·tail·separator style를 strict 검증한 뒤 page body의 절대 geometry로만
+  옮긴다. 별도 column lane을 public `place_doc`/`NaiveLayout`/`block_pages`에 동시 연결해
+  문단·표를 열/쪽 경계에서 분할하고 구분선은 공유 `PlacedLine`→SVG/PDF PaintOp로 내린다.
+  focused hwp-hwp5 **38 tests**, hwp-typeset **83 tests**, public 경계 `0x42/0..28`→
+  `CTRL_HEADER 0x47/431..451`, focused clippy `-D warnings` green. **다음:** unequal/3단·RTL·
+  zone/page/column break·hostile fixture 확장→workspace/quick/full; production route/rhwp 불변.
+
+- 갱신: 2026-08-23 · Codex(sol) — **PR #162 병합 · #161 다단 조판 착수**.
+  #162는 head `24516e7`에서 issue-link·build-test 8m58s·licenses green, CLEAN/MERGEABLE,
+  리뷰/일반/인라인 댓글 0을 확인한 뒤 main `a5c1125`로 squash 병합했고 #160이 close됐다.
+  원격 브랜치를 정리하고 #94에 STYLE/ref 소유 및 multi-column fail-closed 경계를 동기화했다.
+  정확한 latest main에서 `codex/issue-161-hwp5-columns`를 시작했다. **다음:** source-neutral
+  column geometry→strict `cold` parser→`place_doc`/`NaiveLayout`/`block_pages` LOCKSTEP fixture.
+  production HWP5 route와 `external/rhwp`는 불변이다.
+
 - 갱신: 2026-08-23 · Codex(sol) — **#160 PR #162 게시**.
   검증 완료 commit `75f5ad5`를 push하고 PR #162(`Closes #160`, `Refs #94 #158 #161`)를 만들었다.
   strict STYLE, content-free failure reasons, public multi-column boundary, #161 faithful column dependency,

--- a/docs/HWP5-NATIVE-PARSER.md
+++ b/docs/HWP5-NATIVE-PARSER.md
@@ -3,7 +3,8 @@
 Issue #107 introduced the first owned binary-HWP layer; issue #154 added its first semantic slice,
 issue #156 added the minimum source-layout facts needed by the shared typesetter, issue #158 owns
 the paragraph support-pool boundary, and issue #160 owns DocInfo styles plus content-free paragraph
-header refusal reasons. None of these slices changes production parsing.
+header refusal reasons; issue #161 adds strict column definitions and the shared multi-column layout
+contract. None of these slices changes production parsing.
 
 ## What is owned now
 
@@ -23,7 +24,18 @@ typesetter does not yet own. The owned section-definition boundary maps a strict
 `Section.page`, including all six margins, gutter, and HWP5 landscape orientation. A strict
 `PARA_LINE_SEG` reader validates declared counts and UTF-16 scalar/control starts, but exposes stored
 line-box metrics only for true blank spacer paragraphs. Stored line breaks never override our
-typesetter and zero-height segments are non-authoritative. Offsets are relative to the decompressed
+typesetter and zero-height segments are non-authoritative. A strict `cold` reader accepts bounded
+1–32-column normal definitions, owned LTR/RTL direction, exact equal-width and
+observed unequal proportional payloads, and known separator line values. Source proportions are
+resolved against the validated page body into absolute HWPUNIT widths/gaps before they enter the
+source-neutral `ColumnLayout`; malformed lengths, zero widths, trailing gaps, unknown upper attrs,
+directions, distribution/parallel kinds, or separator values fail closed. Multiple column zones are
+accepted only when none carries a separator; a separator zone must begin with the section and remain
+its only zone until exact vertical spans are owned. `place_doc`, `NaiveLayout`, and `block_pages` select the
+same column flow only when a paragraph carries a column-zone/break signal, leaving the established
+single-column lane unchanged. Paragraphs and tables advance through identical column/page transitions,
+and separator rules lower through the shared `PlacedLine`/`PaintOp::Line` path used by SVG and PDF.
+Offsets are relative to the decompressed
 standard stream. Source bytes, text,
 filenames, credentials, and source hashes are never copied into the probe or differential report.
 
@@ -47,13 +59,12 @@ rejected instead of being interpreted as records.
 
 - `Engine::open`: unchanged production route. Binary HWP still uses the governed rhwp bootstrap.
 - `open_hwp5_own`: explicit first-party-only route. It returns a `SemanticDoc` only for the owned
-  text plus single-sided page-setup subset. Tables, images, fields, notes, equations, charts,
-  columns, decorations, page border/fill, duplex binding, active custom tabs/lists/paragraph borders,
+  text, single-sided page setup, and strict column subset. Tables, images, fields, notes, equations, charts,
+  decorations, page border/fill, duplex binding, active custom tabs/lists/paragraph borders,
   unknown body controls, and unsupported pool values fail closed with a static reason plus tag,
-  section, and byte span only. It cannot call rhwp. The public benchmark currently stops at a
-  multi-column paragraph header (`0x42`, section 0, bytes 0..28): accepting it would be dishonest
-  because section columns are not yet consumed by both paginators. Issue #161 owns that IR and
-  LOCKSTEP typesetting dependency.
+  section, and byte span only. It cannot call rhwp. The public benchmark now passes its first
+  multi-column paragraph header and `cold` definition, then stops at the next unowned control header
+  (`0x47`, section 0, bytes 431..451) without exposing content.
 - `hwp5_differential`: explicitly runs the owned probe and current rhwp semantic oracle, then reports
   section/paragraph/run/table/image/control/equation/chart counts and their deltas.
 
@@ -69,7 +80,7 @@ or claim semantic parity.
 
 ## Cutover rule
 
-The next #94 slices promote tables, BinData/images, columns/decorations, and remaining controls into
+The next #94 slices promote tables, BinData/images, decorations, and remaining controls into
 this crate. The production route may change only when public-corpus differential gates, native/wasm
 parity, hostile input tests, and the canonical 8/18/24-page + 98.9% line gate remain green. Explicit
 own-parser mode must continue to fail closed for every unsupported semantic construct.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,12 @@
 
 ---
 
+## 2026-08-23 (Codex sol) · #161 PR #163 posted
+- verified `c751833` push + PR #163 (`Closes #161`, `Refs #94 #160`).
+- strict normal columns/LOCKSTEP/shared SVG·PDF/fail-closed boundaries and full evidence published.
+- production route·rhwp·generated drift 0.
+- 다음 state commit push→required CI/review/comment→green 자율 병합.
+
 ## 2026-08-23 (Codex sol) · #161 ready for PR
 - final quick green + PDF column line direct replay produced=1/replayed=1/stubbed=0.
 - full Vitest 1,018(별도 proxy11 포함), Chromium 85 pass/3 skip; temporary links removed.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,41 @@
 
 ---
 
+## 2026-08-23 (Codex sol) · #161 ready for PR
+- final quick green + PDF column line direct replay produced=1/replayed=1/stubbed=0.
+- full Vitest 1,018(별도 proxy11 포함), Chromium 85 pass/3 skip; temporary links removed.
+- final security/diff: content/path/hash/credential/fallback·route/rhwp/generated drift 0.
+- 다음 commit/push→PR #161/required CI→green 자율 병합.
+
+## 2026-08-23 (Codex sol) · #161 full green + separator span hardening
+- full Rust/PDF/wasm/JS/Vitest 1,007 green; Chromium 85 pass/3 intentional skip/0 fail.
+- mid-section separator zone도 정확한 span 소유 전 fail-closed; hwp-hwp5 42/clippy/wasm green.
+- 임시 dependency link 제거, production/rhwp/generated diff 0.
+- 다음 final quick→diff→PR #161/CI/자율 병합.
+
+## 2026-08-23 (Codex sol) · #161 quick green
+- rhwp governance/fmt/clippy/workspace+rhwp/PDF51/parity/canonical 8·18·24+98.9% 전부 green.
+- public corpus 84·oracle82·HWPX lock·wasm32·licenses green; private 실물 gate만 정책상 skip.
+- production route·external/rhwp·generated wasm diff 0.
+- 다음 full→final diff→PR #161/CI/자율 병합.
+
+## 2026-08-23 (Codex sol) · #161 meaning boundary hardening
+- HWP5는 normal 1~32단/LTR·RTL만 owned; distribute/parallel은 fail-closed.
+- 최초 zone 전 단나누기·구분선 포함 복수 zone도 정적 오류로 거부해 거짓 지원 제거.
+- hwp-hwp5 41·typeset 90+4·render 17+3, touched clippy/wasm32 green; route/rhwp/generated diff 0.
+- 다음 quick→full→PR #161/CI/자율 병합.
+
+## 2026-08-23 (Codex sol) · #161 column focused green
+- source-neutral column IR + strict HWP5 cold parser; proportional→absolute body geometry.
+- public place_doc/NaiveLayout/block_pages 동시 column lane, 문단·표 경계/LOCKSTEP + SVG/PDF 구분선.
+- hwp-hwp5 38·typeset 83 + focused clippy green; public boundary 0x42→0x47/431..451.
+- 다음 unequal/3단·RTL·zone/page/column/hostile 확장→quick/full; production/rhwp 불변.
+
+## 2026-08-23 (Codex sol) · PR #162 병합 → #161 착수
+- #162 required CI/CLEAN·댓글 0 확인 후 main `a5c1125` 병합; #160 close·원격 branch 정리.
+- #94 경계 동기화, latest-main `codex/issue-161-hwp5-columns` 시작.
+- 다음 column IR→strict cold parser→LOCKSTEP multi-column layout; production/rhwp 불변.
+
 ## 2026-08-23 (Codex sol) · #160 PR #162
 - commit `75f5ad5` push, PR #162(`Closes #160`, `Refs #94 #158 #161`) 게시.
 - 다음 required CI/review 감시→green 자율 병합→#161 column IR/LOCKSTEP.


### PR DESCRIPTION
## Summary
- add source-neutral absolute column geometry and strict first-party HWP5 cold parsing for normal 1–32-column LTR/RTL layouts
- keep place_doc, NaiveLayout, and block_pages in one LOCKSTEP column flow for paragraphs, tables, breaks, unequal widths, and section transitions
- lower separator rules through the shared PaintOp::Line tree used by SVG and PDF, with direct PDF replay proof
- fail closed for malformed geometry, unsupported distribution/parallel kinds, pre-definition column breaks, and separator zones whose vertical span is not yet owned
- advance the content-free public first-party boundary beyond the first multi-column paragraph to CTRL_HEADER 0x47 section 0 bytes 431..451
- leave production HWP5 routing, generated wasm assets, and external/rhwp unchanged

## Verification
- scripts/verify-local.sh: green
- scripts/verify-local.sh --full: Rust/PDF/canonical 8/18/24 and 98.9%+/public corpus 84/oracle 82/HWPX/wasm/licenses/JS build and crosschecks green
- Vitest: 1,018 passed including demo proxy 11
- Playwright Chromium: 85 passed, 3 intentional skips, 0 failed on PW_PORT=31861
- HWP5: 42 tests; hwp-typeset: 90 + 4; hwp-render: 17 + 3
- PDF separator replay: produced=1, replayed=1, stubbed=0
- production route, external/rhwp, generated assets: diff 0

Closes #161
Refs #94 #160