### PR TITLE
feat: own bounded multi-table HWP5 hosts

### DIFF
--- a/crates/hwp-hwp5/src/semantic.rs
+++ b/crates/hwp-hwp5/src/semantic.rs
@@ -1312,11 +1312,11 @@ fn parse_paragraph(
                 }
             }
             CTRL_TABLE => {
-                if !tables.is_empty() {
+                if tables.len() == 2 {
                     return Err(unsupported_reason(
                         *control,
                         section,
-                        "paragraphs with multiple table controls are not yet owned",
+                        "paragraphs with more than two table controls are not owned",
                     ));
                 }
                 tables.push(parse_inline_table(
@@ -1548,11 +1548,13 @@ fn parse_new_number_control(
         .ok_or_else(|| malformed(record, Some(section), "page-number restart must be nonzero"))
 }
 
-/// Own the two bounded binary-table slices seen at the public first-party boundary: the original
-/// inline 1×1 table and the following inline 10×2 table. Both use the same exact common-object and
-/// no-split TABLE attributes. The larger slice has 17 active cells (three horizontal merges), one to
-/// five paragraphs per cell, and no zones/captions/nested layout. Anything outside that narrow,
-/// source-neutral shape remains fail-closed rather than being approximated.
+/// Own the bounded binary-table slices seen at the public first-party boundary: strict inline 1×1
+/// and 10×2 tables. They use the same exact common-object and no-split TABLE attributes. The larger
+/// slice has 17 active cells (three horizontal merges), one to five paragraphs per cell, and no
+/// zones/captions/nested layout. A 1×1 cell may use the exact observed cell-own inner-margin bit;
+/// protection/header/form bits remain unsupported. Multiple controls in one text-empty host are
+/// emitted in marker/header order by `parse_paragraph`. Anything outside this narrow, source-neutral
+/// shape remains fail-closed rather than being approximated.
 #[allow(clippy::too_many_arguments)]
 fn parse_inline_table(
     stream: &StreamProbe,
@@ -1731,9 +1733,12 @@ fn parse_inline_table(
             ));
         }
         let paragraph_count = read_u16(list_bytes, 0).expect("exact length checked") as usize;
+        let width_ref = read_u16(list_bytes, 6).expect("exact length checked");
+        let owned_width_ref = matches!(width_ref, 0x0000 | 0x0100 | 0x0500)
+            || (width_ref == 0x0501 && (rows, cols) == (1, 1));
         if !(1..=5).contains(&paragraph_count)
             || read_u32(list_bytes, 2) != Some(0x0020_0000)
-            || !matches!(read_u16(list_bytes, 6), Some(0x0000 | 0x0100 | 0x0500))
+            || !owned_width_ref
         {
             return Err(malformed(
                 &list_record,
@@ -1835,8 +1840,9 @@ fn parse_inline_table(
             has_border: cell_fill.has_border,
             borders: cell_fill.borders,
             diagonal: cell_fill.diagonal,
-            // All observed width-reference words have the apply-inner-margin low bit off.
-            padding: None,
+            // The exact observed low bit is HWP's apply-inner-margin flag. Other cell extension
+            // bits (protect/header/form) were rejected with the width-reference word above.
+            padding: (width_ref == 0x0501).then_some(cell_padding.map(|value| value as HwpUnit)),
             width: Some(cell_width as HwpUnit),
             ..Cell::default()
         });

--- a/crates/hwp-hwp5/tests/layout_semantic.rs
+++ b/crates/hwp-hwp5/tests/layout_semantic.rs
@@ -77,6 +77,13 @@ enum Mutation {
     LargeTableBadRowHeight,
     LargeTableBadWidthRef,
     LargeTableBadCellOrder,
+    MultiTable,
+    MultiTableMissingMarker,
+    MultiTableExtraMarker,
+    MultiTableVisibleText,
+    MultiTableBadCellFlag,
+    MultiTableStrayChild,
+    MultiTableThirdControl,
 }
 
 #[test]
@@ -584,6 +591,73 @@ fn strict_ten_by_two_table_rejects_hostile_counts_spans_geometry_and_width_refs(
     }
 }
 
+#[test]
+fn owns_two_ordered_tables_in_one_text_empty_host_and_cell_own_padding() {
+    let doc = OwnHwp5Parser::new()
+        .parse(&fixture(Mutation::MultiTable))
+        .expect("bounded multi-table host parses");
+    let [Block::Paragraph(anchor), Block::Table(first), Block::Table(second), Block::Paragraph(_)] =
+        doc.sections[0].blocks.as_slice()
+    else {
+        panic!("host must lower to one anchor followed by both tables in source order")
+    };
+    assert!(anchor.is_table_anchor);
+    assert_eq!((first.rows, first.cols, first.cells.len()), (10, 2, 17));
+    assert_eq!((second.rows, second.cols, second.cells.len()), (1, 1, 1));
+    assert_eq!(second.cells[0].blocks.len(), 4);
+    assert_eq!(second.cells[0].padding, Some([283, 283, 141, 141]));
+    assert_eq!(second.cells[0].width, Some(20_000));
+}
+
+#[test]
+fn multi_table_host_rejects_marker_mismatch_visible_text_unknown_cell_bits_and_strays() {
+    for mutation in [
+        Mutation::MultiTableMissingMarker,
+        Mutation::MultiTableExtraMarker,
+    ] {
+        assert!(matches!(
+            OwnHwp5Parser::new().parse(&fixture(mutation)),
+            Err(Error::MalformedRecord {
+                tag: TAG_PARA_HEADER,
+                reason: "PARA_TEXT structural markers do not match CTRL_HEADER records",
+                ..
+            })
+        ));
+    }
+    assert!(matches!(
+        OwnHwp5Parser::new().parse(&fixture(Mutation::MultiTableVisibleText)),
+        Err(Error::MalformedRecord {
+            tag: TAG_PARA_HEADER,
+            reason: "owned inline table host also contains visible text",
+            ..
+        })
+    ));
+    assert!(matches!(
+        OwnHwp5Parser::new().parse(&fixture(Mutation::MultiTableBadCellFlag)),
+        Err(Error::MalformedRecord {
+            tag: TAG_LIST_HEADER,
+            reason: "cell LIST_HEADER count, direction, alignment, or width reference is not owned",
+            ..
+        })
+    ));
+    assert!(matches!(
+        OwnHwp5Parser::new().parse(&fixture(Mutation::MultiTableStrayChild)),
+        Err(Error::MalformedRecord {
+            tag: TAG_PAGE_DEF,
+            reason: "owned TABLE has more active cells than its bounded topology",
+            ..
+        })
+    ));
+    assert!(matches!(
+        OwnHwp5Parser::new().parse(&fixture(Mutation::MultiTableThirdControl)),
+        Err(Error::UnsupportedBodyRecord {
+            tag: TAG_CTRL_HEADER,
+            reason: "paragraphs with more than two table controls are not owned",
+            ..
+        })
+    ));
+}
+
 fn fixture(mutation: Mutation) -> Vec<u8> {
     let mut header = vec![0; 256];
     header[..HWP_SIGNATURE.len()].copy_from_slice(HWP_SIGNATURE);
@@ -606,6 +680,23 @@ fn fixture(mutation: Mutation) -> Vec<u8> {
             | Mutation::LargeTableBadRowHeight
             | Mutation::LargeTableBadWidthRef
             | Mutation::LargeTableBadCellOrder
+            | Mutation::MultiTable
+            | Mutation::MultiTableMissingMarker
+            | Mutation::MultiTableExtraMarker
+            | Mutation::MultiTableVisibleText
+            | Mutation::MultiTableBadCellFlag
+            | Mutation::MultiTableStrayChild
+            | Mutation::MultiTableThirdControl
+    );
+    let has_multi_table = matches!(
+        mutation,
+        Mutation::MultiTable
+            | Mutation::MultiTableMissingMarker
+            | Mutation::MultiTableExtraMarker
+            | Mutation::MultiTableVisibleText
+            | Mutation::MultiTableBadCellFlag
+            | Mutation::MultiTableStrayChild
+            | Mutation::MultiTableThirdControl
     );
     let has_large_table = matches!(
         mutation,
@@ -618,6 +709,13 @@ fn fixture(mutation: Mutation) -> Vec<u8> {
             | Mutation::LargeTableBadRowHeight
             | Mutation::LargeTableBadWidthRef
             | Mutation::LargeTableBadCellOrder
+            | Mutation::MultiTable
+            | Mutation::MultiTableMissingMarker
+            | Mutation::MultiTableExtraMarker
+            | Mutation::MultiTableVisibleText
+            | Mutation::MultiTableBadCellFlag
+            | Mutation::MultiTableStrayChild
+            | Mutation::MultiTableThirdControl
     );
     let mut doc_info = Vec::new();
     let mut properties = vec![0; 26];
@@ -730,6 +828,18 @@ fn fixture(mutation: Mutation) -> Vec<u8> {
     }
     if has_table {
         section_text.extend(extended_control(0x000b, CTRL_TABLE));
+        if has_multi_table && !matches!(mutation, Mutation::MultiTableMissingMarker) {
+            section_text.extend(extended_control(0x000b, CTRL_TABLE));
+        }
+        if matches!(mutation, Mutation::MultiTableExtraMarker) {
+            section_text.extend(extended_control(0x000b, CTRL_TABLE));
+        }
+        if matches!(mutation, Mutation::MultiTableThirdControl) {
+            section_text.extend(extended_control(0x000b, CTRL_TABLE));
+        }
+    }
+    if matches!(mutation, Mutation::MultiTableVisibleText) {
+        section_text.push('X' as u16);
     }
     if matches!(mutation, Mutation::BadControlFrame) {
         section_text[7] = 0;
@@ -1078,6 +1188,80 @@ fn fixture(mutation: Mutation) -> Vec<u8> {
                         &[(0, 0)]
                     }),
                 );
+            }
+        }
+    }
+
+    if has_multi_table {
+        let additional_tables = if matches!(mutation, Mutation::MultiTableThirdControl) {
+            2
+        } else {
+            1
+        };
+        for _ in 0..additional_tables {
+            let mut common = Vec::with_capacity(46);
+            common.extend_from_slice(&CTRL_TABLE.to_le_bytes());
+            common.extend_from_slice(&0x082a_2311u32.to_le_bytes());
+            common.extend_from_slice(&0u32.to_le_bytes());
+            common.extend_from_slice(&0u32.to_le_bytes());
+            common.extend_from_slice(&20_000u32.to_le_bytes());
+            common.extend_from_slice(&2_000u32.to_le_bytes());
+            common.extend_from_slice(&0i32.to_le_bytes());
+            for margin in [100i16, 100, 50, 50] {
+                common.extend_from_slice(&margin.to_le_bytes());
+            }
+            common.extend_from_slice(&1u32.to_le_bytes());
+            common.extend_from_slice(&0i32.to_le_bytes());
+            common.extend_from_slice(&0u16.to_le_bytes());
+            push_record(&mut body, TAG_CTRL_HEADER, 1, &common);
+
+            let mut table = Vec::with_capacity(24);
+            table.extend_from_slice(&0x0400_0006u32.to_le_bytes());
+            table.extend_from_slice(&1u16.to_le_bytes());
+            table.extend_from_slice(&1u16.to_le_bytes());
+            table.extend_from_slice(&0u16.to_le_bytes());
+            for padding in [510i16, 510, 141, 141] {
+                table.extend_from_slice(&padding.to_le_bytes());
+            }
+            table.extend_from_slice(&1u16.to_le_bytes());
+            table.extend_from_slice(&1u16.to_le_bytes());
+            table.extend_from_slice(&0u16.to_le_bytes());
+            push_record(&mut body, TAG_TABLE, 2, &table);
+
+            let mut cell = Vec::with_capacity(47);
+            cell.extend_from_slice(&4u16.to_le_bytes());
+            cell.extend_from_slice(&0x0020_0000u32.to_le_bytes());
+            cell.extend_from_slice(
+                &if matches!(mutation, Mutation::MultiTableBadCellFlag) {
+                    0x0503u16
+                } else {
+                    0x0501
+                }
+                .to_le_bytes(),
+            );
+            for value in [0u16, 0, 1, 1] {
+                cell.extend_from_slice(&value.to_le_bytes());
+            }
+            cell.extend_from_slice(&20_000u32.to_le_bytes());
+            cell.extend_from_slice(&2_000u32.to_le_bytes());
+            for padding in [283i16, 283, 141, 141] {
+                cell.extend_from_slice(&padding.to_le_bytes());
+            }
+            cell.extend_from_slice(&1u16.to_le_bytes());
+            cell.extend([0; 13]);
+            push_record(&mut body, TAG_LIST_HEADER, 2, &cell);
+            for _ in 0..4 {
+                push_para_header_at_level(&mut body, 2, 2, 0, 1, 0, 0);
+                push_record(
+                    &mut body,
+                    TAG_PARA_TEXT,
+                    3,
+                    &utf16_bytes(&['A' as u16, 0x000d]),
+                );
+                push_record(&mut body, TAG_PARA_CHAR_SHAPE, 3, &shape_refs(&[(0, 0)]));
+            }
+            if matches!(mutation, Mutation::MultiTableStrayChild) {
+                push_record(&mut body, TAG_PAGE_DEF, 2, &[0; 4]);
             }
         }
     }

--- a/crates/hwp-hwp5/tests/public_probe.rs
+++ b/crates/hwp-hwp5/tests/public_probe.rs
@@ -28,17 +28,27 @@ fn public_hwp5_has_bounded_content_free_record_provenance() {
 }
 
 #[test]
-fn explicit_own_parser_owns_the_ten_by_two_table_then_stops_content_free() {
+fn explicit_own_parser_owns_bounded_multi_table_then_stops_content_free() {
+    let probed = probe(&benchmark()).unwrap();
+    let next = probed
+        .streams
+        .iter()
+        .flat_map(|stream| &stream.records)
+        .find(|record| record.head == 7_561)
+        .unwrap();
+    assert_eq!(
+        (next.tag, next.level, next.head, next.data, next.end, next.size,),
+        (0x4d, 2, 7_561, 7_565, 7_605, 40)
+    );
     let error = OwnHwp5Parser::new().parse(&benchmark()).unwrap_err();
     eprintln!("{error:?}");
     assert!(matches!(
         error,
-        Error::UnsupportedBodyRecord {
-            tag: 0x47,
-            section: 0,
-            start: 5926,
-            end: 5976,
-            reason: "paragraphs with multiple table controls are not yet owned",
+        Error::MalformedRecord {
+            tag: 0x4d,
+            section: Some(0),
+            offset: 7561,
+            reason: "TABLE attributes or framing are not owned",
             ..
         }
     ));

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -82,7 +82,9 @@
   build cache 누적으로 ENOSPC였고, 병합 완료 #164/#166/#168/#170/#171의 재생성 가능한 Cargo
   cache만 `cargo clean`해 약 69GiB를 회수한 뒤 같은 quick이 전부 green. 임시 dependency link 제거,
   production route·rhwp·HWPX parser/serializer·generated asset diff 0.
-  **다음:** final security/diff→commit/push/PR #174→필수 CI/자율 병합→TABLE 7561 child 분류.
+  검증 완료 commit `aee1f70`을 push하고 PR #175(`Closes #174`, `Refs #94 #170 #171 #172 #173`)을
+  게시했다. **다음:** exact-head issue-link/build-test/licenses·mergeability·review/comment 추적→전부
+  green이면 자율 병합·branch 정리→TABLE 7561 child 분류.
 
 - 갱신: 2026-08-23 · Codex(sol) — **#161 PR #163 게시**.
   검증 완료 commit `c751833`을 push하고 PR #163(`Closes #161`, `Refs #94 #160`)을 만들었다.

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,7 +3,7 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
-- 갱신: 2026-08-24 · Codex(sol) — **PR #172 병합 · #170 strict 10×2 TABLE 재개**.
+- 갱신: 2026-08-24 · Codex(sol) — **PR #173 병합 · #174 multi-table 경계 착수**.
   자체 HWP5 파서가 exact `tbl ` marker/common-object/TABLE/LIST_HEADER/cell paragraph를 검증해
   treat-as-character 1×1 표를 source-neutral `Table`/`Cell` IR로 내린다. 셀/개체 geometry,
   inherited padding, CENTER alignment, border-fill refs를 range/shape 검증하고 visible host text,
@@ -53,9 +53,36 @@
   로컬 서버에서 분리 재실행해 Chromium **85 pass/3 intentional skip/0 fail**이며, 이후 강화한
   distinct terminal char-shape/extra-cell bound도 focused HWP5·clippy 재검증 green. 임시 dependency
   link 제거, production route·rhwp·HWPX parser/serializer·generated asset diff 0.
-  검증 완료 commit `25010cb`을 push하고 PR #173(`Closes #170`, `Refs #94 #168 #171 #172`)을
-  게시했다. **다음:** exact-head issue-link/build-test/licenses·mergeability·review/comment 추적→전부
-  green이면 자율 병합·branch 정리→다음 multi-table boundary child 분류.
+  검증 완료 PR #173은 exact head `864d985`에서 issue-link **5s**·build-test **9m01s**·licenses
+  **2m45s** green, CLEAN/MERGEABLE, review/general/inline 댓글 0을 확인하고 main `cfb42b3d`로
+  squash 병합했다. #170 close·원격 branch 정리 후 #94에 근거를 동기화했고, 중복 검색 0건인
+  다음 content-free 경계를 #174로 등록했다. exact latest main의
+  `codex/issue-174-hwp5-multi-table`에서 marker/header 1:1 순서, disjoint child ownership,
+  anchor→ordered Table lowering을 먼저 분류하며 표현 불가능한 inline semantics면 fail-closed와 최소
+  prerequisite를 유지한다. 커뮤니티 감사상 새 외부 PR·스팸·보안 신호는 없고 기존 외부 #50은
+  Proposal·provider 보안 child에 이미 연결돼 있다. **다음:** #174 content-free 분류→합성 hostile
+  fixture→focused/quick/full; production route·HWPX·rhwp 불변. 1차 분류 결과 host는 visible char 0,
+  table marker 2개(offset 0/8)와 동일 순서의 disjoint CTRL_HEADER 2개를 가진다. 두 번째 표는 exact
+  common-object/no-split 1×1/1 active cell/4 paragraphs이며 object·cell geometry가 일치한다. 기존
+  strict 1×1과의 유일한 의미 차이는 LIST_HEADER `0x0501`: pinned rhwp와 공식 bitfield상 low bit는
+  cell-own inner margin이고 shared `Cell.padding`으로 정확히 표현 가능하다. rhwp lift도 동일 control
+  순서대로 anchor 뒤 `Block::Table`을 1:1 emit한다. 따라서 #174는 exact own-margin bit + ordered
+  multi-table lowering만 소유하고 보호/header/form 등 다른 low bit와 mixed/nested/floating은 거부한다.
+  구현은 host당 exact 최대 2개, marker/header count·ID·순서와 disjoint record-level child 귀속을 기존
+  strict framing으로 검증한 뒤 ordered `Table`을 emit한다. 1×1 `0x0501`만 stored padding을
+  `Cell.padding`으로 내리고 10×2 또는 protect/header/form low bit는 거부한다. 합성 positive는
+  10×2→1×1 순서/단일 anchor/4 paragraphs/own padding을 잠갔고 missing·extra marker, visible text,
+  unknown cell bit, stray child, third control을 정확한 정적 오류로 거부한다. 공개 경계는 multi-table
+  CTRL `5926..5976`를 넘어 다음 TABLE `0x4d/7561..7605`의 unowned attr/framing으로 전진했다.
+  HWP5 **55 tests**, clippy `-D warnings`, wasm32 green; route/rhwp/HWPX/generated diff 0.
+  quick/full의 Rust workspace, typeset **100+4**, PDF visual **51**, canonical **8/18/24·98.9%+**,
+  public corpus **84**, oracle **82**, HWPX, wasm(7,810,657B), licenses, JS build·crosscheck·i18n,
+  Vitest **1,018**이 green이다. full의 샌드박스 포트 EPERM만 전용 `PW_PORT=31974`에서 분리해
+  Chromium **85 pass/3 intentional skip/0 fail**을 확인했다. 첫 quick은 코드가 아닌 완료 worktree
+  build cache 누적으로 ENOSPC였고, 병합 완료 #164/#166/#168/#170/#171의 재생성 가능한 Cargo
+  cache만 `cargo clean`해 약 69GiB를 회수한 뒤 같은 quick이 전부 green. 임시 dependency link 제거,
+  production route·rhwp·HWPX parser/serializer·generated asset diff 0.
+  **다음:** final security/diff→commit/push/PR #174→필수 CI/자율 병합→TABLE 7561 child 분류.
 
 - 갱신: 2026-08-23 · Codex(sol) — **#161 PR #163 게시**.
   검증 완료 commit `c751833`을 push하고 PR #163(`Closes #161`, `Refs #94 #160`)을 만들었다.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,26 @@
 
 ---
 
+## 2026-08-24 (Codex sol) · #174 full green / PR ready
+- max-2 ordered tables + own padding, HWP5 55; next boundary TABLE 7561..7605.
+- quick/full·Vitest 1,018·Chromium 85/3 green; route/rhwp/HWPX/generated diff 0.
+- merged-worktree build cache만 정리(약 69GiB); 다음 commit/push/PR→CI/merge.
+
+## 2026-08-24 (Codex sol) · #174 focused green
+- exact max-2 anchor→ordered tables + 1×1 cell-own padding; hostile 6축 fail-closed.
+- HWP5 55/clippy/wasm32 green; public boundary 5926..5976→TABLE 7561..7605.
+- route/rhwp/HWPX/generated diff 0. 다음 quick→full→PR/CI/merge.
+
+## 2026-08-24 (Codex sol) · #174 content-free classified
+- host visible 0, table markers 0/8 ↔ disjoint CTRL 2; second = strict 1×1/4 paras.
+- only new semantic is width-ref `0x0501` low-bit cell-own padding; shared Cell.padding represents it.
+- pinned rhwp lift confirms anchor→ordered Table 1:1. 다음 strict synthetic/hostile→public boundary.
+
+## 2026-08-24 (Codex sol) · PR #173 merged → #174 started
+- #173 required CI/CLEAN/MERGEABLE·댓글 0 후 main `cfb42b3d` 병합; #170 close·branch 정리.
+- #94 동기화, 중복 없는 multi-table boundary #174 생성, exact-main worktree 시작.
+- 다음 content-free marker/header/child-order 분류→strict synthetic tests; route/rhwp 불변.
+
 ## 2026-08-24 (Codex sol) · #170 PR #173 게시
 - strict 10×2 TABLE commit `25010cb`을 push하고 PR #173(`Closes #170`) 생성.
 - route/rhwp/HWPX/generated 불변과 quick/full/Vitest 1,007/Chromium 85·3을 명시.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,11 @@
 
 ---
 
+## 2026-08-24 (Codex sol) · #174 PR #175 게시
+- bounded multi-table commit `aee1f70` push, PR #175(`Closes #174`) 생성.
+- route/rhwp/HWPX/generated 불변과 quick/full/Vitest 1,018/Chromium 85·3 명시.
+- 다음 required CI·댓글 추적→green 자율 병합→TABLE 7561 child.
+
 ## 2026-08-24 (Codex sol) · #174 full green / PR ready
 - max-2 ordered tables + own padding, HWP5 55; next boundary TABLE 7561..7605.
 - quick/full·Vitest 1,018·Chromium 85/3 green; route/rhwp/HWPX/generated diff 0.


### PR DESCRIPTION
Closes #174

Refs #94 #170 #171 #172 #173

## What changed
- Own the exact bounded HWP5 host shape containing at most two ordered table controls in one text-empty paragraph.
- Preserve the existing 1:1 PARA_TEXT marker / CTRL_HEADER contract and disjoint record-level child ownership, then lower one anchor followed by Table blocks in source order.
- Interpret only the observed `0x0501` LIST_HEADER low bit on a strict 1×1 table as cell-own inner padding and lower it to shared `Cell.padding`.
- Continue to reject mixed visible text, missing or extra markers, a third table control, stray children, and protect/header/form cell bits.
- Advance the content-free public boundary from CTRL_HEADER `5926..5976` to TABLE `7561..7605`.

## Safety boundary
- No production HWP5 route cutover and no rhwp fallback change.
- No change to `external/rhwp`, HWPX parser/serializer, or generated wasm/public assets.
- No source content, local path, hash, raw payload, or private fixture is published.

## Verification
- `scripts/verify-local.sh`
- `scripts/verify-local.sh --full`
- HWP5: 55 tests; typeset: 100+4; PDF visual: 51
- canonical: 8/18/24 and 98.9%+; public corpus: 84; oracle: 82
- Vitest: 1,018 green
- Chromium: 85 passed, 3 intentional skipped, 0 failed
- touched clippy `-D warnings` and wasm32 checks green