### PR TITLE
feat: own HWP5 nwno page-number restart

### DIFF
--- a/crates/hwp-export/src/pdf.rs
+++ b/crates/hwp-export/src/pdf.rs
@@ -1197,6 +1197,7 @@ mod tests {
         let plain = doc_with(vec![Block::Paragraph(para("본문"))]);
         let mut numbered = plain.clone();
         numbered.sections[0].page_number = Some(PageNumberDecoration {
+            start: std::num::NonZeroU16::new(7).unwrap(),
             format: PageNumberFormat::Digit,
             position: PageNumberPosition::BottomCenter,
             prefix: Some('['),
@@ -1223,7 +1224,7 @@ mod tests {
         assert_eq!(
             numbered_out.replay[0].text.produced,
             plain_out.replay[0].text.produced + 5,
-            "-[1]- is five shared PaintOp::Glyph operations"
+            "-[7]- is five shared PaintOp::Glyph operations"
         );
         assert_eq!(
             numbered_out.replay[0].text.produced,

--- a/crates/hwp-hwp5/src/semantic.rs
+++ b/crates/hwp-hwp5/src/semantic.rs
@@ -24,6 +24,7 @@ const TAG_PAGE_DEF: u16 = 0x49;
 const CTRL_SECTION_DEF: u32 = u32::from_be_bytes(*b"secd");
 const CTRL_COLUMN_DEF: u32 = u32::from_be_bytes(*b"cold");
 const CTRL_PAGE_NUM_POS: u32 = u32::from_be_bytes(*b"pgnp");
+const CTRL_NEW_NUMBER: u32 = u32::from_be_bytes(*b"nwno");
 
 #[derive(Clone, Copy, Debug, Default)]
 struct IdMappings {
@@ -934,7 +935,10 @@ fn parse_section(
     if !allow_page_number {
         if let Some(control) = stream.records.iter().find(|record| {
             record.tag == TAG_CTRL_HEADER
-                && read_u32(data(stream, record), 0) == Some(CTRL_PAGE_NUM_POS)
+                && matches!(
+                    read_u32(data(stream, record), 0),
+                    Some(CTRL_PAGE_NUM_POS) | Some(CTRL_NEW_NUMBER)
+                )
         }) {
             return Err(malformed(
                 control,
@@ -1146,7 +1150,7 @@ fn parse_paragraph(
                 };
                 if !matches!(
                     control_id,
-                    CTRL_SECTION_DEF | CTRL_COLUMN_DEF | CTRL_PAGE_NUM_POS
+                    CTRL_SECTION_DEF | CTRL_COLUMN_DEF | CTRL_PAGE_NUM_POS | CTRL_NEW_NUMBER
                 ) {
                     return Err(unsupported(record, section));
                 }
@@ -1198,6 +1202,7 @@ fn parse_paragraph(
     let mut page = None;
     let mut raw_columns = None;
     let mut page_number = None;
+    let mut page_number_start = None;
     for ((marker_offset, marker_id), (control, children)) in
         decoded.structural_controls.iter().zip(structural_controls)
     {
@@ -1248,8 +1253,31 @@ fn parse_paragraph(
                     section,
                 )?);
             }
+            CTRL_NEW_NUMBER => {
+                if !children.is_empty() || page_number_start.is_some() {
+                    return Err(malformed(
+                        control,
+                        Some(section),
+                        "page-number restart has children or is duplicated",
+                    ));
+                }
+                page_number_start = Some((
+                    parse_new_number_control(data(stream, control), control, section)?,
+                    *control,
+                ));
+            }
             _ => unreachable!("structural control id filtered above"),
         }
+    }
+    if let Some((start, control)) = page_number_start {
+        let Some(number) = page_number.as_mut() else {
+            return Err(malformed(
+                &control,
+                Some(section),
+                "page-number restart requires an owned page-number position",
+            ));
+        };
+        number.start = start;
     }
     if break_type & 0x01 != 0 && page.is_none() {
         return Err(unsupported_reason(
@@ -1409,12 +1437,57 @@ fn parse_page_number_control(
         ));
     }
     Ok(PageNumberDecoration {
+        start: std::num::NonZeroU16::MIN,
         format,
         position,
         prefix: scalar(10)?,
         suffix: scalar(12)?,
         dash: scalar(14)?,
     })
+}
+
+fn parse_new_number_control(
+    bytes: &[u8],
+    record: &Record,
+    section: usize,
+) -> Result<std::num::NonZeroU16> {
+    if bytes.len() != 10 {
+        return Err(malformed(
+            record,
+            Some(section),
+            "new-number control is not exactly 10 bytes",
+        ));
+    }
+    if read_u32(bytes, 0) != Some(CTRL_NEW_NUMBER) {
+        return Err(unsupported(*record, section));
+    }
+    let attr = read_u32(bytes, 4).expect("exact length checked");
+    if attr & !0x0f != 0 {
+        return Err(malformed(
+            record,
+            Some(section),
+            "new-number control has unknown attribute bits",
+        ));
+    }
+    match attr & 0x0f {
+        0 => {}
+        1..=5 => {
+            return Err(malformed(
+                record,
+                Some(section),
+                "non-page new-number counter is not yet supported",
+            ));
+        }
+        _ => {
+            return Err(malformed(
+                record,
+                Some(section),
+                "new-number counter type is not supported",
+            ));
+        }
+    }
+    std::num::NonZeroU16::new(read_u16(bytes, 8).expect("exact length checked"))
+        .ok_or_else(|| malformed(record, Some(section), "page-number restart must be nonzero"))
 }
 
 fn validate_para_usage(
@@ -2043,7 +2116,7 @@ fn decode_text(bytes: &[u8], record: Record, section: usize) -> Result<DecodedTe
                 let control_id = u32::from_le_bytes([lo[0], lo[1], hi[0], hi[1]]);
                 let owned = match unit {
                     0x0002 => matches!(control_id, CTRL_SECTION_DEF | CTRL_COLUMN_DEF),
-                    0x0015 => control_id == CTRL_PAGE_NUM_POS,
+                    0x0015 => matches!(control_id, CTRL_PAGE_NUM_POS | CTRL_NEW_NUMBER),
                     _ => false,
                 };
                 if !owned {

--- a/crates/hwp-hwp5/tests/layout_semantic.rs
+++ b/crates/hwp-hwp5/tests/layout_semantic.rs
@@ -17,6 +17,7 @@ const TAG_PAGE_DEF: u16 = 0x49;
 const TAG_FOOTNOTE_SHAPE: u16 = 0x4a;
 const CTRL_SECTION_DEF: u32 = u32::from_be_bytes(*b"secd");
 const CTRL_PAGE_NUM_POS: u32 = u32::from_be_bytes(*b"pgnp");
+const CTRL_NEW_NUMBER: u32 = u32::from_be_bytes(*b"nwno");
 
 #[derive(Clone, Copy)]
 enum Mutation {
@@ -47,6 +48,14 @@ enum Mutation {
     BadPageNumberFormat,
     BadPageNumberSurrogate,
     BadPageNumberUserSymbol,
+    NewNumber,
+    NewNumberMultiSection,
+    BadNewNumberLength,
+    BadNewNumberAttr,
+    BadNewNumberType,
+    BadNewNumberZero,
+    NewNumberWithoutPageNumber,
+    DuplicateNewNumber,
 }
 
 #[test]
@@ -367,6 +376,74 @@ fn rejects_multi_section_page_number_until_inheritance_is_owned() {
     ));
 }
 
+#[test]
+fn parses_page_number_restart_into_source_neutral_start() {
+    let doc = OwnHwp5Parser::new()
+        .parse(&fixture(Mutation::NewNumber))
+        .expect("owned page-number restart fixture parses");
+    assert_eq!(
+        doc.sections[0]
+            .page_number
+            .expect("page-number decoration")
+            .start
+            .get(),
+        7
+    );
+}
+
+#[test]
+fn rejects_malformed_or_unowned_new_number_semantics() {
+    for (mutation, reason) in [
+        (
+            Mutation::BadNewNumberLength,
+            "new-number control is not exactly 10 bytes",
+        ),
+        (
+            Mutation::BadNewNumberAttr,
+            "new-number control has unknown attribute bits",
+        ),
+        (
+            Mutation::BadNewNumberType,
+            "non-page new-number counter is not yet supported",
+        ),
+        (
+            Mutation::BadNewNumberZero,
+            "page-number restart must be nonzero",
+        ),
+        (
+            Mutation::NewNumberWithoutPageNumber,
+            "page-number restart requires an owned page-number position",
+        ),
+        (
+            Mutation::DuplicateNewNumber,
+            "page-number restart has children or is duplicated",
+        ),
+    ] {
+        assert!(matches!(
+            OwnHwp5Parser::new().parse(&fixture(mutation)),
+            Err(Error::MalformedRecord {
+                tag: TAG_CTRL_HEADER,
+                section: Some(0),
+                reason: actual,
+                ..
+            }) if actual == reason
+        ));
+    }
+}
+
+#[test]
+fn rejects_multi_section_new_number_until_inheritance_is_owned() {
+    assert!(matches!(
+        OwnHwp5Parser::new().parse(&fixture(Mutation::NewNumberMultiSection)),
+        Err(Error::MalformedRecord {
+            tag: TAG_CTRL_HEADER,
+            section: Some(0),
+            reason: "multi-section page-number inheritance is not yet supported",
+            ..
+        })
+    ));
+}
+
 fn fixture(mutation: Mutation) -> Vec<u8> {
     let mut header = vec![0; 256];
     header[..HWP_SIGNATURE.len()].copy_from_slice(HWP_SIGNATURE);
@@ -374,7 +451,10 @@ fn fixture(mutation: Mutation) -> Vec<u8> {
 
     let mut doc_info = Vec::new();
     let mut properties = vec![0; 26];
-    let section_count = if matches!(mutation, Mutation::PageNumberMultiSection) {
+    let section_count = if matches!(
+        mutation,
+        Mutation::PageNumberMultiSection | Mutation::NewNumberMultiSection
+    ) {
         2u16
     } else {
         1
@@ -404,6 +484,24 @@ fn fixture(mutation: Mutation) -> Vec<u8> {
             | Mutation::BadPageNumberFormat
             | Mutation::BadPageNumberSurrogate
             | Mutation::BadPageNumberUserSymbol
+            | Mutation::NewNumber
+            | Mutation::NewNumberMultiSection
+            | Mutation::BadNewNumberLength
+            | Mutation::BadNewNumberAttr
+            | Mutation::BadNewNumberType
+            | Mutation::BadNewNumberZero
+            | Mutation::DuplicateNewNumber
+    );
+    let has_new_number = matches!(
+        mutation,
+        Mutation::NewNumber
+            | Mutation::NewNumberMultiSection
+            | Mutation::BadNewNumberLength
+            | Mutation::BadNewNumberAttr
+            | Mutation::BadNewNumberType
+            | Mutation::BadNewNumberZero
+            | Mutation::NewNumberWithoutPageNumber
+            | Mutation::DuplicateNewNumber
     );
     let has_columns = matches!(
         mutation,
@@ -420,6 +518,12 @@ fn fixture(mutation: Mutation) -> Vec<u8> {
     if has_page_number {
         section_text.extend(extended_control(0x0015, CTRL_PAGE_NUM_POS));
     }
+    if has_new_number {
+        section_text.extend(extended_control(0x0015, CTRL_NEW_NUMBER));
+        if matches!(mutation, Mutation::DuplicateNewNumber) {
+            section_text.extend(extended_control(0x0015, CTRL_NEW_NUMBER));
+        }
+    }
     if matches!(mutation, Mutation::BadControlFrame) {
         section_text[7] = 0;
     }
@@ -427,7 +531,12 @@ fn fixture(mutation: Mutation) -> Vec<u8> {
     push_para_header_with_break(
         &mut body,
         section_text.len() as u32,
-        (1 << 2) | if has_page_number { 1 << 0x15 } else { 0 },
+        (1 << 2)
+            | if has_page_number || has_new_number {
+                1 << 0x15
+            } else {
+                0
+            },
         1,
         0,
         if has_columns {
@@ -534,6 +643,35 @@ fn fixture(mutation: Mutation) -> Vec<u8> {
         }
         push_record(&mut body, TAG_CTRL_HEADER, 1, &control);
     }
+    if has_new_number {
+        let count = if matches!(mutation, Mutation::DuplicateNewNumber) {
+            2
+        } else {
+            1
+        };
+        for _ in 0..count {
+            let mut control = Vec::with_capacity(10);
+            control.extend_from_slice(&CTRL_NEW_NUMBER.to_le_bytes());
+            let attr = if matches!(mutation, Mutation::BadNewNumberAttr) {
+                1u32 << 16
+            } else if matches!(mutation, Mutation::BadNewNumberType) {
+                1
+            } else {
+                0
+            };
+            control.extend_from_slice(&attr.to_le_bytes());
+            let start = if matches!(mutation, Mutation::BadNewNumberZero) {
+                0u16
+            } else {
+                7
+            };
+            control.extend_from_slice(&start.to_le_bytes());
+            if matches!(mutation, Mutation::BadNewNumberLength) {
+                control.pop();
+            }
+            push_record(&mut body, TAG_CTRL_HEADER, 1, &control);
+        }
+    }
 
     if matches!(mutation, Mutation::MidSectionSeparator) {
         let mut text = extended_control(0x0002, u32::from_be_bytes(*b"cold"));
@@ -589,7 +727,10 @@ fn fixture(mutation: Mutation) -> Vec<u8> {
         let mut stream = compound.create_stream("/BodyText/Section0").unwrap();
         stream.write_all(&body).unwrap();
     }
-    if matches!(mutation, Mutation::PageNumberMultiSection) {
+    if matches!(
+        mutation,
+        Mutation::PageNumberMultiSection | Mutation::NewNumberMultiSection
+    ) {
         let mut stream = compound.create_stream("/BodyText/Section1").unwrap();
         stream.write_all(&body).unwrap();
     }

--- a/crates/hwp-hwp5/tests/public_probe.rs
+++ b/crates/hwp-hwp5/tests/public_probe.rs
@@ -36,8 +36,8 @@ fn explicit_own_parser_never_falls_back() {
         Error::UnsupportedBodyRecord {
             tag: 0x47,
             section: 0,
-            start: 451,
-            end: 465,
+            start: 499,
+            end: 549,
             reason: "record semantics are not owned",
             ..
         }

--- a/crates/hwp-jsx/src/lib.rs
+++ b/crates/hwp-jsx/src/lib.rs
@@ -237,6 +237,7 @@ fn emit_section_meta(sec: &Section) -> SectionMeta {
 
 fn emit_page_number(number: PageNumberDecoration) -> PageNumberBlob {
     PageNumberBlob {
+        start: number.start.get(),
         format: match number.format {
             PageNumberFormat::Digit => "digit",
             PageNumberFormat::CircledDigit => "circled-digit",
@@ -806,6 +807,8 @@ pub fn parse(proj: &JsxCssProject) -> Result<SemanticDoc> {
 }
 
 fn parse_page_number(number: &PageNumberBlob) -> Result<PageNumberDecoration> {
+    let start = std::num::NonZeroU16::new(number.start)
+        .ok_or_else(|| Error::Parse("page-number start must be nonzero".into()))?;
     let format = match number.format.as_str() {
         "digit" => PageNumberFormat::Digit,
         "circled-digit" => PageNumberFormat::CircledDigit,
@@ -834,6 +837,7 @@ fn parse_page_number(number: &PageNumberBlob) -> Result<PageNumberDecoration> {
         }
     };
     Ok(PageNumberDecoration {
+        start,
         format,
         position,
         prefix: number.prefix,

--- a/crates/hwp-jsx/src/project.rs
+++ b/crates/hwp-jsx/src/project.rs
@@ -94,11 +94,18 @@ pub struct SectionMeta {
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct PageNumberBlob {
+    /// Defaults to one for schema-v1 projects written before page-number restarts were modeled.
+    #[serde(default = "default_page_number_start")]
+    pub start: u16,
     pub format: String,
     pub position: String,
     pub prefix: Option<char>,
     pub suffix: Option<char>,
     pub dash: Option<char>,
+}
+
+fn default_page_number_start() -> u16 {
+    1
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]

--- a/crates/hwp-jsx/tests/roundtrip.rs
+++ b/crates/hwp-jsx/tests/roundtrip.rs
@@ -61,6 +61,7 @@ fn t1d_page_number_semantics_roundtrip_and_are_equality_visible() {
     let mut doc = SemanticDoc::default();
     doc.sections.push(Section {
         page_number: Some(PageNumberDecoration {
+            start: std::num::NonZeroU16::new(7).unwrap(),
             format: PageNumberFormat::RomanLower,
             position: PageNumberPosition::OutsideBottom,
             prefix: Some('('),
@@ -70,12 +71,37 @@ fn t1d_page_number_semantics_roundtrip_and_are_equality_visible() {
         ..Section::default()
     });
 
-    let back = parse(&emit(&doc)).expect("page-number projection round-trip");
+    let mut projected = emit(&doc);
+    assert_eq!(
+        projected.manifest.sections[0]
+            .page_number
+            .as_ref()
+            .unwrap()
+            .start,
+        7
+    );
+    let back = parse(&projected).expect("page-number projection round-trip");
     assert!(doc_value_eq(&doc, &back));
+
+    projected.manifest.sections[0]
+        .page_number
+        .as_mut()
+        .unwrap()
+        .start = 0;
+    assert!(parse(&projected).is_err(), "zero restart must fail closed");
 
     let mut tampered = back;
     tampered.sections[0].page_number = None;
     assert!(!doc_value_eq(&doc, &tampered));
+}
+
+#[test]
+fn t1e_legacy_page_number_blob_defaults_restart_to_one() {
+    let blob: hwp_jsx::project::PageNumberBlob = serde_json::from_str(
+        r#"{"format":"digit","position":"bottom-center","prefix":null,"suffix":null,"dash":null}"#,
+    )
+    .expect("pre-restart schema-v1 blob remains readable");
+    assert_eq!(blob.start, 1);
 }
 
 /// T1b — the equality test is FALSIFIABLE: mutating the round-tripped doc breaks it.

--- a/crates/hwp-model/src/document.rs
+++ b/crates/hwp-model/src/document.rs
@@ -5,6 +5,7 @@
 use crate::style::{CharShape, ParaShape};
 use crate::types::{Dirty, HwpUnit, NodeId, Passthrough, Provenance};
 use std::collections::{BTreeMap, BTreeSet};
+use std::num::NonZeroU16;
 
 /// A whole document.
 #[derive(Clone, Debug, Default)]
@@ -127,8 +128,8 @@ fn block_text(b: &Block, out: &mut String) {
 pub struct Section {
     pub blocks: Vec<Block>,
     pub page: PageSetup,
-    /// Optional page-number decoration scoped to this section. The displayed number is derived from
-    /// final page order by the typesetter; parsers store only source-neutral format/position facts.
+    /// Optional page-number decoration scoped to this section. The typesetter derives progression
+    /// from the source-neutral section start, format, position, and final page order.
     pub page_number: Option<PageNumberDecoration>,
     /// True once `page` was explicitly edited — the serializer then patches the section's `secPr`
     /// (parsed sections leave this false so their original page setup round-trips verbatim).
@@ -143,6 +144,8 @@ pub struct Section {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PageNumberDecoration {
+    /// The first visible number in this section. Zero is not a valid authored restart value.
+    pub start: NonZeroU16,
     pub format: PageNumberFormat,
     pub position: PageNumberPosition,
     pub prefix: Option<char>,

--- a/crates/hwp-typeset/src/place.rs
+++ b/crates/hwp-typeset/src/place.rs
@@ -2732,7 +2732,7 @@ fn place_section_decorations(
             place_page_number(
                 pg,
                 number,
-                i + 1,
+                usize::from(number.start.get()) + (i - first_page),
                 fonts,
                 left,
                 header_y,
@@ -3124,6 +3124,7 @@ mod tests {
         };
         let without = place_doc(&doc, &ApproxFontMetrics);
         doc.sections[0].page_number = Some(PageNumberDecoration {
+            start: std::num::NonZeroU16::new(7).unwrap(),
             format: PageNumberFormat::LatinUpper,
             position: PageNumberPosition::BottomCenter,
             prefix: Some('['),
@@ -3156,8 +3157,8 @@ mod tests {
             .filter(|glyph| glyph.baseline > 2_400.0)
             .map(|glyph| glyph.ch)
             .collect::<String>();
-        assert_eq!(first_footer, "-[A]-");
-        assert_eq!(second_footer, "-[B]-");
+        assert_eq!(first_footer, "-[G]-");
+        assert_eq!(second_footer, "-[H]-");
     }
 
     #[test]
@@ -3173,6 +3174,7 @@ mod tests {
     #[test]
     fn page_number_positions_map_to_bands_and_duplex_edges() {
         let decoration = |position| PageNumberDecoration {
+            start: std::num::NonZeroU16::MIN,
             format: PageNumberFormat::Digit,
             position,
             prefix: None,
@@ -3229,7 +3231,7 @@ mod tests {
     }
 
     #[test]
-    fn page_number_continues_from_final_page_order_across_sections() {
+    fn page_number_restart_is_scoped_to_each_section() {
         let mut doc = doc_with(vec![Block::Paragraph(para("가"))]);
         doc.sections[0].page = PageSetup {
             width: 5_000,
@@ -3243,6 +3245,7 @@ mod tests {
             ..PageSetup::default()
         };
         let number = PageNumberDecoration {
+            start: std::num::NonZeroU16::MIN,
             format: PageNumberFormat::Digit,
             position: PageNumberPosition::BottomCenter,
             prefix: None,
@@ -3250,10 +3253,14 @@ mod tests {
             dash: None,
         };
         doc.sections[0].page_number = Some(number);
+        let restarted = PageNumberDecoration {
+            start: std::num::NonZeroU16::new(7).unwrap(),
+            ..number
+        };
         doc.sections.push(Section {
             blocks: vec![Block::Paragraph(para("나"))],
             page: doc.sections[0].page,
-            page_number: Some(number),
+            page_number: Some(restarted),
             ..Section::default()
         });
 
@@ -3267,7 +3274,7 @@ mod tests {
                 .collect::<String>()
         };
         assert_eq!(footer_text(&placed.pages[0]), "1");
-        assert_eq!(footer_text(&placed.pages[1]), "2");
+        assert_eq!(footer_text(&placed.pages[1]), "7");
     }
 
     #[test]

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,7 +3,7 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
-- 갱신: 2026-08-24 · Codex(sol) — **#166 `nwno` 구현·full 검증 완료 / PR 준비**.
+- 갱신: 2026-08-24 · Codex(sol) — **#166 `nwno` 구현·full green / PR #167 게시**.
   `PageNumberDecoration.start: NonZeroU16`을 source-neutral IR과 JSX side-channel/equality에 추가하고,
   기존 schema-v1 blob은 start=1로 읽되 0은 거부한다. HWP5 exact 10B `nwno`의 page counter만 strict
   파싱해 같은 첫 문단의 owned `pgnp`에 결합하며 unknown attr·비page counter·0·중복·position 누락·
@@ -14,8 +14,11 @@
   oracle **82**, HWPX, wasm(7,810,113B), licenses, JS build·crosscheck·i18n, Vitest **1,018**이 green;
   Chromium **85 pass/3 intentional skip/0 fail**이다. fresh worktree node_modules와 sandbox port는
   루트 설치 임시 링크/허용된 로컬 서버로 분리 검증 후 링크를 제거했다. production route·
-  `external/rhwp`·generated asset diff 0. **다음:** final diff/security review→commit/push→PR `Closes
-  #166`/`Refs #94 #164`→required CI/review/comment 추적→green 자율 병합→다음 499..549 원인 분해.
+  `external/rhwp`·generated asset diff 0. 구현 commit `4ed836a`과 PR #167(`Closes #166`,
+  `Refs #94 #164`)을 게시했다. 최초 PR-open stdin 오류로 빈 본문 event의 issue-link가 실패했고 현재
+  본문은 즉시 복구됐지만 rerun은 최초 payload를 재사용해 같은 실패를 냈다; 이 상태 commit push의
+  새 synchronize event로 재검증한다. build-test **9m19s**·licenses **2m22s**는 이미 green이다.
+  **다음:** state push→새 issue-link/required CI·review/comment→green 자율 병합→499..549 원인 분해.
 
 - 갱신: 2026-08-23 · Codex(sol) — **#161 PR #163 게시**.
   검증 완료 commit `c751833`을 push하고 PR #163(`Closes #161`, `Refs #94 #160`)을 만들었다.

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,18 +3,19 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
-- 갱신: 2026-08-24 · Codex(sol) — **#164 PR #165 게시**.
-  source-neutral page-number format/position/decorations를 IR과 JSX side-channel/equality에 보존하고,
-  HWP5 `pgnp` exact 16B·format 0..5·position 0..10·UTF-16/attr/user-symbol을 strict 파싱한다.
-  단일 섹션만 owned로 한정해 미검증 다중 섹션 상속은 정적 사유로 fail-closed한다. 최종 page index로
-  만든 글리프를 기존 decoration lane에 추가해 본문 geometry/page count를 바꾸지 않고 SVG/PDF 공통
-  PaintOp을 사용하며 상/하·좌/중/우·안/밖 홀짝과 구역 전환 전역 번호를 직접 회귀로 잠갔다.
-  full의 fmt/clippy/workspace, PDF visual **51**, canonical **8/18/24·98.9%+**,
-  public corpus **84**, oracle **82**, HWPX, wasm, licenses, JS build와 Vitest **1,018**이 green이다.
-  Chromium은 **84 pass/3 intentional skip/1 flaky retry-pass/0 fail**; 공개 경계 0x47/451..465,
-  production route·`external/rhwp`·generated asset diff 0. 구현 commit `a5a7b21`을 push하고 PR #165
-  (`Closes #164`, `Refs #94 #161`)를 만들었다. **다음:** state commit push→issue-link/build-test/licenses·
-  mergeability·review/comment 확인→전부 green이면 자율 병합·branch 정리.
+- 갱신: 2026-08-24 · Codex(sol) — **#166 `nwno` 구현·full 검증 완료 / PR 준비**.
+  `PageNumberDecoration.start: NonZeroU16`을 source-neutral IR과 JSX side-channel/equality에 추가하고,
+  기존 schema-v1 blob은 start=1로 읽되 0은 거부한다. HWP5 exact 10B `nwno`의 page counter만 strict
+  파싱해 같은 첫 문단의 owned `pgnp`에 결합하며 unknown attr·비page counter·0·중복·position 누락·
+  다중 구역 상속은 content-free 정적 사유로 fail-closed한다. 조판은 구역 start+최종 physical page
+  order로 SVG/PDF 공통 glyph를 만들고 body geometry/page count 및 3-path LOCKSTEP은 불변이다.
+  공개 benchmark 자체 파서 경계는 `0x47/451..465`에서 `0x47/499..549`로 전진했다. Rust workspace,
+  HWP5 **48**, typeset **94**, PDF visual **51**, canonical **8/18/24·98.9%+**, public corpus **84**,
+  oracle **82**, HWPX, wasm(7,810,113B), licenses, JS build·crosscheck·i18n, Vitest **1,018**이 green;
+  Chromium **85 pass/3 intentional skip/0 fail**이다. fresh worktree node_modules와 sandbox port는
+  루트 설치 임시 링크/허용된 로컬 서버로 분리 검증 후 링크를 제거했다. production route·
+  `external/rhwp`·generated asset diff 0. **다음:** final diff/security review→commit/push→PR `Closes
+  #166`/`Refs #94 #164`→required CI/review/comment 추적→green 자율 병합→다음 499..549 원인 분해.
 
 - 갱신: 2026-08-23 · Codex(sol) — **#161 PR #163 게시**.
   검증 완료 commit `c751833`을 push하고 PR #163(`Closes #161`, `Refs #94 #160`)을 만들었다.

--- a/docs/HWP5-NATIVE-PARSER.md
+++ b/docs/HWP5-NATIVE-PARSER.md
@@ -64,7 +64,9 @@ rejected instead of being interpreted as records.
   unknown body controls, and unsupported pool values fail closed with a static reason plus tag,
   section, and byte span only. It cannot call rhwp. The public benchmark now passes its first
   multi-column paragraph header and `cold` definition, then stops at the next unowned control header
-  (`0x47`, section 0, bytes 431..451) without exposing content.
+  (`0x47`, section 0, bytes 499..549) without exposing content. The owned prefix now includes strict
+  single-section `pgnp` positioning and `nwno` page-counter restarts; other counters, zero starts,
+  duplicates, missing positions, and multi-section inheritance fail closed.
 - `hwp5_differential`: explicitly runs the owned probe and current rhwp semantic oracle, then reports
   section/paragraph/run/table/image/control/equation/chart counts and their deltas.
 

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,18 @@
 
 ---
 
+## 2026-08-24 (Codex sol) · #166 nwno full green / PR ready
+- NonZero start IR+legacy JSX default; exact page-counter nwno와 hostile fail-closed 구현.
+- shared SVG/PDF progression·LOCKSTEP; public boundary 451..465→499..549.
+- Rust/PDF51/canonical/corpus84/oracle82/HWPX/wasm/licenses/JS/Vitest1,018/Chromium85 green.
+- route·rhwp·generated diff 0; 다음 commit/push/PR→CI→green 자율 병합→next boundary.
+
+## 2026-08-24 (Codex sol) · PR #165 merged → #166 nwno started
+- #165 required CI/CLEAN·댓글 0 후 main `ff449e4` 병합; #164 close·remote branch 정리.
+- #94 동기화; next 0x47/451..465 = content-free `nwno`, temporary structural assertion removed.
+- child #166 + latest-main `codex/issue-166-hwp5-new-number` 시작.
+- 다음 page start IR→strict parser→shared SVG/PDF progression; route/rhwp 불변.
+
 ## 2026-08-24 (Codex sol) · #164 PR #165 posted
 - verified implementation `a5a7b21` push + PR #165 (`Closes #164`, `Refs #94 #161`).
 - strict single-section pgnp/shared SVG·PDF/LOCKSTEP/public boundary and full evidence published.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,12 @@
 
 ---
 
+## 2026-08-24 (Codex sol) · #166 PR #167 posted
+- 구현 `4ed836a` push + PR #167; build-test 9m19s·licenses 2m22s green.
+- 최초 빈-body event는 본문 복구 뒤에도 rerun payload가 stale이라 issue-link 재실패.
+- 현재 본문은 `Closes #166`; state commit push로 새 synchronize event를 트리거한다.
+- 다음 required CI/review/comment→green 자율 병합→next 499..549.
+
 ## 2026-08-24 (Codex sol) · #166 nwno full green / PR ready
 - NonZero start IR+legacy JSX default; exact page-counter nwno와 hostile fail-closed 구현.
 - shared SVG/PDF progression·LOCKSTEP; public boundary 451..465→499..549.


### PR DESCRIPTION
Closes #166
Refs #94 #164

## What changed
- Add a source-neutral, non-zero section page-number start to the shared IR and JSX side channel.
- Parse the strict 10-byte HWP5 nwno page-counter subset and combine it with the owned first-paragraph pgnp.
- Derive visible numbers from section start plus final physical page order in the shared SVG/PDF decoration lane.
- Fail closed on unknown attributes, non-page counters, zero, duplicates, missing position, and multi-section inheritance.
- Advance the public own-parser boundary from 0x47/451..465 to 0x47/499..549.

## Invariants
- Body geometry and place_doc/NaiveLayout/fragment pagination lockstep are unchanged.
- Production HWP5 route is unchanged; this remains an explicit own-parser candidate.
- external/rhwp and generated asset diff: 0.
- No source content, raw payload, local path, or private fixture is published.

## Verification
- Rust workspace and clippy -D warnings.
- HWP5 48 tests; typeset 94 tests.
- PDF visual oracle 51/51 and direct -[7]- glyph replay (produced=replayed, stubbed=0).
- Canonical 8/18/24 pages and 98.9%+ line accuracy.
- Public corpus 84; oracle 82; HWPX locks; wasm; licenses.
- JS builds, caret cross-check, i18n gate, Vitest 1,018.
- Chromium E2E 85 passed / 3 intentional skips / 0 failed.

Fresh-worktree JS dependencies were linked temporarily from the existing root install and removed after verification. The sandbox-only port bind denial was rerun with the approved local Playwright server.