### PR TITLE
feat: own strict HWP5 inline 1x1 table

### DIFF
--- a/crates/hwp-hwp5/src/semantic.rs
+++ b/crates/hwp-hwp5/src/semantic.rs
@@ -19,12 +19,15 @@ const TAG_PARA_TEXT: u16 = 0x43;
 const TAG_PARA_CHAR_SHAPE: u16 = 0x44;
 const TAG_PARA_LINE_SEG: u16 = 0x45;
 const TAG_CTRL_HEADER: u16 = 0x47;
+const TAG_LIST_HEADER: u16 = 0x48;
 const TAG_PAGE_DEF: u16 = 0x49;
+const TAG_TABLE: u16 = 0x4d;
 
 const CTRL_SECTION_DEF: u32 = u32::from_be_bytes(*b"secd");
 const CTRL_COLUMN_DEF: u32 = u32::from_be_bytes(*b"cold");
 const CTRL_PAGE_NUM_POS: u32 = u32::from_be_bytes(*b"pgnp");
 const CTRL_NEW_NUMBER: u32 = u32::from_be_bytes(*b"nwno");
+const CTRL_TABLE: u32 = u32::from_be_bytes(*b"tbl ");
 
 #[derive(Clone, Copy, Debug, Default)]
 struct IdMappings {
@@ -979,7 +982,7 @@ fn parse_section(
             .get(ordinal + 1)
             .copied()
             .unwrap_or(stream.records.len());
-        let parsed = parse_paragraph(
+        let mut parsed = parse_paragraph(
             stream,
             &stream.records[start..end],
             doc,
@@ -1036,7 +1039,22 @@ fn parse_section(
             separator_zone_seen |= has_separator;
             has_active_columns = true;
         }
+        if !parsed.tables.is_empty() {
+            if parsed.paragraph.runs.iter().any(|run| {
+                run.content
+                    .iter()
+                    .any(|inline| matches!(inline, Inline::Text(text) if !text.is_empty()))
+            }) {
+                return Err(malformed(
+                    &stream.records[start],
+                    Some(section),
+                    "owned inline table host also contains visible text",
+                ));
+            }
+            parsed.paragraph.is_table_anchor = true;
+        }
         blocks.push(Block::Paragraph(parsed.paragraph));
+        blocks.extend(parsed.tables.into_iter().map(Block::Table));
     }
     Ok(Section {
         blocks,
@@ -1054,6 +1072,7 @@ struct ParsedParagraph {
     paragraph: Paragraph,
     page: Option<PageSetup>,
     page_number: Option<PageNumberDecoration>,
+    tables: Vec<Table>,
 }
 
 fn parse_paragraph(
@@ -1066,6 +1085,10 @@ fn parse_paragraph(
     _current_page: Option<&PageSetup>,
 ) -> Result<ParsedParagraph> {
     let header = records[0];
+    let base_level = header.level;
+    if header.tag != TAG_PARA_HEADER {
+        return Err(unsupported(header, section));
+    }
     let header_data = data(stream, &header);
     if header_data.len() < 22 {
         return Err(malformed(
@@ -1133,7 +1156,7 @@ fn parse_paragraph(
     let mut cursor = 1usize;
     while cursor < records.len() {
         let record = records[cursor];
-        if record.level != 1 {
+        if record.level != base_level + 1 {
             return Err(unsupported(record, section));
         }
         match record.tag {
@@ -1150,13 +1173,17 @@ fn parse_paragraph(
                 };
                 if !matches!(
                     control_id,
-                    CTRL_SECTION_DEF | CTRL_COLUMN_DEF | CTRL_PAGE_NUM_POS | CTRL_NEW_NUMBER
+                    CTRL_SECTION_DEF
+                        | CTRL_COLUMN_DEF
+                        | CTRL_PAGE_NUM_POS
+                        | CTRL_NEW_NUMBER
+                        | CTRL_TABLE
                 ) {
                     return Err(unsupported(record, section));
                 }
                 let start = cursor;
                 cursor += 1;
-                while cursor < records.len() && records[cursor].level > 1 {
+                while cursor < records.len() && records[cursor].level > base_level + 1 {
                     cursor += 1;
                 }
                 structural_controls.push((&records[start], &records[start + 1..cursor]));
@@ -1203,6 +1230,7 @@ fn parse_paragraph(
     let mut raw_columns = None;
     let mut page_number = None;
     let mut page_number_start = None;
+    let mut tables = Vec::new();
     for ((marker_offset, marker_id), (control, children)) in
         decoded.structural_controls.iter().zip(structural_controls)
     {
@@ -1223,7 +1251,9 @@ fn parse_paragraph(
                         "section definition marker is duplicate or not at paragraph start",
                     ));
                 }
-                page = Some(parse_section_control(stream, control, children, section)?);
+                page = Some(parse_section_control(
+                    stream, control, children, doc, section,
+                )?);
             }
             CTRL_COLUMN_DEF => {
                 if !children.is_empty() || raw_columns.is_some() {
@@ -1240,31 +1270,58 @@ fn parse_paragraph(
                 )?);
             }
             CTRL_PAGE_NUM_POS => {
-                if !children.is_empty() || page_number.is_some() {
+                if !children.is_empty() {
                     return Err(malformed(
                         control,
                         Some(section),
-                        "page-number position has children or is duplicated",
+                        "page-number position has children",
                     ));
                 }
-                page_number = Some(parse_page_number_control(
-                    data(stream, control),
-                    control,
-                    section,
-                )?);
+                let candidate = parse_page_number_control(data(stream, control), control, section)?;
+                match page_number {
+                    Some(existing) if existing == candidate => {}
+                    Some(_) => {
+                        return Err(malformed(
+                            control,
+                            Some(section),
+                            "page-number positions are duplicated with conflicting semantics",
+                        ));
+                    }
+                    None => page_number = Some(candidate),
+                }
             }
             CTRL_NEW_NUMBER => {
-                if !children.is_empty() || page_number_start.is_some() {
+                if !children.is_empty() {
                     return Err(malformed(
                         control,
                         Some(section),
-                        "page-number restart has children or is duplicated",
+                        "page-number restart has children",
                     ));
                 }
-                page_number_start = Some((
-                    parse_new_number_control(data(stream, control), control, section)?,
-                    *control,
-                ));
+                let candidate = parse_new_number_control(data(stream, control), control, section)?;
+                match page_number_start {
+                    Some((existing, _)) if existing == candidate => {}
+                    Some(_) => {
+                        return Err(malformed(
+                            control,
+                            Some(section),
+                            "page-number restarts are duplicated with conflicting semantics",
+                        ));
+                    }
+                    None => page_number_start = Some((candidate, *control)),
+                }
+            }
+            CTRL_TABLE => {
+                if tables.len() == 1 {
+                    return Err(malformed(
+                        control,
+                        Some(section),
+                        "owned paragraph contains duplicate tables",
+                    ));
+                }
+                tables.push(parse_inline_table(
+                    stream, control, children, doc, para_usage, styles, section,
+                )?);
             }
             _ => unreachable!("structural control id filtered above"),
         }
@@ -1354,6 +1411,7 @@ fn parse_paragraph(
         paragraph,
         page,
         page_number,
+        tables,
     })
 }
 
@@ -1490,6 +1548,240 @@ fn parse_new_number_control(
         .ok_or_else(|| malformed(record, Some(section), "page-number restart must be nonzero"))
 }
 
+/// Own the first bounded binary-table slice seen in the public corpus: an inline, treat-as-character
+/// 1×1 table with one cell paragraph. The strict framing is intentional. A larger or floating table
+/// must fail closed until its positioning, split, caption, merge, and cell-list semantics are typed.
+#[allow(clippy::too_many_arguments)]
+fn parse_inline_table(
+    stream: &StreamProbe,
+    control: &Record,
+    children: &[Record],
+    doc: &SemanticDoc,
+    para_usage: &[ParaUsage],
+    styles: &[StyleDef],
+    section: usize,
+) -> Result<Table> {
+    let common = data(stream, control);
+    if common.len() != 46 || read_u32(common, 0) != Some(CTRL_TABLE) {
+        return Err(malformed(
+            control,
+            Some(section),
+            "inline table CTRL_HEADER is not the owned 46-byte record",
+        ));
+    }
+    // Observed public slice: treat-as-char, para-relative inline placement, top-and-bottom wrapping,
+    // and the known storage high bit. Exact matching prevents a floating object from being flattened.
+    if read_u32(common, 4) != Some(0x082a_2311) {
+        return Err(malformed(
+            control,
+            Some(section),
+            "inline table common-object attributes are not owned",
+        ));
+    }
+    if read_u32(common, 8) != Some(0) || read_u32(common, 12) != Some(0) {
+        return Err(malformed(
+            control,
+            Some(section),
+            "inline table offsets must be zero",
+        ));
+    }
+    let width = read_u32(common, 16).expect("exact length checked");
+    let height = read_u32(common, 20).expect("exact length checked");
+    const MAX_OBJECT_HWPUNIT: u32 = 10_000_000;
+    if width == 0 || height == 0 || width > MAX_OBJECT_HWPUNIT || height > MAX_OBJECT_HWPUNIT {
+        return Err(malformed(
+            control,
+            Some(section),
+            "inline table dimensions are not positive and bounded",
+        ));
+    }
+    let margin = |at: usize| i16::from_le_bytes(common[at..at + 2].try_into().unwrap());
+    let margins = [margin(28), margin(30), margin(32), margin(34)];
+    if margins.iter().any(|value| *value < 0) {
+        return Err(malformed(
+            control,
+            Some(section),
+            "inline table outer margins must be nonnegative",
+        ));
+    }
+    if read_i32(common, 40) != Some(0) || read_u16(common, 44) != Some(0) {
+        return Err(malformed(
+            control,
+            Some(section),
+            "inline table page-break prevention or description is not owned",
+        ));
+    }
+    if children.len() < 3
+        || children[0].tag != TAG_TABLE
+        || children[1].tag != TAG_LIST_HEADER
+        || children[2].tag != TAG_PARA_HEADER
+        || children[0].level != control.level + 1
+        || children[1].level != control.level + 1
+        || children[2].level != control.level + 1
+    {
+        return Err(malformed(
+            control,
+            Some(section),
+            "inline table child topology is not exactly TABLE, LIST_HEADER, paragraph",
+        ));
+    }
+
+    let table_record = children[0];
+    let table_bytes = data(stream, &table_record);
+    if table_bytes.len() != 24 {
+        return Err(unsupported(table_record, section));
+    }
+    if read_u32(table_bytes, 0) != Some(0x0400_0006)
+        || read_u16(table_bytes, 4) != Some(1)
+        || read_u16(table_bytes, 6) != Some(1)
+        || read_u16(table_bytes, 8) != Some(0)
+        || read_u16(table_bytes, 18) != Some(1)
+        || read_u16(table_bytes, 22) != Some(0)
+    {
+        return Err(malformed(
+            &table_record,
+            Some(section),
+            "TABLE attributes or 1x1 topology are not owned",
+        ));
+    }
+    let table_padding = [10usize, 12, 14, 16]
+        .map(|at| i16::from_le_bytes(table_bytes[at..at + 2].try_into().unwrap()));
+    if table_padding.iter().any(|value| *value < 0) {
+        return Err(malformed(
+            &table_record,
+            Some(section),
+            "TABLE padding must be nonnegative",
+        ));
+    }
+    let table_border_id = read_u16(table_bytes, 20).expect("exact length checked");
+    let table_fill = table_border(doc, table_border_id, &table_record, section, "table")?;
+
+    let list_record = children[1];
+    let list_bytes = data(stream, &list_record);
+    if list_bytes.len() != 47 {
+        return Err(malformed(
+            &list_record,
+            Some(section),
+            "owned cell LIST_HEADER is not exactly 47 bytes",
+        ));
+    }
+    if read_u16(list_bytes, 0) != Some(1)
+        || read_u32(list_bytes, 2) != Some(0x0020_0000)
+        || read_u16(list_bytes, 6) != Some(0x0500)
+        || read_u16(list_bytes, 8) != Some(0)
+        || read_u16(list_bytes, 10) != Some(0)
+        || read_u16(list_bytes, 12) != Some(1)
+        || read_u16(list_bytes, 14) != Some(1)
+        || read_u32(list_bytes, 16) != Some(width)
+        || read_u32(list_bytes, 20) != Some(height)
+    {
+        return Err(malformed(
+            &list_record,
+            Some(section),
+            "cell LIST_HEADER attributes or geometry are not the owned centered 1x1 slice",
+        ));
+    }
+    let cell_padding = [24usize, 26, 28, 30]
+        .map(|at| i16::from_le_bytes(list_bytes[at..at + 2].try_into().unwrap()));
+    if cell_padding.iter().any(|value| *value < 0) {
+        return Err(malformed(
+            &list_record,
+            Some(section),
+            "cell stored padding must be nonnegative",
+        ));
+    }
+    // The pinned parser can only materialize a field name from an extension of at least 18 bytes.
+    // This exact 13-byte public storage tail carries no typed field in that oracle and is discarded;
+    // any other length remains unsupported instead of becoming passthrough executable/content data.
+    debug_assert_eq!(list_bytes[34..].len(), 13);
+    let cell_border_id = read_u16(list_bytes, 32).expect("exact length checked");
+    let cell_fill = table_border(doc, cell_border_id, &list_record, section, "table cell")?;
+
+    let parsed_cell = parse_paragraph(
+        stream,
+        &children[2..],
+        doc,
+        para_usage,
+        styles,
+        section,
+        None,
+    )?;
+    if parsed_cell.page.is_some()
+        || parsed_cell.page_number.is_some()
+        || !parsed_cell.tables.is_empty()
+        || parsed_cell.paragraph.page_break_before
+        || parsed_cell.paragraph.column_break_before
+        || parsed_cell.paragraph.column_layout_before.is_some()
+    {
+        return Err(malformed(
+            &children[2],
+            Some(section),
+            "owned table cell paragraph contains nested layout controls",
+        ));
+    }
+
+    let cell = Cell {
+        row: 0,
+        col: 0,
+        row_span: 1,
+        col_span: 1,
+        blocks: vec![Block::Paragraph(parsed_cell.paragraph)],
+        active: true,
+        shade_color: cell_fill.shade,
+        has_border: cell_fill.has_border,
+        borders: cell_fill.borders,
+        diagonal: cell_fill.diagonal,
+        // width_ref low bit is off: stored cell padding is inactive and table padding is inherited.
+        padding: None,
+        width: Some(width as HwpUnit),
+        ..Cell::default()
+    };
+    Ok(Table {
+        rows: 1,
+        cols: 1,
+        cells: vec![cell],
+        col_widths: vec![width as HwpUnit],
+        row_heights: vec![height as HwpUnit],
+        outer_margin_left: margins[0] as HwpUnit,
+        outer_margin_right: margins[1] as HwpUnit,
+        outer_margin_top: margins[2] as HwpUnit,
+        outer_margin_bottom: margins[3] as HwpUnit,
+        padding: Some(table_padding.map(|value| value as HwpUnit)),
+        borders: table_fill.borders,
+        provenance: Provenance {
+            source: Some(SourceFormat::Hwp5),
+            raw: None,
+        },
+        ..Table::default()
+    })
+}
+
+fn table_border<'a>(
+    doc: &'a SemanticDoc,
+    id: u16,
+    record: &Record,
+    section: usize,
+    kind: &'static str,
+) -> Result<&'a BorderFillDef> {
+    if id == 0 {
+        return Err(malformed(
+            record,
+            Some(section),
+            "owned table border-fill reference must be nonzero",
+        ));
+    }
+    doc.header_pools
+        .border
+        .get(&(id as u64))
+        .ok_or(Error::InvalidReference {
+            kind,
+            index: id as usize,
+            pool_len: doc.header_pools.border.len(),
+            section: Some(section),
+            offset: record.head,
+        })
+}
+
 fn validate_para_usage(
     usage: &ParaUsage,
     decoded: &DecodedText,
@@ -1542,24 +1834,145 @@ fn parse_section_control(
     stream: &StreamProbe,
     control: &Record,
     children: &[Record],
+    doc: &SemanticDoc,
     section: usize,
 ) -> Result<PageSetup> {
     let bytes = data(stream, control);
-    if bytes.len() != 28 {
+    if !matches!(bytes.len(), 28 | 47) {
         return Err(malformed(
             control,
             Some(section),
-            "section CTRL_HEADER is not the owned 28-byte base record",
+            "section CTRL_HEADER is not the owned base or 19-byte extension record",
         ));
     }
     if read_u32(bytes, 0) != Some(CTRL_SECTION_DEF) {
         return Err(unsupported(*control, section));
     }
-    if children.len() != 1 || children[0].tag != TAG_PAGE_DEF || children[0].level != 2 {
+    if bytes.len() == 47 {
+        // HWP 5.0.1.5+: representative language (0 = application default), followed by the
+        // pinned-rhwp/Hancom master-page tail marker and 15 reserved zero bytes.
+        if read_u16(bytes, 28) != Some(0)
+            || !matches!(read_u16(bytes, 30), Some(0 | 1))
+            || bytes[32..].iter().any(|byte| *byte != 0)
+        {
+            return Err(malformed(
+                control,
+                Some(section),
+                "section CTRL_HEADER extension semantics are not owned",
+            ));
+        }
+    }
+    if children.is_empty() || children[0].tag != TAG_PAGE_DEF || children[0].level != 2 {
         let offending = children.first().copied().unwrap_or(*control);
         return Err(unsupported(offending, section));
     }
+    match children.len() {
+        1 => {}
+        6 if children[1..3]
+            .iter()
+            .all(|record| record.tag == 0x4a && record.level == 2)
+            && children[3..]
+                .iter()
+                .all(|record| record.tag == 0x4b && record.level == 2) =>
+        {
+            for record in &children[1..3] {
+                validate_dormant_note_shape(stream, record, section)?;
+            }
+            for record in &children[3..] {
+                validate_inactive_page_border(stream, record, doc, section)?;
+            }
+        }
+        _ => return Err(unsupported(children[1], section)),
+    }
     parse_page_def(data(stream, &children[0]), &children[0], section)
+}
+
+/// Note-shape records are safe to ignore only in this parser's current lane because no foot/endnote
+/// control is accepted. Validate the complete known 28-byte scalar/line framing so malformed dormant
+/// metadata cannot ride along; a future note-control slice must promote these values into shared IR.
+fn validate_dormant_note_shape(
+    stream: &StreamProbe,
+    record: &Record,
+    section: usize,
+) -> Result<()> {
+    let bytes = data(stream, record);
+    if bytes.len() != 28 {
+        return Err(malformed(
+            record,
+            Some(section),
+            "dormant note shape is not exactly 28 bytes",
+        ));
+    }
+    for at in [4usize, 6, 8] {
+        let scalar = read_u16(bytes, at).expect("exact length checked");
+        if (0xd800..=0xdfff).contains(&scalar) {
+            return Err(malformed(
+                record,
+                Some(section),
+                "dormant note shape contains a surrogate code unit",
+            ));
+        }
+    }
+    if read_u16(bytes, 10) == Some(0) || border_line_style(bytes[22]).is_none() || bytes[23] > 15 {
+        return Err(malformed(
+            record,
+            Some(section),
+            "dormant note shape has invalid numbering or separator line framing",
+        ));
+    }
+    Ok(())
+}
+
+/// Page-border records are discarded only when their referenced borderFill is visually inert.
+/// Any visible edge, shade, or diagonal remains unsupported rather than silently disappearing.
+fn validate_inactive_page_border(
+    stream: &StreamProbe,
+    record: &Record,
+    doc: &SemanticDoc,
+    section: usize,
+) -> Result<()> {
+    let bytes = data(stream, record);
+    if bytes.len() != 14 {
+        return Err(malformed(
+            record,
+            Some(section),
+            "page border/fill is not exactly 14 bytes",
+        ));
+    }
+    let attr = read_u32(bytes, 0).expect("exact length checked");
+    // Spec revision 1.3 owns bits 0..4. The public Hancom-authored slice carries one exact legacy
+    // storage word whose low five bits decode normally; pinned-rhwp confirms its referenced fill is
+    // fully inert. Keep that word as a narrow allowlist instead of accepting arbitrary high bits.
+    if attr & !0x1f != 0 && !matches!(attr, 0x0978_f9c1 | 0x271b_0b81) {
+        return Err(malformed(
+            record,
+            Some(section),
+            "page border/fill has unknown attribute bits",
+        ));
+    }
+    let border_id = read_u16(bytes, 12).expect("exact length checked");
+    if border_id == 0 {
+        return Ok(());
+    }
+    let border =
+        doc.header_pools
+            .border
+            .get(&(border_id as u64))
+            .ok_or(Error::InvalidReference {
+                kind: "page border fill",
+                index: border_id as usize,
+                pool_len: doc.header_pools.border.len(),
+                section: Some(section),
+                offset: record.head,
+            })?;
+    if border.has_border || border.shade.is_some() || border.diagonal.is_some() {
+        return Err(malformed(
+            record,
+            Some(section),
+            "active page border or fill semantics are not supported",
+        ));
+    }
+    Ok(())
 }
 
 #[derive(Debug)]
@@ -2088,15 +2501,15 @@ fn decode_text(bytes: &[u8], record: Record, section: usize) -> Result<DecodedTe
                 inline_control_mask |= 1 << 0x0009;
                 cursor += 8;
             }
-            0x0002 | 0x0015 => {
+            0x0002 | 0x000b | 0x0015 => {
                 if cursor + 8 > units.len() {
                     return Err(malformed(
                         &record,
                         Some(section),
-                        if unit == 0x0002 {
-                            "PARA_TEXT section control is truncated"
-                        } else {
-                            "PARA_TEXT page-number control is truncated"
+                        match unit {
+                            0x0002 => "PARA_TEXT section control is truncated",
+                            0x000b => "PARA_TEXT table control is truncated",
+                            _ => "PARA_TEXT page-number control is truncated",
                         },
                     ));
                 }
@@ -2104,10 +2517,10 @@ fn decode_text(bytes: &[u8], record: Record, section: usize) -> Result<DecodedTe
                     return Err(malformed(
                         &record,
                         Some(section),
-                        if unit == 0x0002 {
-                            "PARA_TEXT section control framing is invalid"
-                        } else {
-                            "PARA_TEXT page-number control framing is invalid"
+                        match unit {
+                            0x0002 => "PARA_TEXT section control framing is invalid",
+                            0x000b => "PARA_TEXT table control framing is invalid",
+                            _ => "PARA_TEXT page-number control framing is invalid",
                         },
                     ));
                 }
@@ -2116,6 +2529,7 @@ fn decode_text(bytes: &[u8], record: Record, section: usize) -> Result<DecodedTe
                 let control_id = u32::from_le_bytes([lo[0], lo[1], hi[0], hi[1]]);
                 let owned = match unit {
                     0x0002 => matches!(control_id, CTRL_SECTION_DEF | CTRL_COLUMN_DEF),
+                    0x000b => control_id == CTRL_TABLE,
                     0x0015 => matches!(control_id, CTRL_PAGE_NUM_POS | CTRL_NEW_NUMBER),
                     _ => false,
                 };

--- a/crates/hwp-hwp5/tests/layout_semantic.rs
+++ b/crates/hwp-hwp5/tests/layout_semantic.rs
@@ -6,6 +6,7 @@ use std::io::{Cursor, Write};
 const TAG_DOCUMENT_PROPERTIES: u16 = 0x10;
 const TAG_ID_MAPPINGS: u16 = 0x11;
 const TAG_FACE_NAME: u16 = 0x13;
+const TAG_BORDER_FILL: u16 = 0x14;
 const TAG_CHAR_SHAPE: u16 = 0x15;
 const TAG_PARA_SHAPE: u16 = 0x19;
 const TAG_PARA_HEADER: u16 = 0x42;
@@ -13,11 +14,14 @@ const TAG_PARA_TEXT: u16 = 0x43;
 const TAG_PARA_CHAR_SHAPE: u16 = 0x44;
 const TAG_PARA_LINE_SEG: u16 = 0x45;
 const TAG_CTRL_HEADER: u16 = 0x47;
+const TAG_LIST_HEADER: u16 = 0x48;
 const TAG_PAGE_DEF: u16 = 0x49;
 const TAG_FOOTNOTE_SHAPE: u16 = 0x4a;
+const TAG_TABLE: u16 = 0x4d;
 const CTRL_SECTION_DEF: u32 = u32::from_be_bytes(*b"secd");
 const CTRL_PAGE_NUM_POS: u32 = u32::from_be_bytes(*b"pgnp");
 const CTRL_NEW_NUMBER: u32 = u32::from_be_bytes(*b"nwno");
+const CTRL_TABLE: u32 = u32::from_be_bytes(*b"tbl ");
 
 #[derive(Clone, Copy)]
 enum Mutation {
@@ -56,6 +60,14 @@ enum Mutation {
     BadNewNumberZero,
     NewNumberWithoutPageNumber,
     DuplicateNewNumber,
+    DuplicatePageNumber,
+    IdempotentPageNumberControls,
+    Table,
+    BadTableAttr,
+    BadTableTopology,
+    BadTableGeometry,
+    BadTableCellAlign,
+    BadTableBorderRef,
 }
 
 #[test]
@@ -350,6 +362,10 @@ fn rejects_malformed_or_unowned_page_number_semantics() {
             Mutation::BadPageNumberUserSymbol,
             "page-number user-symbol semantics are not yet supported",
         ),
+        (
+            Mutation::DuplicatePageNumber,
+            "page-number positions are duplicated with conflicting semantics",
+        ),
     ] {
         assert!(matches!(
             OwnHwp5Parser::new().parse(&fixture(mutation)),
@@ -392,6 +408,19 @@ fn parses_page_number_restart_into_source_neutral_start() {
 }
 
 #[test]
+fn collapses_exact_duplicate_page_number_controls_by_typed_equality() {
+    let doc = OwnHwp5Parser::new()
+        .parse(&fixture(Mutation::IdempotentPageNumberControls))
+        .expect("identical pgnp/nwno records are idempotent");
+    let number = doc.sections[0].page_number.expect("page number");
+    assert_eq!(number.start.get(), 7);
+    assert_eq!(
+        number.position,
+        hwp_model::document::PageNumberPosition::BottomCenter
+    );
+}
+
+#[test]
 fn rejects_malformed_or_unowned_new_number_semantics() {
     for (mutation, reason) in [
         (
@@ -416,7 +445,7 @@ fn rejects_malformed_or_unowned_new_number_semantics() {
         ),
         (
             Mutation::DuplicateNewNumber,
-            "page-number restart has children or is duplicated",
+            "page-number restarts are duplicated with conflicting semantics",
         ),
     ] {
         assert!(matches!(
@@ -444,11 +473,70 @@ fn rejects_multi_section_new_number_until_inheritance_is_owned() {
     ));
 }
 
+#[test]
+fn owns_strict_inline_one_by_one_table_as_anchor_plus_shared_ir() {
+    let doc = OwnHwp5Parser::new()
+        .parse(&fixture(Mutation::Table))
+        .expect("strict table fixture parses");
+    let [Block::Paragraph(anchor), Block::Table(table), Block::Paragraph(_)] =
+        doc.sections[0].blocks.as_slice()
+    else {
+        panic!("table host must become anchor + table block")
+    };
+    assert!(anchor.is_table_anchor);
+    assert_eq!((table.rows, table.cols), (1, 1));
+    assert_eq!(table.col_widths, vec![20_000]);
+    assert_eq!(table.row_heights, vec![2_000]);
+    assert_eq!(table.padding, Some([510, 510, 141, 141]));
+    assert!(table.borders.iter().all(Option::is_some));
+    let cell = &table.cells[0];
+    assert_eq!(
+        (cell.row, cell.col, cell.row_span, cell.col_span),
+        (0, 0, 1, 1)
+    );
+    assert_eq!(cell.width, Some(20_000));
+    assert_eq!(
+        cell.padding, None,
+        "width_ref low bit inherits table padding"
+    );
+    let Block::Paragraph(cell_paragraph) = &cell.blocks[0] else {
+        panic!("cell owns one paragraph")
+    };
+    assert!(cell_paragraph
+        .runs
+        .iter()
+        .any(|run| run.content.iter().any(
+            |inline| matches!(inline, hwp_model::document::Inline::Text(text) if text == "A")
+        )));
+}
+
+#[test]
+fn strict_inline_table_rejects_unowned_attributes_topology_geometry_alignment_and_refs() {
+    for mutation in [
+        Mutation::BadTableAttr,
+        Mutation::BadTableTopology,
+        Mutation::BadTableGeometry,
+        Mutation::BadTableCellAlign,
+        Mutation::BadTableBorderRef,
+    ] {
+        assert!(OwnHwp5Parser::new().parse(&fixture(mutation)).is_err());
+    }
+}
+
 fn fixture(mutation: Mutation) -> Vec<u8> {
     let mut header = vec![0; 256];
     header[..HWP_SIGNATURE.len()].copy_from_slice(HWP_SIGNATURE);
     header[32..36].copy_from_slice(&[0, 0, 0, 5]);
 
+    let has_table = matches!(
+        mutation,
+        Mutation::Table
+            | Mutation::BadTableAttr
+            | Mutation::BadTableTopology
+            | Mutation::BadTableGeometry
+            | Mutation::BadTableCellAlign
+            | Mutation::BadTableBorderRef
+    );
     let mut doc_info = Vec::new();
     let mut properties = vec![0; 26];
     let section_count = if matches!(
@@ -462,12 +550,31 @@ fn fixture(mutation: Mutation) -> Vec<u8> {
     properties[..2].copy_from_slice(&section_count.to_le_bytes());
     push_record(&mut doc_info, TAG_DOCUMENT_PROPERTIES, 0, &properties);
     let mut mappings = Vec::new();
-    for count in [0, 1, 1, 1, 1, 1, 1, 1, 0, 1, 0, 0, 0, 1, 0] {
+    for count in [
+        0,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        usize::from(has_table),
+        1,
+        0,
+        0,
+        0,
+        1,
+        0,
+    ] {
         mappings.extend_from_slice(&(count as u32).to_le_bytes());
     }
     push_record(&mut doc_info, TAG_ID_MAPPINGS, 0, &mappings);
     for _ in 0..7 {
         push_record(&mut doc_info, TAG_FACE_NAME, 0, &face_name("Test Sans"));
+    }
+    if has_table {
+        push_record(&mut doc_info, TAG_BORDER_FILL, 0, &solid_border_fill());
     }
     push_record(&mut doc_info, TAG_CHAR_SHAPE, 0, &char_shape());
     push_record(&mut doc_info, TAG_PARA_SHAPE, 0, &para_shape());
@@ -491,6 +598,8 @@ fn fixture(mutation: Mutation) -> Vec<u8> {
             | Mutation::BadNewNumberType
             | Mutation::BadNewNumberZero
             | Mutation::DuplicateNewNumber
+            | Mutation::DuplicatePageNumber
+            | Mutation::IdempotentPageNumberControls
     );
     let has_new_number = matches!(
         mutation,
@@ -502,6 +611,7 @@ fn fixture(mutation: Mutation) -> Vec<u8> {
             | Mutation::BadNewNumberZero
             | Mutation::NewNumberWithoutPageNumber
             | Mutation::DuplicateNewNumber
+            | Mutation::IdempotentPageNumberControls
     );
     let has_columns = matches!(
         mutation,
@@ -517,12 +627,24 @@ fn fixture(mutation: Mutation) -> Vec<u8> {
     }
     if has_page_number {
         section_text.extend(extended_control(0x0015, CTRL_PAGE_NUM_POS));
+        if matches!(
+            mutation,
+            Mutation::DuplicatePageNumber | Mutation::IdempotentPageNumberControls
+        ) {
+            section_text.extend(extended_control(0x0015, CTRL_PAGE_NUM_POS));
+        }
     }
     if has_new_number {
         section_text.extend(extended_control(0x0015, CTRL_NEW_NUMBER));
-        if matches!(mutation, Mutation::DuplicateNewNumber) {
+        if matches!(
+            mutation,
+            Mutation::DuplicateNewNumber | Mutation::IdempotentPageNumberControls
+        ) {
             section_text.extend(extended_control(0x0015, CTRL_NEW_NUMBER));
         }
+    }
+    if has_table {
+        section_text.extend(extended_control(0x000b, CTRL_TABLE));
     }
     if matches!(mutation, Mutation::BadControlFrame) {
         section_text[7] = 0;
@@ -536,7 +658,8 @@ fn fixture(mutation: Mutation) -> Vec<u8> {
                 1 << 0x15
             } else {
                 0
-            },
+            }
+            | if has_table { 1 << 0x000b } else { 0 },
         1,
         0,
         if has_columns {
@@ -613,43 +736,58 @@ fn fixture(mutation: Mutation) -> Vec<u8> {
         push_record(&mut body, TAG_CTRL_HEADER, 1, &column);
     }
     if has_page_number {
-        let mut control = Vec::with_capacity(16);
-        control.extend_from_slice(&CTRL_PAGE_NUM_POS.to_le_bytes());
-        let attr = if matches!(mutation, Mutation::BadPageNumberAttr) {
-            1u32 << 16
-        } else if matches!(mutation, Mutation::BadPageNumberPosition) {
-            11u32 << 8
-        } else if matches!(mutation, Mutation::BadPageNumberFormat) {
-            6
-        } else {
-            5u32 << 8
-        };
-        control.extend_from_slice(&attr.to_le_bytes());
-        let user = if matches!(mutation, Mutation::BadPageNumberUserSymbol) {
-            '*' as u16
-        } else {
-            0
-        };
-        let prefix = if matches!(mutation, Mutation::BadPageNumberSurrogate) {
-            0xd800
-        } else {
-            '[' as u16
-        };
-        for scalar in [user, prefix, ']' as u16, '-' as u16] {
-            control.extend_from_slice(&scalar.to_le_bytes());
-        }
-        if matches!(mutation, Mutation::BadPageNumberLength) {
-            control.pop();
-        }
-        push_record(&mut body, TAG_CTRL_HEADER, 1, &control);
-    }
-    if has_new_number {
-        let count = if matches!(mutation, Mutation::DuplicateNewNumber) {
+        let count = if matches!(
+            mutation,
+            Mutation::DuplicatePageNumber | Mutation::IdempotentPageNumberControls
+        ) {
             2
         } else {
             1
         };
-        for _ in 0..count {
+        for index in 0..count {
+            let mut control = Vec::with_capacity(16);
+            control.extend_from_slice(&CTRL_PAGE_NUM_POS.to_le_bytes());
+            let attr = if matches!(mutation, Mutation::BadPageNumberAttr) {
+                1u32 << 16
+            } else if matches!(mutation, Mutation::BadPageNumberPosition) {
+                11u32 << 8
+            } else if matches!(mutation, Mutation::BadPageNumberFormat) {
+                6
+            } else if matches!(mutation, Mutation::DuplicatePageNumber) && index == 1 {
+                4u32 << 8
+            } else {
+                5u32 << 8
+            };
+            control.extend_from_slice(&attr.to_le_bytes());
+            let user = if matches!(mutation, Mutation::BadPageNumberUserSymbol) {
+                '*' as u16
+            } else {
+                0
+            };
+            let prefix = if matches!(mutation, Mutation::BadPageNumberSurrogate) {
+                0xd800
+            } else {
+                '[' as u16
+            };
+            for scalar in [user, prefix, ']' as u16, '-' as u16] {
+                control.extend_from_slice(&scalar.to_le_bytes());
+            }
+            if matches!(mutation, Mutation::BadPageNumberLength) {
+                control.pop();
+            }
+            push_record(&mut body, TAG_CTRL_HEADER, 1, &control);
+        }
+    }
+    if has_new_number {
+        let count = if matches!(
+            mutation,
+            Mutation::DuplicateNewNumber | Mutation::IdempotentPageNumberControls
+        ) {
+            2
+        } else {
+            1
+        };
+        for index in 0..count {
             let mut control = Vec::with_capacity(10);
             control.extend_from_slice(&CTRL_NEW_NUMBER.to_le_bytes());
             let attr = if matches!(mutation, Mutation::BadNewNumberAttr) {
@@ -662,6 +800,8 @@ fn fixture(mutation: Mutation) -> Vec<u8> {
             control.extend_from_slice(&attr.to_le_bytes());
             let start = if matches!(mutation, Mutation::BadNewNumberZero) {
                 0u16
+            } else if matches!(mutation, Mutation::DuplicateNewNumber) {
+                7 + index as u16
             } else {
                 7
             };
@@ -671,6 +811,96 @@ fn fixture(mutation: Mutation) -> Vec<u8> {
             }
             push_record(&mut body, TAG_CTRL_HEADER, 1, &control);
         }
+    }
+    if has_table {
+        let mut common = Vec::with_capacity(46);
+        common.extend_from_slice(&CTRL_TABLE.to_le_bytes());
+        let attr = if matches!(mutation, Mutation::BadTableAttr) {
+            0x082a_2310u32
+        } else {
+            0x082a_2311
+        };
+        common.extend_from_slice(&attr.to_le_bytes());
+        common.extend_from_slice(&0u32.to_le_bytes());
+        common.extend_from_slice(&0u32.to_le_bytes());
+        common.extend_from_slice(&20_000u32.to_le_bytes());
+        common.extend_from_slice(&2_000u32.to_le_bytes());
+        common.extend_from_slice(&0i32.to_le_bytes());
+        for margin in [100i16, 100, 50, 50] {
+            common.extend_from_slice(&margin.to_le_bytes());
+        }
+        common.extend_from_slice(&1u32.to_le_bytes());
+        common.extend_from_slice(&0i32.to_le_bytes());
+        common.extend_from_slice(&0u16.to_le_bytes());
+        push_record(&mut body, TAG_CTRL_HEADER, 1, &common);
+
+        let mut table = Vec::with_capacity(24);
+        table.extend_from_slice(&0x0400_0006u32.to_le_bytes());
+        table.extend_from_slice(&1u16.to_le_bytes());
+        table.extend_from_slice(&1u16.to_le_bytes());
+        table.extend_from_slice(&0u16.to_le_bytes());
+        for padding in [510i16, 510, 141, 141] {
+            table.extend_from_slice(&padding.to_le_bytes());
+        }
+        table.extend_from_slice(&1u16.to_le_bytes());
+        table.extend_from_slice(&1u16.to_le_bytes());
+        table.extend_from_slice(&0u16.to_le_bytes());
+        push_record(
+            &mut body,
+            if matches!(mutation, Mutation::BadTableTopology) {
+                TAG_PAGE_DEF
+            } else {
+                TAG_TABLE
+            },
+            2,
+            &table,
+        );
+
+        let mut cell = Vec::with_capacity(47);
+        cell.extend_from_slice(&1u16.to_le_bytes());
+        cell.extend_from_slice(
+            &if matches!(mutation, Mutation::BadTableCellAlign) {
+                0u32
+            } else {
+                0x0020_0000
+            }
+            .to_le_bytes(),
+        );
+        cell.extend_from_slice(&0x0500u16.to_le_bytes());
+        for value in [0u16, 0, 1, 1] {
+            cell.extend_from_slice(&value.to_le_bytes());
+        }
+        cell.extend_from_slice(
+            &if matches!(mutation, Mutation::BadTableGeometry) {
+                19_999u32
+            } else {
+                20_000
+            }
+            .to_le_bytes(),
+        );
+        cell.extend_from_slice(&2_000u32.to_le_bytes());
+        for padding in [510i16, 510, 141, 141] {
+            cell.extend_from_slice(&padding.to_le_bytes());
+        }
+        cell.extend_from_slice(
+            &if matches!(mutation, Mutation::BadTableBorderRef) {
+                2u16
+            } else {
+                1
+            }
+            .to_le_bytes(),
+        );
+        cell.extend([0; 13]);
+        push_record(&mut body, TAG_LIST_HEADER, 2, &cell);
+
+        push_para_header_at_level(&mut body, 2, 2, 0, 1, 0, 0);
+        push_record(
+            &mut body,
+            TAG_PARA_TEXT,
+            3,
+            &utf16_bytes(&['A' as u16, 0x000d]),
+        );
+        push_record(&mut body, TAG_PARA_CHAR_SHAPE, 3, &shape_refs(&[(0, 0)]));
     }
 
     if matches!(mutation, Mutation::MidSectionSeparator) {
@@ -798,6 +1028,26 @@ fn push_para_header_with_break(
     line_segments: u16,
     break_type: u8,
 ) {
+    push_para_header_at_level(
+        out,
+        0,
+        char_count,
+        control_mask,
+        char_shapes,
+        line_segments,
+        break_type,
+    );
+}
+
+fn push_para_header_at_level(
+    out: &mut Vec<u8>,
+    level: u16,
+    char_count: u32,
+    control_mask: u32,
+    char_shapes: u16,
+    line_segments: u16,
+    break_type: u8,
+) {
     let mut data = Vec::with_capacity(22);
     data.extend_from_slice(&char_count.to_le_bytes());
     data.extend_from_slice(&control_mask.to_le_bytes());
@@ -808,7 +1058,23 @@ fn push_para_header_with_break(
     data.extend_from_slice(&0u16.to_le_bytes());
     data.extend_from_slice(&line_segments.to_le_bytes());
     data.extend_from_slice(&0u32.to_le_bytes());
-    push_record(out, TAG_PARA_HEADER, 0, &data);
+    push_record(out, TAG_PARA_HEADER, level, &data);
+}
+
+fn solid_border_fill() -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(40);
+    bytes.extend_from_slice(&0u16.to_le_bytes());
+    for _ in 0..4 {
+        bytes.push(1); // solid
+        bytes.push(0); // thinnest owned width
+        bytes.extend_from_slice(&0u32.to_le_bytes());
+    }
+    bytes.push(0); // no diagonal
+    bytes.push(0);
+    bytes.extend_from_slice(&0u32.to_le_bytes());
+    bytes.extend_from_slice(&0u32.to_le_bytes()); // no fill
+    bytes.extend_from_slice(&0u32.to_le_bytes()); // required zero tail
+    bytes
 }
 
 fn face_name(value: &str) -> Vec<u8> {

--- a/crates/hwp-hwp5/tests/public_probe.rs
+++ b/crates/hwp-hwp5/tests/public_probe.rs
@@ -34,10 +34,10 @@ fn explicit_own_parser_never_falls_back() {
     assert!(matches!(
         error,
         Error::UnsupportedBodyRecord {
-            tag: 0x47,
+            tag: 0x4d,
             section: 0,
-            start: 499,
-            end: 549,
+            start: 936,
+            end: 982,
             reason: "record semantics are not owned",
             ..
         }

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,7 +3,7 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
-- 갱신: 2026-08-24 · Codex(sol) — **#168 strict inline 1×1 table 구현·full green / PR 준비**.
+- 갱신: 2026-08-24 · Codex(sol) — **#168 strict inline 1×1 table 구현·full green / PR #169 게시**.
   자체 HWP5 파서가 exact `tbl ` marker/common-object/TABLE/LIST_HEADER/cell paragraph를 검증해
   treat-as-character 1×1 표를 source-neutral `Table`/`Cell` IR로 내린다. 셀/개체 geometry,
   inherited padding, CENTER alignment, border-fill refs를 range/shape 검증하고 visible host text,
@@ -19,8 +19,9 @@
   JS build·crosscheck·i18n, Vitest **1,007**이 green이고 Chromium **85 pass/3 intentional skip/0 fail**.
   fresh worktree node_modules와 sandbox port는 루트 설치 임시 링크/허용된 로컬 서버로 분리 검증 후
   링크를 제거했다. production route·HWPX parser/serializer·shared typesetter·`external/rhwp`·
-  generated asset diff 0이며 원문·경로·hash·raw payload는 공개하지 않았다. **다음:** 최종 diff→
-  commit/push/PR `Closes #168`→필수 CI·댓글 확인 후 자율 병합→#169 larger TABLE 936..982 분해.
+  generated asset diff 0이며 원문·경로·hash·raw payload는 공개하지 않았다. 구현 commit `12a754b`을
+  push하고 PR #169(`Closes #168`, `Refs #94 #164 #166`)를 게시했다. **다음:** 이 상태 commit push→
+  exact-head 필수 CI·mergeability·review/comment 확인 후 자율 병합→#170 larger TABLE 936..982 분해.
 
 - 갱신: 2026-08-23 · Codex(sol) — **#161 PR #163 게시**.
   검증 완료 commit `c751833`을 push하고 PR #163(`Closes #161`, `Refs #94 #160`)을 만들었다.

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,22 +3,24 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
-- 갱신: 2026-08-24 · Codex(sol) — **#166 `nwno` 구현·full green / PR #167 게시**.
-  `PageNumberDecoration.start: NonZeroU16`을 source-neutral IR과 JSX side-channel/equality에 추가하고,
-  기존 schema-v1 blob은 start=1로 읽되 0은 거부한다. HWP5 exact 10B `nwno`의 page counter만 strict
-  파싱해 같은 첫 문단의 owned `pgnp`에 결합하며 unknown attr·비page counter·0·중복·position 누락·
-  다중 구역 상속은 content-free 정적 사유로 fail-closed한다. 조판은 구역 start+최종 physical page
-  order로 SVG/PDF 공통 glyph를 만들고 body geometry/page count 및 3-path LOCKSTEP은 불변이다.
-  공개 benchmark 자체 파서 경계는 `0x47/451..465`에서 `0x47/499..549`로 전진했다. Rust workspace,
-  HWP5 **48**, typeset **94**, PDF visual **51**, canonical **8/18/24·98.9%+**, public corpus **84**,
-  oracle **82**, HWPX, wasm(7,810,113B), licenses, JS build·crosscheck·i18n, Vitest **1,018**이 green;
-  Chromium **85 pass/3 intentional skip/0 fail**이다. fresh worktree node_modules와 sandbox port는
-  루트 설치 임시 링크/허용된 로컬 서버로 분리 검증 후 링크를 제거했다. production route·
-  `external/rhwp`·generated asset diff 0. 구현 commit `4ed836a`과 PR #167(`Closes #166`,
-  `Refs #94 #164`)을 게시했다. 최초 PR-open stdin 오류로 빈 본문 event의 issue-link가 실패했고 현재
-  본문은 즉시 복구됐지만 rerun은 최초 payload를 재사용해 같은 실패를 냈다; 이 상태 commit push의
-  새 synchronize event로 재검증한다. build-test **9m19s**·licenses **2m22s**는 이미 green이다.
-  **다음:** state push→새 issue-link/required CI·review/comment→green 자율 병합→499..549 원인 분해.
+- 갱신: 2026-08-24 · Codex(sol) — **#168 strict inline 1×1 table 구현·full green / PR 준비**.
+  자체 HWP5 파서가 exact `tbl ` marker/common-object/TABLE/LIST_HEADER/cell paragraph를 검증해
+  treat-as-character 1×1 표를 source-neutral `Table`/`Cell` IR로 내린다. 셀/개체 geometry,
+  inherited padding, CENTER alignment, border-fill refs를 range/shape 검증하고 visible host text,
+  larger·floating·merged·captioned·nested table과 불일치 geometry/ref는 content-free fail-closed한다.
+  nested cell을 위해 문단 파서는 상대 `base_level`을 소유한다. 표에 앞선 public prerequisite인
+  exact 19B `secd` extension, dormant note-shape framing, visually inert page-border refs도 strict하게
+  소유했다. page-border attr은 로컬 vendored 공식 HWP 5.0 revision 1.3의 low bits와 관측된 두 legacy
+  word만 허용하며 보이는 border/shade/diagonal은 거부한다. 동일한 `pgnp`/`nwno` 중복은 typed
+  equality로 idempotent collapse하고 충돌 중복은 거부한다. 공개 자체 파서 경계는
+  `CTRL_HEADER 0x47/499..549`에서 다음 larger `TABLE 0x4d/936..982`로 전진했다.
+  quick/full의 Rust workspace, HWP5 **51**, typeset **94**, PDF visual **51**, canonical
+  **8/18/24·98.9%+**, public corpus **84**, oracle **82**, HWPX, wasm(7,810,113B), licenses,
+  JS build·crosscheck·i18n, Vitest **1,007**이 green이고 Chromium **85 pass/3 intentional skip/0 fail**.
+  fresh worktree node_modules와 sandbox port는 루트 설치 임시 링크/허용된 로컬 서버로 분리 검증 후
+  링크를 제거했다. production route·HWPX parser/serializer·shared typesetter·`external/rhwp`·
+  generated asset diff 0이며 원문·경로·hash·raw payload는 공개하지 않았다. **다음:** 최종 diff→
+  commit/push/PR `Closes #168`→필수 CI·댓글 확인 후 자율 병합→#169 larger TABLE 936..982 분해.
 
 - 갱신: 2026-08-23 · Codex(sol) — **#161 PR #163 게시**.
   검증 완료 commit `c751833`을 push하고 PR #163(`Closes #161`, `Refs #94 #160`)을 만들었다.

--- a/docs/HWP5-NATIVE-PARSER.md
+++ b/docs/HWP5-NATIVE-PARSER.md
@@ -4,7 +4,8 @@ Issue #107 introduced the first owned binary-HWP layer; issue #154 added its fir
 issue #156 added the minimum source-layout facts needed by the shared typesetter, issue #158 owns
 the paragraph support-pool boundary, and issue #160 owns DocInfo styles plus content-free paragraph
 header refusal reasons; issue #161 adds strict column definitions and the shared multi-column layout
-contract. None of these slices changes production parsing.
+contract; issue #168 adds the first strict inline 1×1 table slice. None of these slices changes
+production parsing.
 
 ## What is owned now
 
@@ -22,6 +23,10 @@ checked. A pool that is merely present is not treated as active: custom tabs, nu
 visible paragraph border/fill still fail closed when a paragraph would depend on semantics the shared
 typesetter does not yet own. The owned section-definition boundary maps a strict 40-byte `PAGE_DEF` to
 `Section.page`, including all six margins, gutter, and HWP5 landscape orientation. A strict
+19-byte `secd` extension is accepted only in the documented representative-language/master-page-tail
+shape. Exact 28-byte foot/endnote-shape records are validated but remain dormant because note controls
+are unsupported. Page-border records may be discarded only when their resolved `BorderFillDef` is
+visually inert; visible page borders, shades, or diagonals fail closed. A strict
 `PARA_LINE_SEG` reader validates declared counts and UTF-16 scalar/control starts, but exposes stored
 line-box metrics only for true blank spacer paragraphs. Stored line breaks never override our
 typesetter and zero-height segments are non-authoritative. A strict `cold` reader accepts bounded
@@ -59,14 +64,19 @@ rejected instead of being interpreted as records.
 
 - `Engine::open`: unchanged production route. Binary HWP still uses the governed rhwp bootstrap.
 - `open_hwp5_own`: explicit first-party-only route. It returns a `SemanticDoc` only for the owned
-  text, single-sided page setup, and strict column subset. Tables, images, fields, notes, equations, charts,
+  text, single-sided page setup, strict column subset, and strict inline 1×1 table subset. Larger,
+  floating, merged, captioned, or nested tables, images, fields, notes, equations, charts,
   decorations, page border/fill, duplex binding, active custom tabs/lists/paragraph borders,
   unknown body controls, and unsupported pool values fail closed with a static reason plus tag,
   section, and byte span only. It cannot call rhwp. The public benchmark now passes its first
-  multi-column paragraph header and `cold` definition, then stops at the next unowned control header
-  (`0x47`, section 0, bytes 499..549) without exposing content. The owned prefix now includes strict
+  multi-column paragraph header and `cold` definition plus its first inline table, then stops at the
+  next larger TABLE record (`0x4d`, section 0, bytes 936..982) without exposing content. The owned prefix includes strict
   single-section `pgnp` positioning and `nwno` page-counter restarts; other counters, zero starts,
-  duplicates, missing positions, and multi-section inheritance fail closed.
+  conflicting duplicates, missing positions, and multi-section inheritance fail closed. Exact duplicate
+  `pgnp`/`nwno` records are idempotently collapsed by typed equality. The first public `tbl ` control is
+  owned only as a treat-as-character 1×1 table with one centered cell paragraph, inherited table
+  padding, consistent object/cell geometry, and resolved border fills. It lowers to the shared
+  `Table`/`Cell` IR, so SVG and PDF consume the same `place_doc` geometry.
 - `hwp5_differential`: explicitly runs the owned probe and current rhwp semantic oracle, then reports
   section/paragraph/run/table/image/control/equation/chart counts and their deltas.
 

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,11 @@
 
 ---
 
+## 2026-08-24 (Codex sol) · #168 PR #169 posted
+- 구현 `12a754b` push + PR #169(`Closes #168`, `Refs #94 #164 #166`) 게시.
+- next GitHub 번호는 PR이 사용했으므로 larger TABLE 936..982 후속은 #170 issue-first.
+- 다음 state push→required CI/mergeability/review/comment→green 자율 병합→#170.
+
 ## 2026-08-24 (Codex sol) · #168 inline 1×1 table full green / PR ready
 - strict tbl/common-object/TABLE/LIST_HEADER/cell paragraph → shared Table/Cell IR.
 - secd extension·dormant notes·inert page border prerequisite와 typed duplicate collapse 소유.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,18 @@
 
 ---
 
+## 2026-08-24 (Codex sol) · #168 inline 1×1 table full green / PR ready
+- strict tbl/common-object/TABLE/LIST_HEADER/cell paragraph → shared Table/Cell IR.
+- secd extension·dormant notes·inert page border prerequisite와 typed duplicate collapse 소유.
+- public boundary 499..549→TABLE 936..982; hostile fixture와 HWP5 51 tests green.
+- quick/full·Vitest 1,007·Chromium 85/3 green; route/rhwp/HWPX/generated diff 0. 다음 PR→CI→#169.
+
+## 2026-08-24 (Codex sol) · PR #167 merged → #168 next control started
+- #167 required CI/MERGEABLE·댓글 0 후 main `c39b852` 병합; #166 close·remote branch 정리.
+- #94 완료 근거 동기화; next content-free boundary 0x47/499..549.
+- child #168 + latest-main `codex/issue-168-hwp5-next-control`; rhwp pinned `f137b4c9`.
+- 다음 bounded structural probe→oracle 대조→최소 typed subset; probe/raw content commit 금지.
+
 ## 2026-08-24 (Codex sol) · #166 PR #167 posted
 - 구현 `4ed836a` push + PR #167; build-test 9m19s·licenses 2m22s green.
 - 최초 빈-body event는 본문 복구 뒤에도 rerun payload가 stale이라 issue-link 재실패.


### PR DESCRIPTION
Closes #168

Refs #94 #164 #166

## Summary

- own the first strict treat-as-character HWP5 inline 1x1 table as the shared source-neutral `Table`/`Cell` IR
- validate exact control, table, list-header, cell geometry, padding, alignment, and border-fill references; fail closed on unsupported table semantics
- own the strict section prerequisites exposed before that table and collapse identical page-number controls only by typed equality
- advance the content-free public boundary from `CTRL_HEADER 0x47 / 499..549` to the next larger `TABLE 0x4d / 936..982`

## Safety boundaries

- production HWP5 parsing remains on the governed rhwp facade
- `external/rhwp`, HWPX parsing/serialization, the shared typesetter, and generated wasm assets are unchanged
- larger, floating, merged, captioned, nested, or inconsistent table shapes fail closed
- no document content, local path, hash, or raw payload is published

## Verification

- `scripts/verify-local.sh` — green
- `scripts/verify-local.sh --full` — Rust/PDF/canonical 8/18/24 and 98.9%+/public corpus 84/oracle 82/HWPX/wasm/licenses/JS build/Vitest 1,007 green; sandbox-only port denial separated from the application
- `pnpm exec playwright test` — 85 passed, 3 intentional skips, 0 failed
- HWP5 tests: 51 total; focused clippy `-D warnings` green
- `external/rhwp` and generated asset diff: 0
