### PR TITLE
feat: own the next strict HWP5 table slice

### DIFF
--- a/crates/hwp-hwp5/src/semantic.rs
+++ b/crates/hwp-hwp5/src/semantic.rs
@@ -1312,11 +1312,11 @@ fn parse_paragraph(
                 }
             }
             CTRL_TABLE => {
-                if tables.len() == 1 {
-                    return Err(malformed(
-                        control,
-                        Some(section),
-                        "owned paragraph contains duplicate tables",
+                if !tables.is_empty() {
+                    return Err(unsupported_reason(
+                        *control,
+                        section,
+                        "paragraphs with multiple table controls are not yet owned",
                     ));
                 }
                 tables.push(parse_inline_table(
@@ -1548,9 +1548,11 @@ fn parse_new_number_control(
         .ok_or_else(|| malformed(record, Some(section), "page-number restart must be nonzero"))
 }
 
-/// Own the first bounded binary-table slice seen in the public corpus: an inline, treat-as-character
-/// 1×1 table with one cell paragraph. The strict framing is intentional. A larger or floating table
-/// must fail closed until its positioning, split, caption, merge, and cell-list semantics are typed.
+/// Own the two bounded binary-table slices seen at the public first-party boundary: the original
+/// inline 1×1 table and the following inline 10×2 table. Both use the same exact common-object and
+/// no-split TABLE attributes. The larger slice has 17 active cells (three horizontal merges), one to
+/// five paragraphs per cell, and no zones/captions/nested layout. Anything outside that narrow,
+/// source-neutral shape remains fail-closed rather than being approximated.
 #[allow(clippy::too_many_arguments)]
 fn parse_inline_table(
     stream: &StreamProbe,
@@ -1611,37 +1613,64 @@ fn parse_inline_table(
             "inline table page-break prevention or description is not owned",
         ));
     }
-    if children.len() < 3
-        || children[0].tag != TAG_TABLE
-        || children[1].tag != TAG_LIST_HEADER
-        || children[2].tag != TAG_PARA_HEADER
-        || children[0].level != control.level + 1
-        || children[1].level != control.level + 1
-        || children[2].level != control.level + 1
-    {
+    let child_level = control.level + 1;
+    if children.len() < 3 || children[0].tag != TAG_TABLE || children[0].level != child_level {
         return Err(malformed(
             control,
             Some(section),
-            "inline table child topology is not exactly TABLE, LIST_HEADER, paragraph",
+            "inline table child topology does not begin with an owned TABLE record",
         ));
     }
 
     let table_record = children[0];
     let table_bytes = data(stream, &table_record);
-    if table_bytes.len() != 24 {
-        return Err(unsupported(table_record, section));
-    }
-    if read_u32(table_bytes, 0) != Some(0x0400_0006)
-        || read_u16(table_bytes, 4) != Some(1)
-        || read_u16(table_bytes, 6) != Some(1)
-        || read_u16(table_bytes, 8) != Some(0)
-        || read_u16(table_bytes, 18) != Some(1)
-        || read_u16(table_bytes, 22) != Some(0)
-    {
+    if table_bytes.len() < 24 || read_u32(table_bytes, 0) != Some(0x0400_0006) {
         return Err(malformed(
             &table_record,
             Some(section),
-            "TABLE attributes or 1x1 topology are not owned",
+            "TABLE attributes or framing are not owned",
+        ));
+    }
+    let rows = read_u16(table_bytes, 4).expect("minimum length checked") as usize;
+    let cols = read_u16(table_bytes, 6).expect("minimum length checked") as usize;
+    let expected_cells = match (rows, cols) {
+        (1, 1) => 1,
+        (10, 2) => 17,
+        _ => {
+            return Err(malformed(
+                &table_record,
+                Some(section),
+                "TABLE row/column topology is not in the owned 1x1 or 10x2 subset",
+            ))
+        }
+    };
+    if read_u16(table_bytes, 8) != Some(0) {
+        return Err(malformed(
+            &table_record,
+            Some(section),
+            "owned TABLE cell spacing must be zero",
+        ));
+    }
+    let expected_table_len = 22usize
+        .checked_add(rows.checked_mul(2).ok_or_else(|| {
+            malformed(
+                &table_record,
+                Some(section),
+                "TABLE row-size length overflows",
+            )
+        })?)
+        .ok_or_else(|| {
+            malformed(
+                &table_record,
+                Some(section),
+                "TABLE record length overflows",
+            )
+        })?;
+    if table_bytes.len() != expected_table_len {
+        return Err(malformed(
+            &table_record,
+            Some(section),
+            "owned TABLE record length or zone framing differs from its row count",
         ));
     }
     let table_padding = [10usize, 12, 14, 16]
@@ -1653,95 +1682,280 @@ fn parse_inline_table(
             "TABLE padding must be nonnegative",
         ));
     }
-    let table_border_id = read_u16(table_bytes, 20).expect("exact length checked");
+    let row_sizes = (0..rows)
+        .map(|row| read_u16(table_bytes, 18 + row * 2).expect("exact length checked") as HwpUnit)
+        .collect::<Vec<_>>();
+    if row_sizes.iter().any(|height| *height <= 0) {
+        return Err(malformed(
+            &table_record,
+            Some(section),
+            "TABLE row-size slots must be positive",
+        ));
+    }
+    let table_border_at = 18 + rows * 2;
+    let table_border_id = read_u16(table_bytes, table_border_at).expect("exact length checked");
+    if read_u16(table_bytes, table_border_at + 2) != Some(0) {
+        return Err(malformed(
+            &table_record,
+            Some(section),
+            "owned TABLE zone count must be zero",
+        ));
+    }
     let table_fill = table_border(doc, table_border_id, &table_record, section, "table")?;
 
-    let list_record = children[1];
-    let list_bytes = data(stream, &list_record);
-    if list_bytes.len() != 47 {
+    let mut cells = Vec::with_capacity(expected_cells);
+    let mut cell_heights = Vec::with_capacity(expected_cells);
+    let mut cursor = 1usize;
+    while cursor < children.len() {
+        if cells.len() == expected_cells {
+            return Err(malformed(
+                &children[cursor],
+                Some(section),
+                "owned TABLE has more active cells than its bounded topology",
+            ));
+        }
+        let list_record = children[cursor];
+        if list_record.tag != TAG_LIST_HEADER || list_record.level != child_level {
+            return Err(malformed(
+                &list_record,
+                Some(section),
+                "owned TABLE expects a LIST_HEADER before each active cell",
+            ));
+        }
+        let list_bytes = data(stream, &list_record);
+        if list_bytes.len() != 47 {
+            return Err(malformed(
+                &list_record,
+                Some(section),
+                "owned cell LIST_HEADER is not exactly 47 bytes",
+            ));
+        }
+        let paragraph_count = read_u16(list_bytes, 0).expect("exact length checked") as usize;
+        if !(1..=5).contains(&paragraph_count)
+            || read_u32(list_bytes, 2) != Some(0x0020_0000)
+            || !matches!(read_u16(list_bytes, 6), Some(0x0000 | 0x0100 | 0x0500))
+        {
+            return Err(malformed(
+                &list_record,
+                Some(section),
+                "cell LIST_HEADER count, direction, alignment, or width reference is not owned",
+            ));
+        }
+        let col = read_u16(list_bytes, 8).expect("exact length checked") as usize;
+        let row = read_u16(list_bytes, 10).expect("exact length checked") as usize;
+        let col_span = read_u16(list_bytes, 12).expect("exact length checked") as usize;
+        let row_span = read_u16(list_bytes, 14).expect("exact length checked") as usize;
+        let cell_width = read_u32(list_bytes, 16).expect("exact length checked");
+        let cell_height = read_u32(list_bytes, 20).expect("exact length checked");
+        if col_span == 0
+            || row_span != 1
+            || col.checked_add(col_span).is_none_or(|end| end > cols)
+            || row >= rows
+            || cell_width == 0
+            || cell_height == 0
+            || cell_width > MAX_OBJECT_HWPUNIT
+            || cell_height > MAX_OBJECT_HWPUNIT
+        {
+            return Err(malformed(
+                &list_record,
+                Some(section),
+                "cell coordinates, horizontal span, or dimensions are outside the owned TABLE grid",
+            ));
+        }
+        let cell_padding = [24usize, 26, 28, 30]
+            .map(|at| i16::from_le_bytes(list_bytes[at..at + 2].try_into().unwrap()));
+        if cell_padding.iter().any(|value| *value < 0) {
+            return Err(malformed(
+                &list_record,
+                Some(section),
+                "cell stored padding must be nonnegative",
+            ));
+        }
+        // The 13-byte extension cannot yield a typed field in the pinned parser. Keep it inert and
+        // out of shared IR; the exact 47-byte framing prevents a longer field-bearing tail.
+        debug_assert_eq!(list_bytes[34..].len(), 13);
+        let cell_border_id = read_u16(list_bytes, 32).expect("exact length checked");
+        let cell_fill = table_border(doc, cell_border_id, &list_record, section, "table cell")?;
+
+        cursor += 1;
+        let mut blocks = Vec::with_capacity(paragraph_count);
+        for _ in 0..paragraph_count {
+            let Some(header) = children.get(cursor).copied() else {
+                return Err(malformed(
+                    &list_record,
+                    Some(section),
+                    "cell LIST_HEADER declares missing paragraphs",
+                ));
+            };
+            if header.tag != TAG_PARA_HEADER || header.level != child_level {
+                return Err(malformed(
+                    &header,
+                    Some(section),
+                    "cell LIST_HEADER is not followed by its declared paragraph headers",
+                ));
+            }
+            let start = cursor;
+            cursor += 1;
+            while cursor < children.len() && children[cursor].level > child_level {
+                cursor += 1;
+            }
+            let parsed = parse_paragraph(
+                stream,
+                &children[start..cursor],
+                doc,
+                para_usage,
+                styles,
+                section,
+                None,
+            )?;
+            if parsed.page.is_some()
+                || parsed.page_number.is_some()
+                || !parsed.tables.is_empty()
+                || parsed.paragraph.page_break_before
+                || parsed.paragraph.column_break_before
+                || parsed.paragraph.column_layout_before.is_some()
+            {
+                return Err(malformed(
+                    &header,
+                    Some(section),
+                    "owned table cell paragraph contains nested layout controls",
+                ));
+            }
+            blocks.push(Block::Paragraph(parsed.paragraph));
+        }
+        cell_heights.push(cell_height as HwpUnit);
+        cells.push(Cell {
+            row,
+            col,
+            row_span,
+            col_span,
+            blocks,
+            active: true,
+            shade_color: cell_fill.shade,
+            has_border: cell_fill.has_border,
+            borders: cell_fill.borders,
+            diagonal: cell_fill.diagonal,
+            // All observed width-reference words have the apply-inner-margin low bit off.
+            padding: None,
+            width: Some(cell_width as HwpUnit),
+            ..Cell::default()
+        });
+    }
+    if cells.len() != expected_cells {
         return Err(malformed(
-            &list_record,
+            &table_record,
             Some(section),
-            "owned cell LIST_HEADER is not exactly 47 bytes",
+            "owned TABLE active-cell count differs from its exact topology",
         ));
     }
-    if read_u16(list_bytes, 0) != Some(1)
-        || read_u32(list_bytes, 2) != Some(0x0020_0000)
-        || read_u16(list_bytes, 6) != Some(0x0500)
-        || read_u16(list_bytes, 8) != Some(0)
-        || read_u16(list_bytes, 10) != Some(0)
-        || read_u16(list_bytes, 12) != Some(1)
-        || read_u16(list_bytes, 14) != Some(1)
-        || read_u32(list_bytes, 16) != Some(width)
-        || read_u32(list_bytes, 20) != Some(height)
+
+    let expected_positions = (0..rows)
+        .flat_map(|row| {
+            if cols == 2 && matches!(row, 0 | 1 | 5) {
+                vec![(row, 0, 2)]
+            } else {
+                (0..cols).map(|col| (row, col, 1)).collect()
+            }
+        })
+        .collect::<Vec<_>>();
+    if cells
+        .iter()
+        .zip(&expected_positions)
+        .any(|(cell, expected)| (cell.row, cell.col, cell.col_span) != *expected)
     {
         return Err(malformed(
-            &list_record,
+            &table_record,
             Some(section),
-            "cell LIST_HEADER attributes or geometry are not the owned centered 1x1 slice",
+            "owned TABLE cells are not in the exact row-major merge topology",
         ));
     }
-    let cell_padding = [24usize, 26, 28, 30]
-        .map(|at| i16::from_le_bytes(list_bytes[at..at + 2].try_into().unwrap()));
-    if cell_padding.iter().any(|value| *value < 0) {
-        return Err(malformed(
-            &list_record,
-            Some(section),
-            "cell stored padding must be nonnegative",
-        ));
-    }
-    // The pinned parser can only materialize a field name from an extension of at least 18 bytes.
-    // This exact 13-byte public storage tail carries no typed field in that oracle and is discarded;
-    // any other length remains unsupported instead of becoming passthrough executable/content data.
-    debug_assert_eq!(list_bytes[34..].len(), 13);
-    let cell_border_id = read_u16(list_bytes, 32).expect("exact length checked");
-    let cell_fill = table_border(doc, cell_border_id, &list_record, section, "table cell")?;
 
-    let parsed_cell = parse_paragraph(
-        stream,
-        &children[2..],
-        doc,
-        para_usage,
-        styles,
-        section,
-        None,
-    )?;
-    if parsed_cell.page.is_some()
-        || parsed_cell.page_number.is_some()
-        || !parsed_cell.tables.is_empty()
-        || parsed_cell.paragraph.page_break_before
-        || parsed_cell.paragraph.column_break_before
-        || parsed_cell.paragraph.column_layout_before.is_some()
+    let mut col_widths = vec![None::<HwpUnit>; cols];
+    let mut derived_rows = vec![None::<HwpUnit>; rows];
+    for (cell, cell_height) in cells.iter().zip(cell_heights) {
+        let cell_width = cell.width.expect("owned cells always carry width");
+        if cell.col_span == 1 {
+            match col_widths[cell.col] {
+                Some(existing) if existing != cell_width => {
+                    return Err(malformed(
+                        &table_record,
+                        Some(section),
+                        "single-column cell widths disagree across TABLE rows",
+                    ))
+                }
+                None => col_widths[cell.col] = Some(cell_width),
+                _ => {}
+            }
+        }
+        match derived_rows[cell.row] {
+            Some(existing) if existing != cell_height => {
+                return Err(malformed(
+                    &table_record,
+                    Some(section),
+                    "cell heights disagree within a TABLE row",
+                ))
+            }
+            None => derived_rows[cell.row] = Some(cell_height),
+            _ => {}
+        }
+    }
+    let col_widths = col_widths
+        .into_iter()
+        .collect::<Option<Vec<_>>>()
+        .ok_or_else(|| {
+            malformed(
+                &table_record,
+                Some(section),
+                "TABLE has a column whose width cannot be derived from an active cell",
+            )
+        })?;
+    if col_widths
+        .iter()
+        .try_fold(0i64, |sum, value| sum.checked_add(i64::from(*value)))
+        != Some(i64::from(width))
+        || cells.iter().any(|cell| {
+            col_widths[cell.col..cell.col + cell.col_span]
+                .iter()
+                .map(|value| i64::from(*value))
+                .sum::<i64>()
+                != i64::from(cell.width.expect("owned cells always carry width"))
+        })
     {
         return Err(malformed(
-            &children[2],
+            &table_record,
             Some(section),
-            "owned table cell paragraph contains nested layout controls",
+            "TABLE column widths or merged-cell widths disagree with common-object geometry",
+        ));
+    }
+    let derived_rows = derived_rows
+        .into_iter()
+        .collect::<Option<Vec<_>>>()
+        .ok_or_else(|| {
+            malformed(
+                &table_record,
+                Some(section),
+                "TABLE has a row whose stored height cannot be derived from an active cell",
+            )
+        })?;
+    if derived_rows
+        .iter()
+        .try_fold(0i64, |sum, value| sum.checked_add(i64::from(*value)))
+        != Some(i64::from(height))
+    {
+        return Err(malformed(
+            &table_record,
+            Some(section),
+            "stored active-cell row heights do not sum to common-object geometry",
         ));
     }
 
-    let cell = Cell {
-        row: 0,
-        col: 0,
-        row_span: 1,
-        col_span: 1,
-        blocks: vec![Block::Paragraph(parsed_cell.paragraph)],
-        active: true,
-        shade_color: cell_fill.shade,
-        has_border: cell_fill.has_border,
-        borders: cell_fill.borders,
-        diagonal: cell_fill.diagonal,
-        // width_ref low bit is off: stored cell padding is inactive and table padding is inherited.
-        padding: None,
-        width: Some(width as HwpUnit),
-        ..Cell::default()
-    };
     Ok(Table {
-        rows: 1,
-        cols: 1,
-        cells: vec![cell],
-        col_widths: vec![width as HwpUnit],
-        row_heights: vec![height as HwpUnit],
+        rows,
+        cols,
+        cells,
+        keep_together: true,
+        col_widths,
+        row_heights: derived_rows,
         outer_margin_left: margins[0] as HwpUnit,
         outer_margin_right: margins[1] as HwpUnit,
         outer_margin_top: margins[2] as HwpUnit,
@@ -2440,6 +2654,7 @@ struct DecodedText {
     structural_controls: Vec<(u32, u32)>,
     stored_units: u32,
     inline_control_mask: u32,
+    terminator: Option<u32>,
 }
 
 impl DecodedText {
@@ -2453,6 +2668,7 @@ impl DecodedText {
                 .structural_controls
                 .binary_search_by_key(&offset, |(start, _)| *start)
                 .is_ok()
+            || self.terminator == Some(offset)
     }
 }
 
@@ -2472,6 +2688,7 @@ fn decode_text(bytes: &[u8], record: Record, section: usize) -> Result<DecodedTe
     let mut structural_controls = Vec::new();
     let mut cursor = 0usize;
     let mut ended = false;
+    let mut terminator = None;
     let mut inline_control_mask = 0u32;
     while cursor < units.len() {
         let start = cursor as u32;
@@ -2479,6 +2696,7 @@ fn decode_text(bytes: &[u8], record: Record, section: usize) -> Result<DecodedTe
         match unit {
             0x000d => {
                 ended = true;
+                terminator = Some(start);
                 cursor += 1;
                 if units[cursor..].iter().any(|unit| *unit != 0) {
                     return Err(malformed(
@@ -2610,6 +2828,7 @@ fn decode_text(bytes: &[u8], record: Record, section: usize) -> Result<DecodedTe
         structural_controls,
         stored_units: units.len() as u32,
         inline_control_mask,
+        terminator,
     })
 }
 
@@ -2717,6 +2936,16 @@ fn make_runs(
         runs.push(Run {
             char_shape: current_shape,
             content: vec![Inline::Text(current_text)],
+            ..Run::default()
+        });
+    }
+    if let Some((_, shape)) = decoded
+        .terminator
+        .and_then(|terminator| effective.iter().find(|(start, _)| *start == terminator))
+    {
+        runs.push(Run {
+            char_shape: *shape,
+            content: Vec::new(),
             ..Run::default()
         });
     }

--- a/crates/hwp-hwp5/tests/layout_semantic.rs
+++ b/crates/hwp-hwp5/tests/layout_semantic.rs
@@ -68,6 +68,15 @@ enum Mutation {
     BadTableGeometry,
     BadTableCellAlign,
     BadTableBorderRef,
+    LargeTable,
+    LargeTableBadCellCount,
+    LargeTableExtraCell,
+    LargeTableBadSpan,
+    LargeTableBadWidth,
+    LargeTableBadParagraphCount,
+    LargeTableBadRowHeight,
+    LargeTableBadWidthRef,
+    LargeTableBadCellOrder,
 }
 
 #[test]
@@ -485,6 +494,7 @@ fn owns_strict_inline_one_by_one_table_as_anchor_plus_shared_ir() {
     };
     assert!(anchor.is_table_anchor);
     assert_eq!((table.rows, table.cols), (1, 1));
+    assert!(table.keep_together);
     assert_eq!(table.col_widths, vec![20_000]);
     assert_eq!(table.row_heights, vec![2_000]);
     assert_eq!(table.padding, Some([510, 510, 141, 141]));
@@ -523,6 +533,57 @@ fn strict_inline_table_rejects_unowned_attributes_topology_geometry_alignment_an
     }
 }
 
+#[test]
+fn owns_strict_inline_ten_by_two_table_with_horizontal_merges_and_multiple_paragraphs() {
+    let doc = OwnHwp5Parser::new()
+        .parse(&fixture(Mutation::LargeTable))
+        .expect("strict 10x2 table fixture parses");
+    let Block::Table(table) = &doc.sections[0].blocks[1] else {
+        panic!("table host must be followed by a shared table block")
+    };
+    assert_eq!((table.rows, table.cols, table.cells.len()), (10, 2, 17));
+    assert!(table.keep_together, "TABLE no-split attr reaches shared IR");
+    assert_eq!(table.col_widths, vec![9_361, 38_552]);
+    assert_eq!(table.row_heights.iter().sum::<i32>(), 65_409);
+    assert_eq!(
+        table
+            .cells
+            .iter()
+            .filter(|cell| cell.col_span == 2)
+            .map(|cell| cell.row)
+            .collect::<Vec<_>>(),
+        vec![0, 1, 5]
+    );
+    assert_eq!(table.cells[0].blocks.len(), 5);
+    let Block::Paragraph(first) = &table.cells[0].blocks[0] else {
+        panic!("cell content remains paragraph blocks")
+    };
+    assert!(
+        first.runs.last().is_some_and(|run| run.content.is_empty()
+            && run.char_shape != first.runs[0].char_shape),
+        "paragraph-mark character shape remains as a terminal empty run"
+    );
+}
+
+#[test]
+fn strict_ten_by_two_table_rejects_hostile_counts_spans_geometry_and_width_refs() {
+    for mutation in [
+        Mutation::LargeTableBadCellCount,
+        Mutation::LargeTableExtraCell,
+        Mutation::LargeTableBadSpan,
+        Mutation::LargeTableBadWidth,
+        Mutation::LargeTableBadParagraphCount,
+        Mutation::LargeTableBadRowHeight,
+        Mutation::LargeTableBadWidthRef,
+        Mutation::LargeTableBadCellOrder,
+    ] {
+        assert!(
+            OwnHwp5Parser::new().parse(&fixture(mutation)).is_err(),
+            "hostile mutation must fail closed"
+        );
+    }
+}
+
 fn fixture(mutation: Mutation) -> Vec<u8> {
     let mut header = vec![0; 256];
     header[..HWP_SIGNATURE.len()].copy_from_slice(HWP_SIGNATURE);
@@ -536,6 +597,27 @@ fn fixture(mutation: Mutation) -> Vec<u8> {
             | Mutation::BadTableGeometry
             | Mutation::BadTableCellAlign
             | Mutation::BadTableBorderRef
+            | Mutation::LargeTable
+            | Mutation::LargeTableBadCellCount
+            | Mutation::LargeTableExtraCell
+            | Mutation::LargeTableBadSpan
+            | Mutation::LargeTableBadWidth
+            | Mutation::LargeTableBadParagraphCount
+            | Mutation::LargeTableBadRowHeight
+            | Mutation::LargeTableBadWidthRef
+            | Mutation::LargeTableBadCellOrder
+    );
+    let has_large_table = matches!(
+        mutation,
+        Mutation::LargeTable
+            | Mutation::LargeTableBadCellCount
+            | Mutation::LargeTableExtraCell
+            | Mutation::LargeTableBadSpan
+            | Mutation::LargeTableBadWidth
+            | Mutation::LargeTableBadParagraphCount
+            | Mutation::LargeTableBadRowHeight
+            | Mutation::LargeTableBadWidthRef
+            | Mutation::LargeTableBadCellOrder
     );
     let mut doc_info = Vec::new();
     let mut properties = vec![0; 26];
@@ -560,7 +642,7 @@ fn fixture(mutation: Mutation) -> Vec<u8> {
         1,
         1,
         usize::from(has_table),
-        1,
+        if has_large_table { 2 } else { 1 },
         0,
         0,
         0,
@@ -577,6 +659,9 @@ fn fixture(mutation: Mutation) -> Vec<u8> {
         push_record(&mut doc_info, TAG_BORDER_FILL, 0, &solid_border_fill());
     }
     push_record(&mut doc_info, TAG_CHAR_SHAPE, 0, &char_shape());
+    if has_large_table {
+        push_record(&mut doc_info, TAG_CHAR_SHAPE, 0, &char_shape());
+    }
     push_record(&mut doc_info, TAG_PARA_SHAPE, 0, &para_shape());
 
     let mut body = Vec::new();
@@ -813,6 +898,11 @@ fn fixture(mutation: Mutation) -> Vec<u8> {
         }
     }
     if has_table {
+        let (table_width, table_height, table_rows, table_cols) = if has_large_table {
+            (47_913u32, 65_409u32, 10u16, 2u16)
+        } else {
+            (20_000, 2_000, 1, 1)
+        };
         let mut common = Vec::with_capacity(46);
         common.extend_from_slice(&CTRL_TABLE.to_le_bytes());
         let attr = if matches!(mutation, Mutation::BadTableAttr) {
@@ -823,8 +913,8 @@ fn fixture(mutation: Mutation) -> Vec<u8> {
         common.extend_from_slice(&attr.to_le_bytes());
         common.extend_from_slice(&0u32.to_le_bytes());
         common.extend_from_slice(&0u32.to_le_bytes());
-        common.extend_from_slice(&20_000u32.to_le_bytes());
-        common.extend_from_slice(&2_000u32.to_le_bytes());
+        common.extend_from_slice(&table_width.to_le_bytes());
+        common.extend_from_slice(&table_height.to_le_bytes());
         common.extend_from_slice(&0i32.to_le_bytes());
         for margin in [100i16, 100, 50, 50] {
             common.extend_from_slice(&margin.to_le_bytes());
@@ -834,15 +924,21 @@ fn fixture(mutation: Mutation) -> Vec<u8> {
         common.extend_from_slice(&0u16.to_le_bytes());
         push_record(&mut body, TAG_CTRL_HEADER, 1, &common);
 
-        let mut table = Vec::with_capacity(24);
+        let mut table = Vec::with_capacity(22 + usize::from(table_rows) * 2);
         table.extend_from_slice(&0x0400_0006u32.to_le_bytes());
-        table.extend_from_slice(&1u16.to_le_bytes());
-        table.extend_from_slice(&1u16.to_le_bytes());
+        table.extend_from_slice(&table_rows.to_le_bytes());
+        table.extend_from_slice(&table_cols.to_le_bytes());
         table.extend_from_slice(&0u16.to_le_bytes());
         for padding in [510i16, 510, 141, 141] {
             table.extend_from_slice(&padding.to_le_bytes());
         }
-        table.extend_from_slice(&1u16.to_le_bytes());
+        if has_large_table {
+            for height in [6_500u16; 9].into_iter().chain([6_909]) {
+                table.extend_from_slice(&height.to_le_bytes());
+            }
+        } else {
+            table.extend_from_slice(&1u16.to_le_bytes());
+        }
         table.extend_from_slice(&1u16.to_le_bytes());
         table.extend_from_slice(&0u16.to_le_bytes());
         push_record(
@@ -856,51 +952,134 @@ fn fixture(mutation: Mutation) -> Vec<u8> {
             &table,
         );
 
-        let mut cell = Vec::with_capacity(47);
-        cell.extend_from_slice(&1u16.to_le_bytes());
-        cell.extend_from_slice(
-            &if matches!(mutation, Mutation::BadTableCellAlign) {
-                0u32
-            } else {
-                0x0020_0000
-            }
-            .to_le_bytes(),
-        );
-        cell.extend_from_slice(&0x0500u16.to_le_bytes());
-        for value in [0u16, 0, 1, 1] {
-            cell.extend_from_slice(&value.to_le_bytes());
+        let mut positions = if has_large_table {
+            (0usize..10)
+                .flat_map(|row| {
+                    if matches!(row, 0 | 1 | 5) {
+                        vec![(row, 0usize, 2usize)]
+                    } else {
+                        vec![(row, 0, 1), (row, 1, 1)]
+                    }
+                })
+                .collect::<Vec<_>>()
+        } else {
+            vec![(0, 0, 1)]
+        };
+        if matches!(mutation, Mutation::LargeTableBadCellCount) {
+            positions.pop();
         }
-        cell.extend_from_slice(
-            &if matches!(mutation, Mutation::BadTableGeometry) {
-                19_999u32
-            } else {
-                20_000
-            }
-            .to_le_bytes(),
-        );
-        cell.extend_from_slice(&2_000u32.to_le_bytes());
-        for padding in [510i16, 510, 141, 141] {
-            cell.extend_from_slice(&padding.to_le_bytes());
+        if matches!(mutation, Mutation::LargeTableExtraCell) {
+            positions.push((9, 1, 1));
         }
-        cell.extend_from_slice(
-            &if matches!(mutation, Mutation::BadTableBorderRef) {
-                2u16
+        if matches!(mutation, Mutation::LargeTableBadSpan) {
+            positions[0].2 = 1;
+        }
+        if matches!(mutation, Mutation::LargeTableBadCellOrder) {
+            positions.swap(2, 3);
+        }
+        for (cell_index, (row, col, col_span)) in positions.into_iter().enumerate() {
+            let paragraph_count = if has_large_table && cell_index == 0 {
+                if matches!(mutation, Mutation::LargeTableBadParagraphCount) {
+                    6u16
+                } else {
+                    5
+                }
             } else {
                 1
+            };
+            let width_ref =
+                if matches!(mutation, Mutation::LargeTableBadWidthRef) && cell_index == 0 {
+                    0x0200u16
+                } else if has_large_table {
+                    [0x0000u16, 0x0100, 0x0500][cell_index % 3]
+                } else {
+                    0x0500
+                };
+            let mut cell_width = if has_large_table {
+                [9_361u32, 38_552][col..col + col_span].iter().sum()
+            } else {
+                20_000
+            };
+            if cell_index == 0
+                && matches!(
+                    mutation,
+                    Mutation::BadTableGeometry | Mutation::LargeTableBadWidth
+                )
+            {
+                cell_width -= 1;
             }
-            .to_le_bytes(),
-        );
-        cell.extend([0; 13]);
-        push_record(&mut body, TAG_LIST_HEADER, 2, &cell);
+            let mut cell_height = if has_large_table {
+                if row == 9 {
+                    6_909u32
+                } else {
+                    6_500
+                }
+            } else {
+                2_000
+            };
+            if matches!(mutation, Mutation::LargeTableBadRowHeight) && cell_index == 0 {
+                cell_height -= 1;
+            }
 
-        push_para_header_at_level(&mut body, 2, 2, 0, 1, 0, 0);
-        push_record(
-            &mut body,
-            TAG_PARA_TEXT,
-            3,
-            &utf16_bytes(&['A' as u16, 0x000d]),
-        );
-        push_record(&mut body, TAG_PARA_CHAR_SHAPE, 3, &shape_refs(&[(0, 0)]));
+            let mut cell = Vec::with_capacity(47);
+            cell.extend_from_slice(&paragraph_count.to_le_bytes());
+            cell.extend_from_slice(
+                &if matches!(mutation, Mutation::BadTableCellAlign) {
+                    0u32
+                } else {
+                    0x0020_0000
+                }
+                .to_le_bytes(),
+            );
+            cell.extend_from_slice(&width_ref.to_le_bytes());
+            for value in [col as u16, row as u16, col_span as u16, 1] {
+                cell.extend_from_slice(&value.to_le_bytes());
+            }
+            cell.extend_from_slice(&cell_width.to_le_bytes());
+            cell.extend_from_slice(&cell_height.to_le_bytes());
+            for padding in [510i16, 510, 141, 141] {
+                cell.extend_from_slice(&padding.to_le_bytes());
+            }
+            cell.extend_from_slice(
+                &if matches!(mutation, Mutation::BadTableBorderRef) {
+                    2u16
+                } else {
+                    1
+                }
+                .to_le_bytes(),
+            );
+            cell.extend([0; 13]);
+            push_record(&mut body, TAG_LIST_HEADER, 2, &cell);
+
+            for paragraph in 0..paragraph_count {
+                let terminal_shape = has_large_table && cell_index == 0 && paragraph == 0;
+                push_para_header_at_level(
+                    &mut body,
+                    2,
+                    2,
+                    0,
+                    if terminal_shape { 2 } else { 1 },
+                    0,
+                    0,
+                );
+                push_record(
+                    &mut body,
+                    TAG_PARA_TEXT,
+                    3,
+                    &utf16_bytes(&['A' as u16, 0x000d]),
+                );
+                push_record(
+                    &mut body,
+                    TAG_PARA_CHAR_SHAPE,
+                    3,
+                    &shape_refs(if terminal_shape {
+                        &[(0, 0), (1, 1)]
+                    } else {
+                        &[(0, 0)]
+                    }),
+                );
+            }
+        }
     }
 
     if matches!(mutation, Mutation::MidSectionSeparator) {

--- a/crates/hwp-hwp5/tests/public_probe.rs
+++ b/crates/hwp-hwp5/tests/public_probe.rs
@@ -28,17 +28,17 @@ fn public_hwp5_has_bounded_content_free_record_provenance() {
 }
 
 #[test]
-fn explicit_own_parser_never_falls_back() {
+fn explicit_own_parser_owns_the_ten_by_two_table_then_stops_content_free() {
     let error = OwnHwp5Parser::new().parse(&benchmark()).unwrap_err();
     eprintln!("{error:?}");
     assert!(matches!(
         error,
         Error::UnsupportedBodyRecord {
-            tag: 0x4d,
+            tag: 0x47,
             section: 0,
-            start: 936,
-            end: 982,
-            reason: "record semantics are not owned",
+            start: 5926,
+            end: 5976,
+            reason: "paragraphs with multiple table controls are not yet owned",
             ..
         }
     ));

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,7 +3,7 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
-- 갱신: 2026-08-24 · Codex(sol) — **PR #169 병합 · #170 분류 · #171 keep-together 게시 준비 완료**.
+- 갱신: 2026-08-24 · Codex(sol) — **PR #172 병합 · #170 strict 10×2 TABLE 재개**.
   자체 HWP5 파서가 exact `tbl ` marker/common-object/TABLE/LIST_HEADER/cell paragraph를 검증해
   treat-as-character 1×1 표를 source-neutral `Table`/`Cell` IR로 내린다. 셀/개체 geometry,
   inherited padding, CENTER alignment, border-fill refs를 range/shape 검증하고 visible host text,
@@ -35,8 +35,25 @@
   JS build·crosscheck·i18n, Vitest **1,007**이 green이고, 샌드박스 포트 EPERM만 허용된 로컬
   서버에서 분리 재실행해 Chromium **85 pass/3 intentional skip/0 fail**이다. 임시 dependency
   link는 제거했고 production route·rhwp·HWPX parser/serializer·generated asset diff 0.
-  **다음:** commit/push/PR #171→필수 CI/자율 병합→#170 rebase 후 keep_together=true strict
-  10×2 parser 재개.
+  PR #172는 exact head `02f0c630`의 issue-link **4s**·build-test **8m32s**·licenses **2m38s**
+  green, CLEAN/MERGEABLE, review/general/inline 댓글 0을 확인하고 main `e14c8e7`로 squash 병합했다.
+  #171 close·원격 branch 정리 후 #170의 중복 docs-only checkpoint는 main에 이미 포함된 것을
+  대조해 rebase에서 skip하고, `codex/issue-170-hwp5-next-table`을 exact new main으로 force-with-lease
+  갱신했다. strict parser는 exact 10×2/17 active cells, row-major horizontal spans(row 0/1/5),
+  zero spacing/zones, CENTER horizontal LIST_HEADER, observed width-ref 0/0x100/0x500, 1~5 paragraphs,
+  table/cell padding·border refs·object/column/row geometry를 bounded 검증한다. col widths와 stored row
+  floors는 rhwp lift와 같은 source-neutral 방식으로 도출하고 no-split attr은 `keep_together=true`로
+  내린다. 셀 문단 끝의 별도 char shape boundary는 terminal empty run으로 보존한다. count/span/
+  missing/extra count·span·width·row-height·paragraph-count·width-ref·order hostile 8종은
+  fail-closed하며 HWP5 **53 tests**, clippy `-D warnings`, wasm32 green. 공개 경계는 TABLE
+  `936..982`를 소유하고 다음 multi-table CTRL_HEADER `5926..5976`에서 static content-free
+  unsupported로 전진했다. quick/full의 Rust workspace, typeset **100+4**, PDF visual **51**,
+  canonical **8/18/24·98.9%+**, public corpus **84**, oracle **82**, HWPX, wasm(7,810,657B),
+  licenses, JS build·crosscheck·i18n, Vitest **1,007**이 green이다. 샌드박스 포트 EPERM만 허용된
+  로컬 서버에서 분리 재실행해 Chromium **85 pass/3 intentional skip/0 fail**이며, 이후 강화한
+  distinct terminal char-shape/extra-cell bound도 focused HWP5·clippy 재검증 green. 임시 dependency
+  link 제거, production route·rhwp·HWPX parser/serializer·generated asset diff 0.
+  **다음:** final commit/push/PR #170→필수 CI/자율 병합→다음 child 분류.
 
 - 갱신: 2026-08-23 · Codex(sol) — **#161 PR #163 게시**.
   검증 완료 commit `c751833`을 push하고 PR #163(`Closes #161`, `Refs #94 #160`)을 만들었다.

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -53,7 +53,9 @@
   로컬 서버에서 분리 재실행해 Chromium **85 pass/3 intentional skip/0 fail**이며, 이후 강화한
   distinct terminal char-shape/extra-cell bound도 focused HWP5·clippy 재검증 green. 임시 dependency
   link 제거, production route·rhwp·HWPX parser/serializer·generated asset diff 0.
-  **다음:** final commit/push/PR #170→필수 CI/자율 병합→다음 child 분류.
+  검증 완료 commit `25010cb`을 push하고 PR #173(`Closes #170`, `Refs #94 #168 #171 #172`)을
+  게시했다. **다음:** exact-head issue-link/build-test/licenses·mergeability·review/comment 추적→전부
+  green이면 자율 병합·branch 정리→다음 multi-table boundary child 분류.
 
 - 갱신: 2026-08-23 · Codex(sol) — **#161 PR #163 게시**.
   검증 완료 commit `c751833`을 push하고 PR #163(`Closes #161`, `Refs #94 #160`)을 만들었다.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,21 @@
 
 ---
 
+## 2026-08-24 (Codex sol) · #170 full green / PR ready
+- strict 10×2 TABLE + terminal char shape + bounded extra-cell guard 최종 확정.
+- quick/full·Vitest 1,007·Chromium 85/3 green; route/rhwp/HWPX/generated diff 0.
+- 다음 commit/push/PR→required CI/merge→next public boundary child.
+
+## 2026-08-24 (Codex sol) · #170 strict 10×2 TABLE focused green
+- exact 17 cells/3 horizontal spans/1~5 paras → shared Table, no-split keep_together=true.
+- hostile 8종 fail-closed; terminal char-shape run 보존; HWP5 53/clippy/wasm32 green.
+- public boundary 0x4d 936..982→multi-table CTRL 5926..5976. 다음 quick→full→PR/CI.
+
+## 2026-08-24 (Codex sol) · PR #172 merged → #170 resumed
+- #172 required CI/CLEAN/MERGEABLE·댓글 0 후 main `e14c8e7` 병합; #171 close·branch 정리.
+- #170 중복 docs checkpoint는 main 포함을 대조해 skip, exact new main으로 rebase/push.
+- 다음 strict 10×2/17-cell parser + keep_together=true/hostile tests→full/PR/CI.
+
 ## 2026-08-24 (Codex sol) · #171 full green / PR ready
 - keep-together page/column 3-path LOCKSTEP와 default/over-tall fallback 확정.
 - quick/full·Vitest 1,007·Chromium 85/3 green; route/rhwp/HWPX/generated diff 0.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,11 @@
 
 ---
 
+## 2026-08-24 (Codex sol) · #170 PR #173 게시
+- strict 10×2 TABLE commit `25010cb`을 push하고 PR #173(`Closes #170`) 생성.
+- route/rhwp/HWPX/generated 불변과 quick/full/Vitest 1,007/Chromium 85·3을 명시.
+- 다음 required CI·댓글 추적→green 자율 병합→multi-table boundary child.
+
 ## 2026-08-24 (Codex sol) · #170 full green / PR ready
 - strict 10×2 TABLE + terminal char shape + bounded extra-cell guard 최종 확정.
 - quick/full·Vitest 1,007·Chromium 85/3 green; route/rhwp/HWPX/generated diff 0.


### PR DESCRIPTION
Closes #170

Refs #94 #168 #171 #172

## What changed
- Own the exact observed HWP5 10×2 table subset with 17 active cells and three row-major horizontal merges.
- Strictly validate table, list-header, cell, padding, border-ref, span, paragraph-count, and geometry invariants before lowering to the shared source-neutral Table IR.
- Preserve the distinct terminal paragraph char shape as an empty final run for faithful later editing.
- Lower the official no-split attribute to Table.keep_together and fail closed on multi-table paragraphs and hostile count/span/width/order mutations.
- Advance the content-free public boundary from TABLE 0x4d at 936..982 to CTRL_HEADER 0x47 at 5926..5976.

## Safety boundary
- No production HWP5 route cutover and no rhwp fallback change.
- No change to external/rhwp, the HWPX parser/serializer, or generated wasm/public assets.
- No source content, local path, hash, or raw payload is published.

## Verification
- scripts/verify-local.sh
- scripts/verify-local.sh --full
- HWP5: 53 tests; typeset: 100+4; PDF visual: 51
- canonical: 8/18/24 and 98.9%+; public corpus: 84; oracle: 82
- Vitest: 1,007 green
- Chromium: 85 passed, 3 intentional skipped, 0 failed
- touched clippy -D warnings and wasm32 checks green