### PR TITLE
feat: own HWP5 page-number decoration

### DIFF
--- a/crates/hwp-export/src/pdf.rs
+++ b/crates/hwp-export/src/pdf.rs
@@ -1187,6 +1187,52 @@ mod tests {
     }
 
     #[test]
+    fn page_number_decoration_replays_as_text_from_the_shared_paint_tree() {
+        let bytes = std::fs::read(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../assets/fonts/NanumGothic-Regular.ttf"
+        ))
+        .expect("vendored NanumGothic present for the test");
+        let injected = vec![("Nanum Gothic".to_string(), bytes)];
+        let plain = doc_with(vec![Block::Paragraph(para("본문"))]);
+        let mut numbered = plain.clone();
+        numbered.sections[0].page_number = Some(PageNumberDecoration {
+            format: PageNumberFormat::Digit,
+            position: PageNumberPosition::BottomCenter,
+            prefix: Some('['),
+            suffix: Some(']'),
+            dash: Some('-'),
+        });
+
+        let plain_out = export_pdf_with_fonts(
+            &plain,
+            &ApproxFontMetrics,
+            &PdfOptions::default(),
+            &injected,
+        )
+        .unwrap();
+        let numbered_out = export_pdf_with_fonts(
+            &numbered,
+            &ApproxFontMetrics,
+            &PdfOptions::default(),
+            &injected,
+        )
+        .unwrap();
+
+        assert_eq!(numbered_out.pages, plain_out.pages);
+        assert_eq!(
+            numbered_out.replay[0].text.produced,
+            plain_out.replay[0].text.produced + 5,
+            "-[1]- is five shared PaintOp::Glyph operations"
+        );
+        assert_eq!(
+            numbered_out.replay[0].text.produced,
+            numbered_out.replay[0].text.replayed
+        );
+        assert_eq!(numbered_out.replay[0].text.stubbed, 0);
+    }
+
+    #[test]
     fn empty_doc_still_makes_a_pdf() {
         let doc = doc_with(vec![Block::Paragraph(para(""))]);
         let out = export_pdf(&doc, &ApproxFontMetrics, &PdfOptions::default()).unwrap();

--- a/crates/hwp-hwp5/src/semantic.rs
+++ b/crates/hwp-hwp5/src/semantic.rs
@@ -23,6 +23,7 @@ const TAG_PAGE_DEF: u16 = 0x49;
 
 const CTRL_SECTION_DEF: u32 = u32::from_be_bytes(*b"secd");
 const CTRL_COLUMN_DEF: u32 = u32::from_be_bytes(*b"cold");
+const CTRL_PAGE_NUM_POS: u32 = u32::from_be_bytes(*b"pgnp");
 
 #[derive(Clone, Copy, Debug, Default)]
 struct IdMappings {
@@ -123,6 +124,7 @@ pub(crate) fn parse_text_only(bytes: &[u8]) -> Result<SemanticDoc> {
             &doc,
             &pools.para_usage,
             &pools.styles,
+            pools.section_count == 1,
         )?);
     }
     Ok(doc)
@@ -926,10 +928,24 @@ fn parse_section(
     doc: &SemanticDoc,
     para_usage: &[ParaUsage],
     styles: &[StyleDef],
+    allow_page_number: bool,
 ) -> Result<Section> {
     let section = stream.section.expect("caller selected section streams");
+    if !allow_page_number {
+        if let Some(control) = stream.records.iter().find(|record| {
+            record.tag == TAG_CTRL_HEADER
+                && read_u32(data(stream, record), 0) == Some(CTRL_PAGE_NUM_POS)
+        }) {
+            return Err(malformed(
+                control,
+                Some(section),
+                "multi-section page-number inheritance is not yet supported",
+            ));
+        }
+    }
     let mut blocks = Vec::new();
     let mut page = None;
+    let mut page_number = None;
     let mut has_active_columns = false;
     let mut column_zone_count = 0usize;
     let mut separator_zone_seen = false;
@@ -977,6 +993,15 @@ fn parse_section(
                 ));
             }
         }
+        if let Some(parsed_page_number) = parsed.page_number {
+            if ordinal != 0 || page_number.replace(parsed_page_number).is_some() {
+                return Err(malformed(
+                    &stream.records[start],
+                    Some(section),
+                    "page-number position may occur only once and only in the first paragraph",
+                ));
+            }
+        }
         if parsed.paragraph.column_break_before
             && parsed.paragraph.column_layout_before.is_none()
             && !has_active_columns
