### PR TITLE
feat: preserve no-split tables with shared keep-together layout

### DIFF
--- a/crates/hwp-jsx/src/equality.rs
+++ b/crates/hwp-jsx/src/equality.rs
@@ -158,6 +158,7 @@ fn inline_eq(a: &Inline, b: &Inline) -> bool {
 fn table_eq(a: &Table, b: &Table) -> bool {
     a.rows == b.rows
         && a.cols == b.cols
+        && a.keep_together == b.keep_together
         && a.col_widths == b.col_widths
         && a.row_heights == b.row_heights
         && prov_eq(&a.provenance, &b.provenance)

--- a/crates/hwp-jsx/src/lib.rs
+++ b/crates/hwp-jsx/src/lib.rs
@@ -407,6 +407,9 @@ fn emit_table(t: &Table) -> JsxNode {
     let mut el = JsxElement::new(Tag::Table)
         .with_attr("data-rows", t.rows.to_string())
         .with_attr("data-cols", t.cols.to_string());
+    if t.keep_together {
+        el.attrs.insert("data-keep-together".into(), "1".into());
+    }
     if !t.col_widths.is_empty() {
         let w = t
             .col_widths
@@ -1108,6 +1111,11 @@ fn parse_table(el: &JsxElement) -> Result<Table> {
         .get("data-rowh")
         .map(|s| s.split(',').filter_map(|h| h.parse().ok()).collect())
         .unwrap_or_default();
+    let keep_together = match el.attrs.get("data-keep-together").map(String::as_str) {
+        None => false,
+        Some("1") => true,
+        Some(_) => return Err(Error::Parse("invalid table keep-together flag".into())),
+    };
     Ok(Table {
         rows: el
             .attrs
@@ -1120,6 +1128,7 @@ fn parse_table(el: &JsxElement) -> Result<Table> {
             .and_then(|v| v.parse().ok())
             .unwrap_or(0),
         cells,
+        keep_together,
         col_widths,
         row_heights,
         // Render-IR only (HWPX auto-fit floor) — the JSX surface never carries it (defaults empty).

--- a/crates/hwp-jsx/tests/roundtrip.rs
+++ b/crates/hwp-jsx/tests/roundtrip.rs
@@ -185,6 +185,7 @@ fn t1c_per_edge_borders_and_diagonal_roundtrip() {
         rows: 1,
         cols: 1,
         cells: vec![cell],
+        keep_together: true,
         col_widths: vec![1],
         ..Default::default()
     };
@@ -196,10 +197,53 @@ fn t1c_per_edge_borders_and_diagonal_roundtrip() {
         ..Default::default()
     });
 
-    let back = parse(&emit(&doc)).expect("parse(emit(doc))");
+    let jsx = emit(&doc);
+    let table_element = match &jsx.sections[0] {
+        JsxNode::Element(section) => section
+            .children
+            .iter()
+            .find_map(|node| match node {
+                JsxNode::Element(element) if element.tag() == Some(Tag::Table) => Some(element),
+                _ => None,
+            })
+            .expect("projected table"),
+        _ => panic!("section projection is an element"),
+    };
+    assert_eq!(
+        table_element
+            .attrs
+            .get("data-keep-together")
+            .map(String::as_str),
+        Some("1")
+    );
+    let back = parse(&jsx).expect("parse(emit(doc))");
     assert!(
         doc_value_eq(&doc, &back),
         "per-edge borders + diagonal must round-trip value-equal"
+    );
+    let mut changed_keep = back.clone();
+    if let Some(Block::Table(table)) = changed_keep.sections[0].blocks.get_mut(0) {
+        table.keep_together = false;
+    }
+    assert!(
+        !doc_value_eq(&doc, &changed_keep),
+        "equality must observe keep-together semantics"
+    );
+    let mut invalid_keep = jsx.clone();
+    if let JsxNode::Element(section) = &mut invalid_keep.sections[0] {
+        let table = section
+            .children
+            .iter_mut()
+            .find_map(|node| match node {
+                JsxNode::Element(element) if element.tag() == Some(Tag::Table) => Some(element),
+                _ => None,
+            })
+            .expect("projected table");
+        table.attrs.insert("data-keep-together".into(), "2".into());
+    }
+    assert!(
+        parse(&invalid_keep).is_err(),
+        "unknown keep-together values must fail closed"
     );
 
     // Falsifiable: corrupt the round-tripped left edge style → equality must now FAIL.

--- a/crates/hwp-model/src/document.rs
+++ b/crates/hwp-model/src/document.rs
@@ -461,6 +461,11 @@ pub struct Table {
     pub rows: usize,
     pub cols: usize,
     pub cells: Vec<Cell>,
+    /// Keep the table on one page/column when its fully measured height fits a fresh lane. If the
+    /// current lane lacks room, all three pagination paths advance once before placing row 0. A table
+    /// taller than a fresh lane still uses the existing row-fragmentation fallback, so hostile or
+    /// genuinely over-tall input cannot create an advance loop. `false` preserves legacy behavior.
+    pub keep_together: bool,
     /// Per-column widths (HWPUNIT), `cols` entries — for faithful column proportions on render.
     /// Empty when unknown (then the renderer falls back to auto-layout).
     pub col_widths: Vec<HwpUnit>,

--- a/crates/hwp-typeset/src/lib.rs
+++ b/crates/hwp-typeset/src/lib.rs
@@ -540,7 +540,12 @@ impl LayoutEngine for NaiveLayout {
                         if vert > 0.0 {
                             vert += t.outer_margin_top.max(0) as f64;
                         }
-                        for rh in table_row_heights(t, body_w, doc, fonts) {
+                        let rows = table_row_heights(t, body_w, doc, fonts);
+                        if keep_table_on_fresh_lane(t, &rows, vert, body_h) {
+                            pages.push(new_page(page));
+                            vert = 0.0;
+                        }
+                        for rh in rows {
                             // `rh <= body_h`: a row taller than the whole body never triggers a break — it
                             // can't fit a fresh page either, so a break would only waste the current page
                             // (the 자가진단표 1×1 mega-cell). Mirrors place_table + block_pages for lockstep.
@@ -629,7 +634,17 @@ fn layout_columns(doc: &SemanticDoc, fonts: &dyn FontMetricsProvider) -> LayoutR
                     if flow.vert() > 0.0 {
                         flow.add(table.outer_margin_top.max(0) as f64);
                     }
-                    for row_height in table_row_heights(table, flow.min_width(), doc, fonts) {
+                    let rows = table_row_heights(table, flow.min_width(), doc, fonts);
+                    if keep_table_on_fresh_lane(
+                        table,
+                        &rows,
+                        flow.vert(),
+                        flow.available_height(body_h),
+                    ) && flow.advance_column()
+                    {
+                        pages.push(new_page(page));
+                    }
+                    for row_height in rows {
                         let available = flow.available_height(body_h);
                         if flow.vert() + row_height > available
                             && flow.vert() > 0.0
@@ -905,6 +920,23 @@ pub(crate) fn table_row_heights(
     }
     apply_row_overrides(&mut row_h, t);
     row_h
+}
+
+/// Whether a keep-together table should advance before row 0. The whole measured table must fit a
+/// fresh lane; over-tall tables deliberately return false and retain bounded row fragmentation.
+/// `vert > 0` also suppresses pointless blank-page/blank-column advances at a lane top.
+pub(crate) fn keep_table_on_fresh_lane(
+    table: &Table,
+    row_heights: &[f64],
+    vert: f64,
+    available: f64,
+) -> bool {
+    let total: f64 = row_heights.iter().sum();
+    table.keep_together
+        && vert > 0.0
+        && total > 0.0
+        && total <= available
+        && vert + total > available
 }
 
 /// Apply per-row MINIMUM-height overrides (HWPUNIT) from [`Table::row_heights`] as a FLOOR on the

--- a/crates/hwp-typeset/src/place.rs
+++ b/crates/hwp-typeset/src/place.rs
@@ -752,6 +752,10 @@ pub fn block_pages(doc: &SemanticDoc, fonts: &dyn FontMetricsProvider) -> Vec<Ve
                     // the remaining body flows to the next page. Record the page where the FIRST row
                     // lands as the table's start page (outline/page-nav only needs the start).
                     let row_h = crate::table_row_heights(t, body_w, doc, fonts);
+                    if crate::keep_table_on_fresh_lane(t, &row_h, vert, body_h) {
+                        page_idx += 1;
+                        vert = 0.0;
+                    }
                     // `rh <= body_h` on both checks: an over-tall row (taller than the whole body) never
                     // forces a page bump — mirrors place_table + NaiveLayout so the start pages stay aligned.
                     if vert > 0.0
@@ -854,6 +858,15 @@ fn block_pages_columns(doc: &SemanticDoc, fonts: &dyn FontMetricsProvider) -> Ve
                         flow.add(table.outer_margin_top.max(0) as f64);
                     }
                     let rows = crate::table_row_heights(table, flow.min_width(), doc, fonts);
+                    if crate::keep_table_on_fresh_lane(
+                        table,
+                        &rows,
+                        flow.vert(),
+                        flow.available_height(body_h),
+                    ) && flow.advance_column()
+                    {
+                        page_index += 1;
+                    }
                     if flow.vert() > 0.0
                         && rows.first().is_some_and(|height| {
                             let available = flow.available_height(body_h);
@@ -1184,6 +1197,10 @@ fn place_table(
     let row_h = row_heights(t, avail_w, doc, fonts);
 
     let mut vert = vert;
+    if crate::keep_table_on_fresh_lane(t, &row_h, vert, body_h) {
+        new_page(pages, page);
+        vert = 0.0;
+    }
     // First-row reserve: if not at page top and even the first row won't fit the remaining body, start
     // the table on a fresh page (a table that fits stays put; one that doesn't begins on a clean page).
     // EXCEPT a row taller than the whole body (e.g. the 자가진단표 wrapped in one 1×1 cell): bumping it to
@@ -1244,6 +1261,10 @@ fn place_table_columns(
     let table_width = flow.min_width();
     let col_x = column_offsets(t, table_width);
     let row_h = row_heights(t, table_width, doc, fonts);
+    let available = flow.available_height(body_h);
+    if crate::keep_table_on_fresh_lane(t, &row_h, flow.vert(), available) && flow.advance_column() {
+        new_page(pages, page);
+    }
     let available = flow.available_height(body_h);
     if flow.vert() > 0.0
         && flow.vert() + row_h[0] > available
@@ -3821,6 +3842,14 @@ mod tests {
         }
     }
 
+    fn fixed_height_table(rows: usize, row_height: HwpUnit, keep_together: bool) -> Table {
+        let mut table = n_row_table(rows);
+        table.row_heights = vec![row_height; rows];
+        table.fixed_row_heights = true;
+        table.keep_together = keep_together;
+        table
+    }
+
     /// 이슈 080 — 표 호스트 앵커에 걸린 `<hp:p pageBreak="1">` 은 **표 앞**에서 쪽을 넘겨야 한다.
     /// 우리 HWPX 블록 순서는 왕복 해자 때문에 `[Table, 앵커]` 라, 앵커 자리에서 실행하면 쪽이 표
     /// **뒤**에서 넘어간다(표만 이전 쪽에 남는다). 판정은 세 조판 경로가 공유하는
@@ -4046,6 +4075,172 @@ mod tests {
         assert_eq!(frags.len(), 1, "a fitting table is one fragment");
         assert_eq!((frags[0].first_row, frags[0].last_row), (0, 2));
         assert_eq!(placed.pages.len(), 1, "no extra pages");
+    }
+
+    #[test]
+    fn keep_together_fits_current_page_without_advancing() {
+        use crate::LayoutEngine;
+
+        let table = fixed_height_table(2, 2_000, true);
+        let doc = doc_with_page(
+            vec![Block::Paragraph(para("앞")), Block::Table(table)],
+            6_000,
+        );
+        let placed = place_doc(&doc, &ApproxFontMetrics);
+        let fragments = placed.pages[0].tables.iter().collect::<Vec<_>>();
+        assert_eq!(placed.pages.len(), 1);
+        assert_eq!(fragments.len(), 1);
+        assert_eq!((fragments[0].first_row, fragments[0].last_row), (0, 2));
+        assert_eq!(
+            crate::NaiveLayout
+                .layout(&doc, &ApproxFontMetrics)
+                .unwrap()
+                .pages
+                .len(),
+            1
+        );
+        assert_eq!(block_pages(&doc, &ApproxFontMetrics)[0], vec![0, 0]);
+    }
+
+    #[test]
+    fn keep_together_moves_whole_table_in_all_three_paginators() {
+        use crate::LayoutEngine;
+
+        let table = fixed_height_table(2, 2_700, true);
+        let doc = doc_with_page(
+            vec![Block::Paragraph(para("앞")), Block::Table(table)],
+            6_000,
+        );
+        let placed = place_doc(&doc, &ApproxFontMetrics);
+        assert_eq!(placed.pages.len(), 2);
+        assert!(placed.pages[0].tables.is_empty());
+        assert_eq!(placed.pages[1].tables.len(), 1);
+        assert_eq!(
+            (
+                placed.pages[1].tables[0].first_row,
+                placed.pages[1].tables[0].last_row
+            ),
+            (0, 2)
+        );
+        assert_eq!(
+            crate::NaiveLayout
+                .layout(&doc, &ApproxFontMetrics)
+                .unwrap()
+                .pages
+                .len(),
+            2
+        );
+        assert_eq!(block_pages(&doc, &ApproxFontMetrics)[0], vec![0, 1]);
+    }
+
+    #[test]
+    fn keep_together_over_tall_table_keeps_row_fragment_fallback() {
+        use crate::LayoutEngine;
+
+        let table = fixed_height_table(3, 3_000, true);
+        let doc = doc_with_page(
+            vec![Block::Paragraph(para("앞")), Block::Table(table)],
+            6_000,
+        );
+        let placed = place_doc(&doc, &ApproxFontMetrics);
+        assert!(
+            !placed.pages[0].tables.is_empty(),
+            "over-tall keep-together table must not waste the current page"
+        );
+        let fragments = placed
+            .pages
+            .iter()
+            .flat_map(|page| &page.tables)
+            .collect::<Vec<_>>();
+        assert!(fragments.len() >= 2);
+        assert_eq!(fragments.first().unwrap().first_row, 0);
+        assert_eq!(fragments.last().unwrap().last_row, 3);
+        assert_eq!(
+            crate::NaiveLayout
+                .layout(&doc, &ApproxFontMetrics)
+                .unwrap()
+                .pages
+                .len(),
+            placed.pages.len()
+        );
+        assert_eq!(block_pages(&doc, &ApproxFontMetrics)[0][1], 0);
+    }
+
+    #[test]
+    fn default_table_retains_row_fragmentation() {
+        let table = fixed_height_table(2, 2_700, false);
+        let doc = doc_with_page(
+            vec![Block::Paragraph(para("앞")), Block::Table(table)],
+            6_000,
+        );
+        let placed = place_doc(&doc, &ApproxFontMetrics);
+        assert!(!placed.pages[0].tables.is_empty());
+        assert!(!placed.pages[1].tables.is_empty());
+        assert_eq!(placed.pages[0].tables[0].first_row, 0);
+        assert_eq!(placed.pages[0].tables[0].last_row, 1);
+    }
+
+    #[test]
+    fn keep_together_advances_to_fresh_column_in_lockstep() {
+        use crate::LayoutEngine;
+
+        let mut first = para("앞");
+        first.column_layout_before = Some(ColumnLayout {
+            widths: vec![2_500, 2_500],
+            gaps: vec![0],
+            ..ColumnLayout::default()
+        });
+        let mut table = fixed_height_table(2, 2_700, true);
+        table.col_widths = vec![2_500];
+        let doc = doc_with_page(vec![Block::Paragraph(first), Block::Table(table)], 6_000);
+        let placed = place_doc(&doc, &ApproxFontMetrics);
+        assert_eq!(placed.pages.len(), 1);
+        assert_eq!(placed.pages[0].tables.len(), 1);
+        let fragment = &placed.pages[0].tables[0];
+        assert!(fragment.x >= 2_500.0, "table begins in the second column");
+        assert_eq!((fragment.first_row, fragment.last_row), (0, 2));
+        assert_eq!(
+            crate::NaiveLayout
+                .layout(&doc, &ApproxFontMetrics)
+                .unwrap()
+                .pages
+                .len(),
+            1
+        );
+        assert_eq!(block_pages(&doc, &ApproxFontMetrics)[0], vec![0, 0]);
+    }
+
+    #[test]
+    fn keep_together_over_tall_column_table_fragments_without_blank_lane() {
+        use crate::LayoutEngine;
+
+        let mut first = para("앞");
+        first.column_layout_before = Some(ColumnLayout {
+            widths: vec![2_500, 2_500],
+            gaps: vec![0],
+            ..ColumnLayout::default()
+        });
+        let mut table = fixed_height_table(3, 3_000, true);
+        table.col_widths = vec![2_500];
+        let doc = doc_with_page(vec![Block::Paragraph(first), Block::Table(table)], 6_000);
+        let placed = place_doc(&doc, &ApproxFontMetrics);
+        assert_eq!(placed.pages.len(), 1);
+        assert!(placed.pages[0].tables.len() >= 2);
+        assert!(
+            placed.pages[0].tables[0].x < 2_500.0,
+            "over-tall table begins in the current column instead of wasting it"
+        );
+        assert_eq!(placed.pages[0].tables.first().unwrap().first_row, 0);
+        assert_eq!(placed.pages[0].tables.last().unwrap().last_row, 3);
+        assert_eq!(
+            crate::NaiveLayout
+                .layout(&doc, &ApproxFontMetrics)
+                .unwrap()
+                .pages
+                .len(),
+            1
+        );
+        assert_eq!(block_pages(&doc, &ApproxFontMetrics)[0], vec![0, 0]);
     }
 
     #[test]

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,7 +3,7 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
-- 갱신: 2026-08-24 · Codex(sol) — **#168 strict inline 1×1 table 구현·full green / PR #169 게시**.
+- 갱신: 2026-08-24 · Codex(sol) — **PR #169 병합 · #170 분류 · #171 keep-together 게시 준비 완료**.
   자체 HWP5 파서가 exact `tbl ` marker/common-object/TABLE/LIST_HEADER/cell paragraph를 검증해
   treat-as-character 1×1 표를 source-neutral `Table`/`Cell` IR로 내린다. 셀/개체 geometry,
   inherited padding, CENTER alignment, border-fill refs를 range/shape 검증하고 visible host text,
@@ -19,9 +19,24 @@
   JS build·crosscheck·i18n, Vitest **1,007**이 green이고 Chromium **85 pass/3 intentional skip/0 fail**.
   fresh worktree node_modules와 sandbox port는 루트 설치 임시 링크/허용된 로컬 서버로 분리 검증 후
   링크를 제거했다. production route·HWPX parser/serializer·shared typesetter·`external/rhwp`·
-  generated asset diff 0이며 원문·경로·hash·raw payload는 공개하지 않았다. 구현 commit `12a754b`을
-  push하고 PR #169(`Closes #168`, `Refs #94 #164 #166`)를 게시했다. **다음:** 이 상태 commit push→
-  exact-head 필수 CI·mergeability·review/comment 확인 후 자율 병합→#170 larger TABLE 936..982 분해.
+  generated asset diff 0이며 원문·경로·hash·raw payload는 공개하지 않았다. PR #169는 exact head
+  `d870e80`의 필수 CI·MERGEABLE·댓글 0을 확인하고 main `0cb4529`로 병합, #168 close·branch 정리.
+  #170의 next TABLE은 content-free 분류상 10×2/17 cells/가로병합 3행/셀 1~5문단이며 width/height
+  합이 object geometry와 정확히 일치한다. 그러나 official no-split attr을 현 always-row-split IR이
+  표현하지 못해 #170은 fail-closed 유지하고 #171을 prerequisite로 열었다. exact latest-main
+  `codex/issue-171-table-keep-together`에서 additive `Table.keep_together` default false와
+  `place_doc`/`NaiveLayout`/`block_pages`/column flow 동일 선결정을 구현했다. 전체 측정 높이가 fresh
+  lane에는 맞고 current remainder에만 안 맞을 때 row 0 전에 한 번 advance하며, current에 맞거나
+  fresh lane보다 큰 표와 default false 표는 기존 row fragmentation 그대로다. JSX는 true만
+  `data-keep-together=1`로 왕복하고 다른 값은 거부하며 equality도 의미를 비교한다. direct tests는
+  current fit/page move/over-tall fallback/default unchanged/column move/column over-tall을 잠갔다.
+  quick/full의 Rust workspace, hwp-typeset **100+4**, PDF visual **51**, canonical
+  **8/18/24·98.9%+**, public corpus **84**, oracle **82**, HWPX, wasm(7,810,657B), licenses,
+  JS build·crosscheck·i18n, Vitest **1,007**이 green이고, 샌드박스 포트 EPERM만 허용된 로컬
+  서버에서 분리 재실행해 Chromium **85 pass/3 intentional skip/0 fail**이다. 임시 dependency
+  link는 제거했고 production route·rhwp·HWPX parser/serializer·generated asset diff 0.
+  **다음:** commit/push/PR #171→필수 CI/자율 병합→#170 rebase 후 keep_together=true strict
+  10×2 parser 재개.
 
 - 갱신: 2026-08-23 · Codex(sol) — **#161 PR #163 게시**.
   검증 완료 commit `c751833`을 push하고 PR #163(`Closes #161`, `Refs #94 #160`)을 만들었다.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,22 @@
 
 ---
 
+## 2026-08-24 (Codex sol) · #171 full green / PR ready
+- keep-together page/column 3-path LOCKSTEP와 default/over-tall fallback 확정.
+- quick/full·Vitest 1,007·Chromium 85/3 green; route/rhwp/HWPX/generated diff 0.
+- 다음 commit/push/PR→required CI/merge→#170 rebase/parser resume.
+
+## 2026-08-24 (Codex sol) · #171 keep-together focused green
+- additive Table flag/default false + JSX strict roundtrip/equality.
+- 3-path page current/move/over-tall/default and column move/over-tall direct tests green.
+- hwp-typeset 90+4, hwp-jsx 14, touched clippy green; route/rhwp/HWPX/generated unchanged.
+- 다음 quick→full→PR/CI/merge→#170 rebase/parser resume.
+
+## 2026-08-24 (Codex sol) · #170 classified → #171 keep-together started
+- #169 main `0cb4529`; #170 next TABLE 10×2/17 cells, exact geometry, official no-split prerequisite.
+- #170 fail-closed checkpoint `4e652e6` push; #171 + latest-main keep-together branch 시작.
+- 다음 additive IR/default false→3-path+column LOCKSTEP tests/implementation→full/PR/CI→#170 resume.
+
 ## 2026-08-24 (Codex sol) · #168 PR #169 posted
 - 구현 `12a754b` push + PR #169(`Closes #168`, `Refs #94 #164 #166`) 게시.
 - next GitHub 번호는 PR이 사용했으므로 larger TABLE 936..982 후속은 #170 issue-first.


### PR DESCRIPTION
Closes #171

Refs #94 #170

## Summary
- add a source-neutral `Table.keep_together` flag with legacy-safe `false` default
- make `place_doc`, `NaiveLayout`, `block_pages`, and column flow share the same pre-row advance decision
- move a fully measured table only when it fits a fresh lane; preserve row fragmentation for default and over-tall tables
- round-trip the semantic flag through strict JSX and include it in value equality

## Verification
- `scripts/verify-local.sh`
- `scripts/verify-local.sh --full` (all non-E2E stages green; sandbox-only port EPERM at the E2E stage)
- `pnpm exec playwright test`: 85 passed, 3 intentional skips, 0 failed
- Vitest: 1,007 passed
- canonical layout: 8/18/24 pages and 98.9%+ line floor
- `external/rhwp`, production HWP5 route, HWPX parser/serializer, and generated assets unchanged