@@ -1012,6 +1037,7 @@ fn parse_section(
     Ok(Section {
         blocks,
         page: page.unwrap_or_default(),
+        page_number,
         provenance: Provenance {
             source: Some(SourceFormat::Hwp5),
             raw: None,
@@ -1023,6 +1049,7 @@ fn parse_section(
 struct ParsedParagraph {
     paragraph: Paragraph,
     page: Option<PageSetup>,
+    page_number: Option<PageNumberDecoration>,
 }
 
 fn parse_paragraph(
@@ -1117,7 +1144,10 @@ fn parse_paragraph(
                         "structural CTRL_HEADER is shorter than its control id",
                     ));
                 };
-                if !matches!(control_id, CTRL_SECTION_DEF | CTRL_COLUMN_DEF) {
+                if !matches!(
+                    control_id,
+                    CTRL_SECTION_DEF | CTRL_COLUMN_DEF | CTRL_PAGE_NUM_POS
+                ) {
                     return Err(unsupported(record, section));
                 }
                 let start = cursor;
@@ -1167,6 +1197,7 @@ fn parse_paragraph(
     }
     let mut page = None;
     let mut raw_columns = None;
+    let mut page_number = None;
     for ((marker_offset, marker_id), (control, children)) in
         decoded.structural_controls.iter().zip(structural_controls)
     {
@@ -1198,6 +1229,20 @@ fn parse_paragraph(
                     ));
                 }
                 raw_columns = Some(parse_column_control(
+                    data(stream, control),
+                    control,
+                    section,
+                )?);
+            }
+            CTRL_PAGE_NUM_POS => {
+                if !children.is_empty() || page_number.is_some() {
+                    return Err(malformed(
+                        control,
+                        Some(section),
+                        "page-number position has children or is duplicated",
+                    ));
+                }
+                page_number = Some(parse_page_number_control(
                     data(stream, control),
                     control,
                     section,
@@ -1263,7 +1308,7 @@ fn parse_paragraph(
         runs,
         // Stored line boxes are only an authored-height hint for a true blank spacer.
         // They never dictate line breaks for visible text or a control-host paragraph.
-        source_line_metrics: if decoded.chars.is_empty() && page.is_none() {
+        source_line_metrics: if decoded.chars.is_empty() && decoded.structural_controls.is_empty() {
             line_metrics
         } else {
             Vec::new()
@@ -1277,7 +1322,99 @@ fn parse_paragraph(
     if let (Some(page), Some(layout)) = (&mut page, &paragraph.column_layout_before) {
         page.columns = u8::try_from(layout.count()).unwrap_or(u8::MAX);
     }
-    Ok(ParsedParagraph { paragraph, page })
+    Ok(ParsedParagraph {
+        paragraph,
+        page,
+        page_number,
+    })
+}
+
+fn parse_page_number_control(
+    bytes: &[u8],
+    record: &Record,
+    section: usize,
+) -> Result<PageNumberDecoration> {
+    if bytes.len() != 16 {
+        return Err(malformed(
+            record,
+            Some(section),
+            "page-number position is not exactly 16 bytes",
+        ));
+    }
+    if read_u32(bytes, 0) != Some(CTRL_PAGE_NUM_POS) {
+        return Err(unsupported(*record, section));
+    }
+    let attr = read_u32(bytes, 4).expect("exact length checked");
+    if attr & !0x0fff != 0 {
+        return Err(malformed(
+            record,
+            Some(section),
+            "page-number position has unknown attribute bits",
+        ));
+    }
+    let format = match attr & 0xff {
+        0 => PageNumberFormat::Digit,
+        1 => PageNumberFormat::CircledDigit,
+        2 => PageNumberFormat::RomanUpper,
+        3 => PageNumberFormat::RomanLower,
+        4 => PageNumberFormat::LatinUpper,
+        5 => PageNumberFormat::LatinLower,
+        _ => {
+            return Err(malformed(
+                record,
+                Some(section),
+                "page-number format is not yet supported",
+            ))
+        }
+    };
+    let position = match (attr >> 8) & 0x0f {
+        0 => PageNumberPosition::None,
+        1 => PageNumberPosition::TopLeft,
+        2 => PageNumberPosition::TopCenter,
+        3 => PageNumberPosition::TopRight,
+        4 => PageNumberPosition::BottomLeft,
+        5 => PageNumberPosition::BottomCenter,
+        6 => PageNumberPosition::BottomRight,
+        7 => PageNumberPosition::OutsideTop,
+        8 => PageNumberPosition::OutsideBottom,
+        9 => PageNumberPosition::InsideTop,
+        10 => PageNumberPosition::InsideBottom,
+        _ => {
+            return Err(malformed(
+                record,
+                Some(section),
+                "page-number position is not supported",
+            ))
+        }
+    };
+    let scalar = |at: usize| -> Result<Option<char>> {
+        let unit = read_u16(bytes, at).expect("exact length checked");
+        if unit == 0 {
+            return Ok(None);
+        }
+        if (0xd800..=0xdfff).contains(&unit) {
+            return Err(malformed(
+                record,
+                Some(section),
+                "page-number decoration contains a surrogate code unit",
+            ));
+        }
+        Ok(char::from_u32(u32::from(unit)))
+    };
+    if scalar(8)?.is_some() {
+        return Err(malformed(
+            record,
+            Some(section),
+            "page-number user-symbol semantics are not yet supported",
+        ));
+    }
+    Ok(PageNumberDecoration {
+        format,
+        position,
+        prefix: scalar(10)?,
+        suffix: scalar(12)?,
+        dash: scalar(14)?,
+    })
 }
 
 fn validate_para_usage(
@@ -1878,29 +2015,42 @@ fn decode_text(bytes: &[u8], record: Record, section: usize) -> Result<DecodedTe
                 inline_control_mask |= 1 << 0x0009;
                 cursor += 8;
             }
-            0x0002 => {
+            0x0002 | 0x0015 => {
                 if cursor + 8 > units.len() {
                     return Err(malformed(
                         &record,
                         Some(section),
-                        "PARA_TEXT section control is truncated",
+                        if unit == 0x0002 {
+                            "PARA_TEXT section control is truncated"
+                        } else {
+                            "PARA_TEXT page-number control is truncated"
+                        },
                     ));
                 }
                 if units[cursor + 7] != unit || units[cursor + 3..cursor + 7] != [0; 4] {
                     return Err(malformed(
                         &record,
                         Some(section),
-                        "PARA_TEXT section control framing is invalid",
+                        if unit == 0x0002 {
+                            "PARA_TEXT section control framing is invalid"
+                        } else {
+                            "PARA_TEXT page-number control framing is invalid"
+                        },
                     ));
                 }
                 let lo = units[cursor + 1].to_le_bytes();
                 let hi = units[cursor + 2].to_le_bytes();
                 let control_id = u32::from_le_bytes([lo[0], lo[1], hi[0], hi[1]]);
-                if !matches!(control_id, CTRL_SECTION_DEF | CTRL_COLUMN_DEF) {
+                let owned = match unit {
+                    0x0002 => matches!(control_id, CTRL_SECTION_DEF | CTRL_COLUMN_DEF),
+                    0x0015 => control_id == CTRL_PAGE_NUM_POS,
+                    _ => false,
+                };
+                if !owned {
                     return Err(unsupported(record, section));
                 }
                 structural_controls.push((start, control_id));
-                inline_control_mask |= 1 << 0x0002;
+                inline_control_mask |= 1 << unit;
                 cursor += 8;
             }
             0x000a => {

--- a/crates/hwp-hwp5/tests/layout_semantic.rs
+++ b/crates/hwp-hwp5/tests/layout_semantic.rs
@@ -16,6 +16,7 @@ const TAG_CTRL_HEADER: u16 = 0x47;
 const TAG_PAGE_DEF: u16 = 0x49;
 const TAG_FOOTNOTE_SHAPE: u16 = 0x4a;
 const CTRL_SECTION_DEF: u32 = u32::from_be_bytes(*b"secd");
+const CTRL_PAGE_NUM_POS: u32 = u32::from_be_bytes(*b"pgnp");
 
 #[derive(Clone, Copy)]
 enum Mutation {
@@ -38,6 +39,14 @@ enum Mutation {
     BadColumnKind,
     ColumnBreakWithoutDefinition,
     MidSectionSeparator,
+    PageNumber,
+    PageNumberMultiSection,
+    BadPageNumberLength,
+    BadPageNumberAttr,
+    BadPageNumberPosition,
+    BadPageNumberFormat,
+    BadPageNumberSurrogate,
+    BadPageNumberUserSymbol,
 }
 
 #[test]
@@ -288,6 +297,76 @@ fn rejects_mid_section_separator_without_owned_vertical_span() {
     ));
 }
 
+#[test]
+fn parses_page_number_position_into_source_neutral_decoration() {
+    let doc = OwnHwp5Parser::new()
+        .parse(&fixture(Mutation::PageNumber))
+        .expect("owned page-number fixture parses");
+    let number = doc.sections[0].page_number.expect("page number");
+    assert_eq!(
+        number.position,
+        hwp_model::document::PageNumberPosition::BottomCenter
+    );
+    assert_eq!(number.format, hwp_model::document::PageNumberFormat::Digit);
+    assert_eq!(
+        (number.prefix, number.suffix, number.dash),
+        (Some('['), Some(']'), Some('-'))
+    );
+}
+
+#[test]
+fn rejects_malformed_or_unowned_page_number_semantics() {
+    for (mutation, reason) in [
+        (
+            Mutation::BadPageNumberLength,
+            "page-number position is not exactly 16 bytes",
+        ),
+        (
+            Mutation::BadPageNumberAttr,
+            "page-number position has unknown attribute bits",
+        ),
+        (
+            Mutation::BadPageNumberPosition,
+            "page-number position is not supported",
+        ),
+        (
+            Mutation::BadPageNumberFormat,
+            "page-number format is not yet supported",
+        ),
+        (
+            Mutation::BadPageNumberSurrogate,
+            "page-number decoration contains a surrogate code unit",
+        ),
+        (
+            Mutation::BadPageNumberUserSymbol,
+            "page-number user-symbol semantics are not yet supported",
+        ),
+    ] {
+        assert!(matches!(
+            OwnHwp5Parser::new().parse(&fixture(mutation)),
+            Err(Error::MalformedRecord {
+                tag: TAG_CTRL_HEADER,
+                section: Some(0),
+                reason: actual,
+                ..
+            }) if actual == reason
+        ));
+    }
+}
+
+#[test]
+fn rejects_multi_section_page_number_until_inheritance_is_owned() {
+    assert!(matches!(
+        OwnHwp5Parser::new().parse(&fixture(Mutation::PageNumberMultiSection)),
+        Err(Error::MalformedRecord {
+            tag: TAG_CTRL_HEADER,
+            section: Some(0),
+            reason: "multi-section page-number inheritance is not yet supported",
+            ..
+        })
+    ));
+}
+
 fn fixture(mutation: Mutation) -> Vec<u8> {
     let mut header = vec![0; 256];
     header[..HWP_SIGNATURE.len()].copy_from_slice(HWP_SIGNATURE);
@@ -295,7 +374,12 @@ fn fixture(mutation: Mutation) -> Vec<u8> {
 
     let mut doc_info = Vec::new();
     let mut properties = vec![0; 26];
-    properties[..2].copy_from_slice(&1u16.to_le_bytes());
+    let section_count = if matches!(mutation, Mutation::PageNumberMultiSection) {
+        2u16
+    } else {
+        1
+    };
+    properties[..2].copy_from_slice(&section_count.to_le_bytes());
     push_record(&mut doc_info, TAG_DOCUMENT_PROPERTIES, 0, &properties);
     let mut mappings = Vec::new();
     for count in [0, 1, 1, 1, 1, 1, 1, 1, 0, 1, 0, 0, 0, 1, 0] {
@@ -310,6 +394,17 @@ fn fixture(mutation: Mutation) -> Vec<u8> {
 
     let mut body = Vec::new();
     let mut section_text = extended_control(0x0002, CTRL_SECTION_DEF);
+    let has_page_number = matches!(
+        mutation,
+        Mutation::PageNumber
+            | Mutation::PageNumberMultiSection
+            | Mutation::BadPageNumberLength
+            | Mutation::BadPageNumberAttr
+            | Mutation::BadPageNumberPosition
+            | Mutation::BadPageNumberFormat
+            | Mutation::BadPageNumberSurrogate
+            | Mutation::BadPageNumberUserSymbol
+    );
     let has_columns = matches!(
         mutation,
         Mutation::Column2
@@ -322,6 +417,9 @@ fn fixture(mutation: Mutation) -> Vec<u8> {
     if has_columns {
         section_text.extend(extended_control(0x0002, u32::from_be_bytes(*b"cold")));
     }
+    if has_page_number {
+        section_text.extend(extended_control(0x0015, CTRL_PAGE_NUM_POS));
+    }
     if matches!(mutation, Mutation::BadControlFrame) {
         section_text[7] = 0;
     }
@@ -329,7 +427,7 @@ fn fixture(mutation: Mutation) -> Vec<u8> {
     push_para_header_with_break(
         &mut body,
         section_text.len() as u32,
-        1 << 2,
+        (1 << 2) | if has_page_number { 1 << 0x15 } else { 0 },
         1,
         0,
         if has_columns {
@@ -405,6 +503,37 @@ fn fixture(mutation: Mutation) -> Vec<u8> {
         }
         push_record(&mut body, TAG_CTRL_HEADER, 1, &column);
     }
+    if has_page_number {
+        let mut control = Vec::with_capacity(16);
+        control.extend_from_slice(&CTRL_PAGE_NUM_POS.to_le_bytes());
+        let attr = if matches!(mutation, Mutation::BadPageNumberAttr) {
+            1u32 << 16
+        } else if matches!(mutation, Mutation::BadPageNumberPosition) {
+            11u32 << 8
+        } else if matches!(mutation, Mutation::BadPageNumberFormat) {
+            6
+        } else {
+            5u32 << 8
+        };
+        control.extend_from_slice(&attr.to_le_bytes());
+        let user = if matches!(mutation, Mutation::BadPageNumberUserSymbol) {
+            '*' as u16
+        } else {
+            0
+        };
+        let prefix = if matches!(mutation, Mutation::BadPageNumberSurrogate) {
+            0xd800
+        } else {
+            '[' as u16
+        };
+        for scalar in [user, prefix, ']' as u16, '-' as u16] {
+            control.extend_from_slice(&scalar.to_le_bytes());
+        }
+        if matches!(mutation, Mutation::BadPageNumberLength) {
+            control.pop();
+        }
+        push_record(&mut body, TAG_CTRL_HEADER, 1, &control);
+    }
 
     if matches!(mutation, Mutation::MidSectionSeparator) {
         let mut text = extended_control(0x0002, u32::from_be_bytes(*b"cold"));
@@ -458,6 +587,10 @@ fn fixture(mutation: Mutation) -> Vec<u8> {
     compound.create_storage("/BodyText").unwrap();
     {
         let mut stream = compound.create_stream("/BodyText/Section0").unwrap();
+        stream.write_all(&body).unwrap();
+    }
+    if matches!(mutation, Mutation::PageNumberMultiSection) {
+        let mut stream = compound.create_stream("/BodyText/Section1").unwrap();
         stream.write_all(&body).unwrap();
     }
     compound.into_inner().into_inner()

--- a/crates/hwp-hwp5/tests/public_probe.rs
+++ b/crates/hwp-hwp5/tests/public_probe.rs
@@ -36,8 +36,8 @@ fn explicit_own_parser_never_falls_back() {
         Error::UnsupportedBodyRecord {
             tag: 0x47,
             section: 0,
-            start: 431,
-            end: 451,
+            start: 451,
+            end: 465,
             reason: "record semantics are not owned",
             ..
         }

--- a/crates/hwp-jsx/src/equality.rs
+++ b/crates/hwp-jsx/src/equality.rs
@@ -56,6 +56,7 @@ pub fn doc_value_eq(a: &SemanticDoc, b: &SemanticDoc) -> bool {
 
 fn section_eq(a: &Section, b: &Section) -> bool {
     page_eq(&a.page, &b.page)
+        && a.page_number == b.page_number
         && a.page_edited == b.page_edited
         && prov_eq(&a.provenance, &b.provenance)
         && pass_eq(&a.passthrough, &b.passthrough)

--- a/crates/hwp-jsx/src/lib.rs
+++ b/crates/hwp-jsx/src/lib.rs
@@ -225,12 +225,44 @@ fn emit_rawparts(parts: &[RawPart]) -> Vec<RawPartBlob> {
 fn emit_section_meta(sec: &Section) -> SectionMeta {
     SectionMeta {
         page: PageSetupBlob::from(&sec.page),
+        page_number: sec.page_number.map(emit_page_number),
         page_edited: sec.page_edited,
         provenance_raw_b64: sec.provenance.raw.as_ref().map(|r| b64(r)),
         provenance_source: sec.provenance.source.map(|s| s.as_str().to_string()),
         passthrough: emit_rawparts(&sec.passthrough.parts),
         dirty: sec.dirty.is_dirty(),
         decorations: sec.decorations.iter().map(emit_decoration).collect(),
+    }
+}
+
+fn emit_page_number(number: PageNumberDecoration) -> PageNumberBlob {
+    PageNumberBlob {
+        format: match number.format {
+            PageNumberFormat::Digit => "digit",
+            PageNumberFormat::CircledDigit => "circled-digit",
+            PageNumberFormat::RomanUpper => "roman-upper",
+            PageNumberFormat::RomanLower => "roman-lower",
+            PageNumberFormat::LatinUpper => "latin-upper",
+            PageNumberFormat::LatinLower => "latin-lower",
+        }
+        .into(),
+        position: match number.position {
+            PageNumberPosition::None => "none",
+            PageNumberPosition::TopLeft => "top-left",
+            PageNumberPosition::TopCenter => "top-center",
+            PageNumberPosition::TopRight => "top-right",
+            PageNumberPosition::BottomLeft => "bottom-left",
+            PageNumberPosition::BottomCenter => "bottom-center",
+            PageNumberPosition::BottomRight => "bottom-right",
+            PageNumberPosition::OutsideTop => "outside-top",
+            PageNumberPosition::OutsideBottom => "outside-bottom",
+            PageNumberPosition::InsideTop => "inside-top",
+            PageNumberPosition::InsideBottom => "inside-bottom",
+        }
+        .into(),
+        prefix: number.prefix,
+        suffix: number.suffix,
+        dash: number.dash,
     }
 }
 
@@ -740,6 +772,11 @@ pub fn parse(proj: &JsxCssProject) -> Result<SemanticDoc> {
         doc.sections.push(Section {
             blocks,
             page: meta.page.into(),
+            page_number: meta
+                .page_number
+                .as_ref()
+                .map(parse_page_number)
+                .transpose()?,
             page_edited: meta.page_edited,
             decorations: meta
                 .decorations
@@ -766,6 +803,43 @@ pub fn parse(proj: &JsxCssProject) -> Result<SemanticDoc> {
     }
 
     Ok(doc)
+}
+
+fn parse_page_number(number: &PageNumberBlob) -> Result<PageNumberDecoration> {
+    let format = match number.format.as_str() {
+        "digit" => PageNumberFormat::Digit,
+        "circled-digit" => PageNumberFormat::CircledDigit,
+        "roman-upper" => PageNumberFormat::RomanUpper,
+        "roman-lower" => PageNumberFormat::RomanLower,
+        "latin-upper" => PageNumberFormat::LatinUpper,
+        "latin-lower" => PageNumberFormat::LatinLower,
+        other => return Err(Error::Parse(format!("unknown page-number format: {other}"))),
+    };
+    let position = match number.position.as_str() {
+        "none" => PageNumberPosition::None,
+        "top-left" => PageNumberPosition::TopLeft,
+        "top-center" => PageNumberPosition::TopCenter,
+        "top-right" => PageNumberPosition::TopRight,
+        "bottom-left" => PageNumberPosition::BottomLeft,
+        "bottom-center" => PageNumberPosition::BottomCenter,
+        "bottom-right" => PageNumberPosition::BottomRight,
+        "outside-top" => PageNumberPosition::OutsideTop,
+        "outside-bottom" => PageNumberPosition::OutsideBottom,
+        "inside-top" => PageNumberPosition::InsideTop,
+        "inside-bottom" => PageNumberPosition::InsideBottom,
+        other => {
+            return Err(Error::Parse(format!(
+                "unknown page-number position: {other}"
+            )))
+        }
+    };
+    Ok(PageNumberDecoration {
+        format,
+        position,
+        prefix: number.prefix,
+        suffix: number.suffix,
+        dash: number.dash,
+    })
 }
 
 fn err(s: String) -> Error {

--- a/crates/hwp-jsx/src/project.rs
+++ b/crates/hwp-jsx/src/project.rs
@@ -79,6 +79,10 @@ pub type ShapeBlob = String;
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct SectionMeta {
     pub page: PageSetupBlob,
+    /// Source-neutral page-number decoration. Optional and defaulted so schema-v1 projects written
+    /// before issue #164 remain readable.
+    #[serde(default)]
+    pub page_number: Option<PageNumberBlob>,
     pub page_edited: bool,
     /// base64 of `Section.provenance.raw` (the original section XML), or None.
     pub provenance_raw_b64: Option<String>,
@@ -86,6 +90,15 @@ pub struct SectionMeta {
     pub passthrough: Vec<RawPartBlob>,
     pub dirty: bool,
     pub decorations: Vec<DecorationBlob>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct PageNumberBlob {
+    pub format: String,
+    pub position: String,
+    pub prefix: Option<char>,
+    pub suffix: Option<char>,
+    pub dash: Option<char>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]

--- a/crates/hwp-jsx/tests/roundtrip.rs
+++ b/crates/hwp-jsx/tests/roundtrip.rs
@@ -56,6 +56,28 @@ fn t1_roundtrip_all_fixtures() {
     }
 }
 
+#[test]
+fn t1d_page_number_semantics_roundtrip_and_are_equality_visible() {
+    let mut doc = SemanticDoc::default();
+    doc.sections.push(Section {
+        page_number: Some(PageNumberDecoration {
+            format: PageNumberFormat::RomanLower,
+            position: PageNumberPosition::OutsideBottom,
+            prefix: Some('('),
+            suffix: Some(')'),
+            dash: Some('-'),
+        }),
+        ..Section::default()
+    });
+
+    let back = parse(&emit(&doc)).expect("page-number projection round-trip");
+    assert!(doc_value_eq(&doc, &back));
+
+    let mut tampered = back;
+    tampered.sections[0].page_number = None;
+    assert!(!doc_value_eq(&doc, &tampered));
+}
+
 /// T1b — the equality test is FALSIFIABLE: mutating the round-tripped doc breaks it.
 #[test]
 fn t1b_equality_is_falsifiable() {

--- a/crates/hwp-model/src/document.rs
+++ b/crates/hwp-model/src/document.rs
@@ -127,6 +127,9 @@ fn block_text(b: &Block, out: &mut String) {
 pub struct Section {
     pub blocks: Vec<Block>,
     pub page: PageSetup,
+    /// Optional page-number decoration scoped to this section. The displayed number is derived from
+    /// final page order by the typesetter; parsers store only source-neutral format/position facts.
+    pub page_number: Option<PageNumberDecoration>,
     /// True once `page` was explicitly edited — the serializer then patches the section's `secPr`
     /// (parsed sections leave this false so their original page setup round-trips verbatim).
     pub page_edited: bool,
@@ -136,6 +139,42 @@ pub struct Section {
     pub provenance: Provenance,
     pub passthrough: Passthrough,
     pub dirty: Dirty,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PageNumberDecoration {
+    pub format: PageNumberFormat,
+    pub position: PageNumberPosition,
+    pub prefix: Option<char>,
+    pub suffix: Option<char>,
+    pub dash: Option<char>,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum PageNumberFormat {
+    #[default]
+    Digit,
+    CircledDigit,
+    RomanUpper,
+    RomanLower,
+    LatinUpper,
+    LatinLower,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum PageNumberPosition {
+    #[default]
+    None,
+    TopLeft,
+    TopCenter,
+    TopRight,
+    BottomLeft,
+    BottomCenter,
+    BottomRight,
+    OutsideTop,
+    OutsideBottom,
+    InsideTop,
+    InsideBottom,
 }
 
 /// A header or footer (master pages deferred) and which pages it applies to.

--- a/crates/hwp-typeset/src/place.rs
+++ b/crates/hwp-typeset/src/place.rs
@@ -2704,7 +2704,7 @@ fn place_section_decorations(
     doc: &SemanticDoc,
     fonts: &dyn FontMetricsProvider,
 ) {
-    if sec.decorations.is_empty() {
+    if sec.decorations.is_empty() && sec.page_number.is_none() {
         return;
     }
     let page = &sec.page;
@@ -2728,7 +2728,156 @@ fn place_section_decorations(
             };
             place_deco_blocks(pg, &deco.blocks, doc, fonts, left, y, band_w, h, page);
         }
+        if let Some(number) = sec.page_number {
+            place_page_number(
+                pg,
+                number,
+                i + 1,
+                fonts,
+                left,
+                header_y,
+                footer_y,
+                band_w,
+                header_h,
+                footer_h,
+            );
+        }
     }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn place_page_number(
+    page: &mut PlacedPage,
+    decoration: PageNumberDecoration,
+    page_number: usize,
+    fonts: &dyn FontMetricsProvider,
+    left: f64,
+    header_y: f64,
+    footer_y: f64,
+    band_w: f64,
+    header_h: f64,
+    footer_h: f64,
+) {
+    if decoration.position == PageNumberPosition::None {
+        return;
+    }
+    let number = format_page_number(page_number, decoration.format);
+    let mut text = String::new();
+    if let Some(dash) = decoration.dash {
+        text.push(dash);
+    }
+    if let Some(prefix) = decoration.prefix {
+        text.push(prefix);
+    }
+    text.push_str(&number);
+    if let Some(suffix) = decoration.suffix {
+        text.push(suffix);
+    }
+    if let Some(dash) = decoration.dash {
+        text.push(dash);
+    }
+
+    let size = 1_000.0;
+    let key = FontKey {
+        family: String::new(),
+        bold: false,
+        italic: false,
+    };
+    let width = text
+        .chars()
+        .map(|ch| fonts.advance_width(&key, ch, size as i32))
+        .sum::<f64>();
+    let is_odd = page_number % 2 == 1;
+    let (top, height, horizontal) = match decoration.position {
+        PageNumberPosition::TopLeft => (header_y, header_h, 0),
+        PageNumberPosition::TopCenter => (header_y, header_h, 1),
+        PageNumberPosition::TopRight => (header_y, header_h, 2),
+        PageNumberPosition::BottomLeft => (footer_y, footer_h, 0),
+        PageNumberPosition::BottomCenter => (footer_y, footer_h, 1),
+        PageNumberPosition::BottomRight => (footer_y, footer_h, 2),
+        PageNumberPosition::OutsideTop => (header_y, header_h, usize::from(is_odd) * 2),
+        PageNumberPosition::OutsideBottom => (footer_y, footer_h, usize::from(is_odd) * 2),
+        PageNumberPosition::InsideTop => (header_y, header_h, usize::from(!is_odd) * 2),
+        PageNumberPosition::InsideBottom => (footer_y, footer_h, usize::from(!is_odd) * 2),
+        PageNumberPosition::None => return,
+    };
+    let mut x = match horizontal {
+        0 => left,
+        1 => left + (band_w - width) / 2.0,
+        _ => left + band_w - width,
+    };
+    let baseline = top + (height.max(size) - size) / 2.0 + BASELINE_RATIO * size;
+    for ch in text.chars() {
+        page.glyphs.push(PlacedGlyph {
+            x,
+            baseline,
+            ch,
+            size,
+            color: Color::default(),
+            underline: false,
+            bold: false,
+            italic: false,
+            font: None,
+            cluster: None,
+        });
+        x += fonts.advance_width(&key, ch, size as i32);
+    }
+}
+
+fn format_page_number(number: usize, format: PageNumberFormat) -> String {
+    match format {
+        PageNumberFormat::Digit => number.to_string(),
+        PageNumberFormat::CircledDigit if (1..=20).contains(&number) => {
+            char::from_u32(0x2460 + number as u32 - 1)
+                .expect("circled digit range is scalar")
+                .to_string()
+        }
+        PageNumberFormat::CircledDigit => number.to_string(),
+        PageNumberFormat::RomanUpper => format_roman(number, true),
+        PageNumberFormat::RomanLower => format_roman(number, false),
+        PageNumberFormat::LatinUpper => format_latin(number, true),
+        PageNumberFormat::LatinLower => format_latin(number, false),
+    }
+}
+
+fn format_roman(mut number: usize, upper: bool) -> String {
+    if number == 0 || number > 3_999 {
+        return number.to_string();
+    }
+    let values = [1_000, 900, 500, 400, 100, 90, 50, 40, 10, 9, 5, 4, 1];
+    let upper_symbols = [
+        "M", "CM", "D", "CD", "C", "XC", "L", "XL", "X", "IX", "V", "IV", "I",
+    ];
+    let lower_symbols = [
+        "m", "cm", "d", "cd", "c", "xc", "l", "xl", "x", "ix", "v", "iv", "i",
+    ];
+    let symbols = if upper {
+        &upper_symbols
+    } else {
+        &lower_symbols
+    };
+    let mut out = String::new();
+    for (value, symbol) in values.into_iter().zip(symbols) {
+        while number >= value {
+            out.push_str(symbol);
+            number -= value;
+        }
+    }
+    out
+}
+
+fn format_latin(mut number: usize, upper: bool) -> String {
+    if number == 0 {
+        return String::new();
+    }
+    let mut out = String::new();
+    while number != 0 {
+        number -= 1;
+        let base = if upper { b'A' } else { b'a' };
+        out.insert(0, (base + (number % 26) as u8) as char);
+        number /= 26;
+    }
+    out
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -2955,6 +3104,170 @@ mod tests {
             .iter()
             .any(|glyph| glyph.x >= 4_000.0));
         assert!(placed.pages[1].glyphs.iter().any(|glyph| glyph.x < 1_000.0));
+    }
+
+    #[test]
+    fn page_number_decoration_does_not_change_pagination_or_body_geometry() {
+        let mut doc = doc_with(vec![Block::Paragraph(para(
+            "가\n나\n다\n라\n마\n바\n사\n아",
+        ))]);
+        doc.sections[0].page = PageSetup {
+            width: 5_000,
+            height: 3_000,
+            margin_left: 500,
+            margin_right: 500,
+            margin_top: 500,
+            margin_bottom: 500,
+            margin_header: 100,
+            margin_footer: 100,
+            ..PageSetup::default()
+        };
+        let without = place_doc(&doc, &ApproxFontMetrics);
+        doc.sections[0].page_number = Some(PageNumberDecoration {
+            format: PageNumberFormat::LatinUpper,
+            position: PageNumberPosition::BottomCenter,
+            prefix: Some('['),
+            suffix: Some(']'),
+            dash: Some('-'),
+        });
+
+        let placed = place_doc(&doc, &ApproxFontMetrics);
+        let naive = crate::NaiveLayout
+            .layout(&doc, &ApproxFontMetrics)
+            .expect("page-number decoration keeps layout valid");
+        assert_eq!(placed.pages.len(), without.pages.len());
+        assert_eq!(placed.pages.len(), naive.pages.len());
+        assert!(placed.pages.len() >= 2);
+        for (before, after) in without.pages.iter().zip(&placed.pages) {
+            assert_eq!(before.rects.len(), after.rects.len());
+            assert_eq!(before.tables.len(), after.tables.len());
+            assert_eq!(before.images.len(), after.images.len());
+            assert!(after.glyphs.len() > before.glyphs.len());
+        }
+        let first_footer = placed.pages[0]
+            .glyphs
+            .iter()
+            .filter(|glyph| glyph.baseline > 2_400.0)
+            .map(|glyph| glyph.ch)
+            .collect::<String>();
+        let second_footer = placed.pages[1]
+            .glyphs
+            .iter()
+            .filter(|glyph| glyph.baseline > 2_400.0)
+            .map(|glyph| glyph.ch)
+            .collect::<String>();
+        assert_eq!(first_footer, "-[A]-");
+        assert_eq!(second_footer, "-[B]-");
+    }
+
+    #[test]
+    fn page_number_formats_are_deterministic_and_bounded() {
+        assert_eq!(format_page_number(20, PageNumberFormat::CircledDigit), "⑳");
+        assert_eq!(format_page_number(21, PageNumberFormat::CircledDigit), "21");
+        assert_eq!(format_page_number(14, PageNumberFormat::RomanUpper), "XIV");
+        assert_eq!(format_page_number(14, PageNumberFormat::RomanLower), "xiv");
+        assert_eq!(format_page_number(27, PageNumberFormat::LatinUpper), "AA");
+        assert_eq!(format_page_number(27, PageNumberFormat::LatinLower), "aa");
+    }
+
+    #[test]
+    fn page_number_positions_map_to_bands_and_duplex_edges() {
+        let decoration = |position| PageNumberDecoration {
+            format: PageNumberFormat::Digit,
+            position,
+            prefix: None,
+            suffix: None,
+            dash: None,
+        };
+        let placed = |position, number| {
+            let mut page = PlacedPage::default();
+            place_page_number(
+                &mut page,
+                decoration(position),
+                number,
+                &ApproxFontMetrics,
+                100.0,
+                200.0,
+                700.0,
+                600.0,
+                100.0,
+                100.0,
+            );
+            page.glyphs.first().map(|glyph| (glyph.x, glyph.baseline))
+        };
+
+        let top_left = placed(PageNumberPosition::TopLeft, 1).unwrap();
+        let top_center = placed(PageNumberPosition::TopCenter, 1).unwrap();
+        let top_right = placed(PageNumberPosition::TopRight, 1).unwrap();
+        let bottom_left = placed(PageNumberPosition::BottomLeft, 1).unwrap();
+        let bottom_center = placed(PageNumberPosition::BottomCenter, 1).unwrap();
+        let bottom_right = placed(PageNumberPosition::BottomRight, 1).unwrap();
+        assert!(top_left.0 < top_center.0 && top_center.0 < top_right.0);
+        assert!(bottom_left.0 < bottom_center.0 && bottom_center.0 < bottom_right.0);
+        assert_eq!(top_left.1, top_center.1);
+        assert_eq!(top_center.1, top_right.1);
+        assert_eq!(bottom_left.1, bottom_center.1);
+        assert_eq!(bottom_center.1, bottom_right.1);
+        assert!(top_left.1 < bottom_left.1);
+        assert!(placed(PageNumberPosition::None, 1).is_none());
+        assert_eq!(
+            placed(PageNumberPosition::OutsideTop, 1).unwrap().0,
+            top_right.0
+        );
+        assert_eq!(
+            placed(PageNumberPosition::OutsideTop, 2).unwrap().0,
+            top_left.0
+        );
+        assert_eq!(
+            placed(PageNumberPosition::InsideBottom, 1).unwrap().0,
+            bottom_left.0
+        );
+        assert_eq!(
+            placed(PageNumberPosition::InsideBottom, 2).unwrap().0,
+            bottom_right.0
+        );
+    }
+
+    #[test]
+    fn page_number_continues_from_final_page_order_across_sections() {
+        let mut doc = doc_with(vec![Block::Paragraph(para("가"))]);
+        doc.sections[0].page = PageSetup {
+            width: 5_000,
+            height: 3_000,
+            margin_left: 500,
+            margin_right: 500,
+            margin_top: 500,
+            margin_bottom: 500,
+            margin_header: 100,
+            margin_footer: 100,
+            ..PageSetup::default()
+        };
+        let number = PageNumberDecoration {
+            format: PageNumberFormat::Digit,
+            position: PageNumberPosition::BottomCenter,
+            prefix: None,
+            suffix: None,
+            dash: None,
+        };
+        doc.sections[0].page_number = Some(number);
+        doc.sections.push(Section {
+            blocks: vec![Block::Paragraph(para("나"))],
+            page: doc.sections[0].page,
+            page_number: Some(number),
+            ..Section::default()
+        });
+
+        let placed = place_doc(&doc, &ApproxFontMetrics);
+        assert_eq!(placed.pages.len(), 2);
+        let footer_text = |page: &PlacedPage| {
+            page.glyphs
+                .iter()
+                .filter(|glyph| glyph.baseline > 2_400.0)
+                .map(|glyph| glyph.ch)
+                .collect::<String>()
+        };
+        assert_eq!(footer_text(&placed.pages[0]), "1");
+        assert_eq!(footer_text(&placed.pages[1]), "2");
     }
 
     #[test]

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,7 +3,7 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
-- 갱신: 2026-08-24 · Codex(sol) — **#164 pgnp full 검증 완료 · PR 준비**.
+- 갱신: 2026-08-24 · Codex(sol) — **#164 PR #165 게시**.
   source-neutral page-number format/position/decorations를 IR과 JSX side-channel/equality에 보존하고,
   HWP5 `pgnp` exact 16B·format 0..5·position 0..10·UTF-16/attr/user-symbol을 strict 파싱한다.
   단일 섹션만 owned로 한정해 미검증 다중 섹션 상속은 정적 사유로 fail-closed한다. 최종 page index로
@@ -12,8 +12,9 @@
   full의 fmt/clippy/workspace, PDF visual **51**, canonical **8/18/24·98.9%+**,
   public corpus **84**, oracle **82**, HWPX, wasm, licenses, JS build와 Vitest **1,018**이 green이다.
   Chromium은 **84 pass/3 intentional skip/1 flaky retry-pass/0 fail**; 공개 경계 0x47/451..465,
-  production route·`external/rhwp`·generated asset diff 0. **다음:** commit/push/PR #164→required CI·
-  review/comment 확인→green 자율 병합.
+  production route·`external/rhwp`·generated asset diff 0. 구현 commit `a5a7b21`을 push하고 PR #165
+  (`Closes #164`, `Refs #94 #161`)를 만들었다. **다음:** state commit push→issue-link/build-test/licenses·
+  mergeability·review/comment 확인→전부 green이면 자율 병합·branch 정리.
 
 - 갱신: 2026-08-23 · Codex(sol) — **#161 PR #163 게시**.
   검증 완료 commit `c751833`을 push하고 PR #163(`Closes #161`, `Refs #94 #160`)을 만들었다.

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,6 +3,18 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
+- 갱신: 2026-08-24 · Codex(sol) — **#164 pgnp full 검증 완료 · PR 준비**.
+  source-neutral page-number format/position/decorations를 IR과 JSX side-channel/equality에 보존하고,
+  HWP5 `pgnp` exact 16B·format 0..5·position 0..10·UTF-16/attr/user-symbol을 strict 파싱한다.
+  단일 섹션만 owned로 한정해 미검증 다중 섹션 상속은 정적 사유로 fail-closed한다. 최종 page index로
+  만든 글리프를 기존 decoration lane에 추가해 본문 geometry/page count를 바꾸지 않고 SVG/PDF 공통
+  PaintOp을 사용하며 상/하·좌/중/우·안/밖 홀짝과 구역 전환 전역 번호를 직접 회귀로 잠갔다.
+  full의 fmt/clippy/workspace, PDF visual **51**, canonical **8/18/24·98.9%+**,
+  public corpus **84**, oracle **82**, HWPX, wasm, licenses, JS build와 Vitest **1,018**이 green이다.
+  Chromium은 **84 pass/3 intentional skip/1 flaky retry-pass/0 fail**; 공개 경계 0x47/451..465,
+  production route·`external/rhwp`·generated asset diff 0. **다음:** commit/push/PR #164→required CI·
+  review/comment 확인→green 자율 병합.
+
 - 갱신: 2026-08-23 · Codex(sol) — **#161 PR #163 게시**.
   검증 완료 commit `c751833`을 push하고 PR #163(`Closes #161`, `Refs #94 #160`)을 만들었다.
   normal 1~32단 strict subset, 3-path LOCKSTEP, SVG/PDF shared line, separator-span/distribution

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,24 @@
 
 ---
 
+## 2026-08-24 (Codex sol) · #164 full green / PR ready
+- full Rust/PDF51/canonical 8·18·24+98.9%/corpus84/oracle82/HWPX/wasm/licenses/JS green.
+- Vitest 1,018; Chromium 84 pass/3 intentional skip/1 retry-pass/0 fail.
+- final boundary 0x47/451..465; production route·rhwp·generated diff 0.
+- 다음 commit/push/PR #164→required CI/review/comment→green 자율 병합.
+
+## 2026-08-24 (Codex sol) · #164 pgnp focused green
+- source-neutral page-number IR + strict single-section HWP5 `pgnp`; multi-section inheritance fail-closed.
+- JSX side-channel/equality preserves semantics; final page index decoration keeps body/page LOCKSTEP.
+- HWP5 20, typeset focused 2, JSX round-trip, PDF 5 glyph replay green; public boundary 451..465.
+- 다음 full→security/diff→commit/push/PR #164→required CI/자율 병합; route/rhwp 불변.
+
+## 2026-08-24 (Codex sol) · PR #163 merged → #164 pgnp started
+- #163 required CI/CLEAN·댓글 0 후 main `80a35d7` 병합; #161 close·remote branch 정리.
+- #94 동기화; next 0x47/431..451 = content-free `pgnp`, raw payload 출력 없음.
+- child #164 + latest-main `codex/issue-164-hwp5-page-number` 시작.
+- 다음 page-number IR→strict parser→shared SVG/PDF paint; route/rhwp 불변.
+
 ## 2026-08-23 (Codex sol) · #161 PR #163 posted
 - verified `c751833` push + PR #163 (`Closes #161`, `Refs #94 #160`).
 - strict normal columns/LOCKSTEP/shared SVG·PDF/fail-closed boundaries and full evidence published.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,12 @@
 
 ---
 
+## 2026-08-24 (Codex sol) · #164 PR #165 posted
+- verified implementation `a5a7b21` push + PR #165 (`Closes #164`, `Refs #94 #161`).
+- strict single-section pgnp/shared SVG·PDF/LOCKSTEP/public boundary and full evidence published.
+- production route·external/rhwp·generated drift 0; browser flake disclosed.
+- 다음 state commit push→required CI/review/comment→green 자율 병합.
+
 ## 2026-08-24 (Codex sol) · #164 full green / PR ready
 - full Rust/PDF51/canonical 8·18·24+98.9%/corpus84/oracle82/HWPX/wasm/licenses/JS green.
 - Vitest 1,018; Chromium 84 pass/3 intentional skip/1 retry-pass/0 fail.


### PR DESCRIPTION
Closes #164
Refs #94 #161

## What changed

- adds source-neutral page-number format, position, and decoration facts to the shared IR and JSX side channel
- strictly parses the owned single-section HWP5 pgnp control, with static content-free failures for malformed, unsupported, duplicate, and multi-section inheritance cases
- derives page-number text from final physical page order and places it in the existing decoration lane, preserving body geometry and LOCKSTEP pagination
- replays the same glyph PaintOps through SVG and PDF; advances the public own-parser boundary to CTRL_HEADER 0x47 section 0 bytes 451..465

## Honest boundary

- multi-section HWP5 page-number inheritance remains fail-closed until an owned fixture proves those semantics
- production HWP5 routing is unchanged and external/rhwp is unchanged
- page-number editing and HWP5 production cutover are not part of this PR

## Verification

- scripts/verify-local.sh: green after final changes
- full Rust workspace, fmt, clippy, hwp-rhwp, wasm, and licenses: green
- canonical layout: 8 / 18 / 24 pages and line accuracy at or above 98.9%
- PDF visual oracle: 51 green; direct page-number replay adds five produced/replayed glyphs with zero stubs
- public corpus contract: 84 green; committed oracle: 82 documents
- HWPX gate and JSX page-number round trip/equality: green
- JS build and Vitest: 1,018 green
- Chromium: 84 passed, 3 intentional skips, 1 retry-pass flake, 0 final failures

No user document content, filename, path, hash, raw payload, credential, or private fixture is included.
