### PR TITLE
feat(hwp5): own bounded nested table topology

### DIFF
--- a/crates/hwp-hwp5/src/semantic.rs
+++ b/crates/hwp-hwp5/src/semantic.rs
@@ -990,6 +990,7 @@ fn parse_section(
             styles,
             section,
             page.as_ref(),
+            0,
         )?;
         if let Some(parsed_page) = parsed.page {
             if ordinal != 0 || page.replace(parsed_page).is_some() {
@@ -1075,6 +1076,7 @@ struct ParsedParagraph {
     tables: Vec<Table>,
 }
 
+#[allow(clippy::too_many_arguments)]
 fn parse_paragraph(
     stream: &StreamProbe,
     records: &[Record],
@@ -1083,6 +1085,7 @@ fn parse_paragraph(
     styles: &[StyleDef],
     section: usize,
     _current_page: Option<&PageSetup>,
+    table_depth: usize,
 ) -> Result<ParsedParagraph> {
     let header = records[0];
     let base_level = header.level;
@@ -1320,7 +1323,14 @@ fn parse_paragraph(
                     ));
                 }
                 tables.push(parse_inline_table(
-                    stream, control, children, doc, para_usage, styles, section,
+                    stream,
+                    control,
+                    children,
+                    doc,
+                    para_usage,
+                    styles,
+                    section,
+                    table_depth,
                 )?);
             }
             _ => unreachable!("structural control id filtered above"),
@@ -1548,13 +1558,12 @@ fn parse_new_number_control(
         .ok_or_else(|| malformed(record, Some(section), "page-number restart must be nonzero"))
 }
 
-/// Own the bounded binary-table slices seen at the public first-party boundary: strict inline 1×1
-/// and 10×2 tables. They use the same exact common-object and no-split TABLE attributes. The larger
-/// slice has 17 active cells (three horizontal merges), one to five paragraphs per cell, and no
-/// zones/captions/nested layout. A 1×1 cell may use the exact observed cell-own inner-margin bit;
+/// Own the bounded binary-table slices seen at the public first-party boundary: strict inline 1×1,
+/// 10×2, and 9×8 tables. The 9×8 slice has 34 active cells, an exact horizontal-merge topology, and
+/// one nested 1×1 table at depth one. A 1×1 cell may use the exact observed cell-own inner-margin bit;
 /// protection/header/form bits remain unsupported. Multiple controls in one text-empty host are
-/// emitted in marker/header order by `parse_paragraph`. Anything outside this narrow, source-neutral
-/// shape remains fail-closed rather than being approximated.
+/// emitted in marker/header order by `parse_paragraph`. Anything outside these exact source-neutral
+/// shapes, including deeper nesting, remains fail-closed rather than being approximated.
 #[allow(clippy::too_many_arguments)]
 fn parse_inline_table(
     stream: &StreamProbe,
@@ -1564,7 +1573,15 @@ fn parse_inline_table(
     para_usage: &[ParaUsage],
     styles: &[StyleDef],
     section: usize,
+    table_depth: usize,
 ) -> Result<Table> {
+    if table_depth >= 2 {
+        return Err(unsupported_reason(
+            *control,
+            section,
+            "table nesting deeper than one level is not owned",
+        ));
+    }
     let common = data(stream, control);
     if common.len() != 46 || read_u32(common, 0) != Some(CTRL_TABLE) {
         return Err(malformed(
@@ -1626,7 +1643,7 @@ fn parse_inline_table(
 
     let table_record = children[0];
     let table_bytes = data(stream, &table_record);
-    if table_bytes.len() < 24 || read_u32(table_bytes, 0) != Some(0x0400_0006) {
+    if table_bytes.len() < 24 {
         return Err(malformed(
             &table_record,
             Some(section),
@@ -1635,17 +1652,63 @@ fn parse_inline_table(
     }
     let rows = read_u16(table_bytes, 4).expect("minimum length checked") as usize;
     let cols = read_u16(table_bytes, 6).expect("minimum length checked") as usize;
-    let expected_cells = match (rows, cols) {
-        (1, 1) => 1,
-        (10, 2) => 17,
+    let table_attr = read_u32(table_bytes, 0).expect("minimum length checked");
+    let expected_positions = match (table_attr, rows, cols) {
+        (0x0400_0006, 1, 1) => vec![(0, 0, 1)],
+        (0x0400_0006, 10, 2) => (0..10)
+            .flat_map(|row| {
+                if matches!(row, 0 | 1 | 5) {
+                    vec![(row, 0, 2)]
+                } else {
+                    vec![(row, 0, 1), (row, 1, 1)]
+                }
+            })
+            .collect(),
+        (0x0600_000c, 9, 8) => vec![
+            (0, 0, 3),
+            (0, 3, 5),
+            (1, 0, 3),
+            (1, 3, 5),
+            (2, 0, 3),
+            (2, 3, 2),
+            (2, 5, 1),
+            (2, 6, 2),
+            (3, 0, 8),
+            (4, 0, 1),
+            (4, 1, 1),
+            (4, 2, 2),
+            (4, 4, 3),
+            (4, 7, 1),
+            (5, 0, 1),
+            (5, 1, 1),
+            (5, 2, 2),
+            (5, 4, 3),
+            (5, 7, 1),
+            (6, 0, 1),
+            (6, 1, 1),
+            (6, 2, 2),
+            (6, 4, 3),
+            (6, 7, 1),
+            (7, 0, 1),
+            (7, 1, 1),
+            (7, 2, 2),
+            (7, 4, 3),
+            (7, 7, 1),
+            (8, 0, 1),
+            (8, 1, 1),
+            (8, 2, 2),
+            (8, 4, 3),
+            (8, 7, 1),
+        ],
         _ => {
             return Err(malformed(
                 &table_record,
                 Some(section),
-                "TABLE row/column topology is not in the owned 1x1 or 10x2 subset",
+                "TABLE attributes or row/column topology are not owned",
             ))
         }
     };
+    let expected_cells = expected_positions.len();
     if read_u16(table_bytes, 8) != Some(0) {
         return Err(malformed(
             &table_record,
@@ -1684,14 +1747,22 @@ fn parse_inline_table(
             "TABLE padding must be nonnegative",
         ));
     }
-    let row_sizes = (0..rows)
+    let row_cell_counts = (0..rows)
         .map(|row| read_u16(table_bytes, 18 + row * 2).expect("exact length checked") as HwpUnit)
         .collect::<Vec<_>>();
-    if row_sizes.iter().any(|height| *height <= 0) {
+    let expected_row_cell_counts = (0..rows)
+        .map(|row| {
+            expected_positions
+                .iter()
+                .filter(|(cell_row, _, _)| *cell_row == row)
+                .count() as HwpUnit
+        })
+        .collect::<Vec<_>>();
+    if row_cell_counts != expected_row_cell_counts {
         return Err(malformed(
             &table_record,
             Some(section),
-            "TABLE row-size slots must be positive",
+            "TABLE row cell counts differ from its owned active-cell topology",
         ));
     }
     let table_border_at = 18 + rows * 2;
@@ -1707,6 +1778,7 @@ fn parse_inline_table(
 
     let mut cells = Vec::with_capacity(expected_cells);
     let mut cell_heights = Vec::with_capacity(expected_cells);
+    let mut nested_table_count = 0usize;
     let mut cursor = 1usize;
     while cursor < children.len() {
         if cells.len() == expected_cells {
@@ -1767,6 +1839,17 @@ fn parse_inline_table(
                 "cell coordinates, horizontal span, or dimensions are outside the owned TABLE grid",
             ));
         }
+        let list_extra = &list_bytes[34..];
+        let zero_legacy_extra = list_extra.iter().all(|byte| *byte == 0);
+        let mirrored_width_extra = read_u32(list_extra, 0) == Some(cell_width)
+            && list_extra[4..].iter().all(|byte| *byte == 0);
+        if !(zero_legacy_extra || mirrored_width_extra) {
+            return Err(malformed(
+                &list_record,
+                Some(section),
+                "cell LIST_HEADER extension is not zero or an exact width mirror",
+            ));
+        }
         let cell_padding = [24usize, 26, 28, 30]
             .map(|at| i16::from_le_bytes(list_bytes[at..at + 2].try_into().unwrap()));
         if cell_padding.iter().any(|value| *value < 0) {
@@ -1776,15 +1859,15 @@ fn parse_inline_table(
                 "cell stored padding must be nonnegative",
             ));
         }
-        // The 13-byte extension cannot yield a typed field in the pinned parser. Keep it inert and
-        // out of shared IR; the exact 47-byte framing prevents a longer field-bearing tail.
-        debug_assert_eq!(list_bytes[34..].len(), 13);
+        // The bounded 13-byte extension is either the legacy all-zero form or an exact cell-width
+        // mirror followed by reserved zeros. Longer field-bearing tails remain unsupported.
+        debug_assert_eq!(list_extra.len(), 13);
         let cell_border_id = read_u16(list_bytes, 32).expect("exact length checked");
         let cell_fill = table_border(doc, cell_border_id, &list_record, section, "table cell")?;
 
         cursor += 1;
         let mut blocks = Vec::with_capacity(paragraph_count);
-        for _ in 0..paragraph_count {
+        for paragraph_index in 0..paragraph_count {
             let Some(header) = children.get(cursor).copied() else {
                 return Err(malformed(
                     &list_record,
@@ -1804,7 +1887,7 @@ fn parse_inline_table(
             while cursor < children.len() && children[cursor].level > child_level {
                 cursor += 1;
             }
-            let parsed = parse_paragraph(
+            let mut parsed = parse_paragraph(
                 stream,
                 &children[start..cursor],
                 doc,
@@ -1812,10 +1895,10 @@ fn parse_inline_table(
                 styles,
                 section,
                 None,
+                table_depth + 1,
             )?;
             if parsed.page.is_some()
                 || parsed.page_number.is_some()
-                || !parsed.tables.is_empty()
                 || parsed.paragraph.page_break_before
                 || parsed.paragraph.column_break_before
                 || parsed.paragraph.column_layout_before.is_some()
@@ -1826,7 +1909,28 @@ fn parse_inline_table(
                     "owned table cell paragraph contains nested layout controls",
                 ));
             }
+            if !parsed.tables.is_empty() {
+                let owned_nested_position = (table_attr, rows, cols) == (0x0600_000c, 9, 8)
+                    && (row, col, col_span) == (1, 3, 5)
+                    && paragraph_index == 1
+                    && parsed.tables.len() == 1;
+                let has_visible_text = parsed.paragraph.runs.iter().any(|run| {
+                    run.content
+                        .iter()
+                        .any(|inline| matches!(inline, Inline::Text(text) if !text.is_empty()))
+                });
+                if !owned_nested_position || has_visible_text {
+                    return Err(malformed(
+                        &header,
+                        Some(section),
+                        "nested table is not at the exact owned cell paragraph position",
+                    ));
+                }
+                nested_table_count += parsed.tables.len();
+                parsed.paragraph.is_table_anchor = true;
+            }
             blocks.push(Block::Paragraph(parsed.paragraph));
+            blocks.extend(parsed.tables.into_iter().map(Block::Table));
         }
         cell_heights.push(cell_height as HwpUnit);
         cells.push(Cell {
@@ -1854,16 +1958,15 @@ fn parse_inline_table(
             "owned TABLE active-cell count differs from its exact topology",
         ));
     }
+    let expected_nested_tables = usize::from((table_attr, rows, cols) == (0x0600_000c, 9, 8));
+    if nested_table_count != expected_nested_tables {
+        return Err(malformed(
+            &table_record,
+            Some(section),
+            "owned TABLE nested-table count differs from its exact topology",
+        ));
+    }
 
-    let expected_positions = (0..rows)
-        .flat_map(|row| {
-            if cols == 2 && matches!(row, 0 | 1 | 5) {
-                vec![(row, 0, 2)]
-            } else {
-                (0..cols).map(|col| (row, col, 1)).collect()
-            }
-        })
-        .collect::<Vec<_>>();
     if cells
         .iter()
         .zip(&expected_positions)
@@ -1876,23 +1979,8 @@ fn parse_inline_table(
         ));
     }
 
-    let mut col_widths = vec![None::<HwpUnit>; cols];
     let mut derived_rows = vec![None::<HwpUnit>; rows];
     for (cell, cell_height) in cells.iter().zip(cell_heights) {
-        let cell_width = cell.width.expect("owned cells always carry width");
-        if cell.col_span == 1 {
-            match col_widths[cell.col] {
-                Some(existing) if existing != cell_width => {
-                    return Err(malformed(
-                        &table_record,
-                        Some(section),
-                        "single-column cell widths disagree across TABLE rows",
-                    ))
-                }
-                None => col_widths[cell.col] = Some(cell_width),
-                _ => {}
-            }
-        }
         match derived_rows[cell.row] {
             Some(existing) if existing != cell_height => {
                 return Err(malformed(
@@ -1905,34 +1993,73 @@ fn parse_inline_table(
             _ => {}
         }
     }
-    let col_widths = col_widths
+
+    // Recover absolute column boundaries from all cell span equations. This handles the 9×8 slice,
+    // where several columns never appear as a standalone cell but the connected span graph still
+    // determines every boundary uniquely. Endpoints are pinned to 0 and the common-object width.
+    let mut boundaries = vec![None::<i64>; cols + 1];
+    boundaries[0] = Some(0);
+    boundaries[cols] = Some(i64::from(width));
+    for _ in 0..=cells.len() + cols {
+        let mut progressed = false;
+        for cell in &cells {
+            let start = cell.col;
+            let end = cell.col + cell.col_span;
+            let cell_width = i64::from(cell.width.expect("owned cells always carry width"));
+            match (boundaries[start], boundaries[end]) {
+                (Some(left), Some(right)) if right - left != cell_width => {
+                    return Err(malformed(
+                        &table_record,
+                        Some(section),
+                        "TABLE span equations disagree with common-object geometry",
+                    ));
+                }
+                (Some(left), None) => {
+                    boundaries[end] = Some(left + cell_width);
+                    progressed = true;
+                }
+                (None, Some(right)) => {
+                    boundaries[start] = Some(right - cell_width);
+                    progressed = true;
+                }
+                _ => {}
+            }
+        }
+        if !progressed {
+            break;
+        }
+    }
+    let boundaries = boundaries
         .into_iter()
         .collect::<Option<Vec<_>>>()
         .ok_or_else(|| {
             malformed(
                 &table_record,
                 Some(section),
-                "TABLE has a column whose width cannot be derived from an active cell",
+                "TABLE column boundaries are not uniquely derivable from active cells",
             )
         })?;
-    if col_widths
-        .iter()
-        .try_fold(0i64, |sum, value| sum.checked_add(i64::from(*value)))
-        != Some(i64::from(width))
-        || cells.iter().any(|cell| {
-            col_widths[cell.col..cell.col + cell.col_span]
-                .iter()
-                .map(|value| i64::from(*value))
-                .sum::<i64>()
-                != i64::from(cell.width.expect("owned cells always carry width"))
-        })
+    if boundaries.first() != Some(&0)
+        || boundaries.last() != Some(&i64::from(width))
+        || boundaries.windows(2).any(|pair| pair[0] >= pair[1])
     {
         return Err(malformed(
             &table_record,
             Some(section),
-            "TABLE column widths or merged-cell widths disagree with common-object geometry",
+            "TABLE column boundaries are nonpositive or outside common-object geometry",
         ));
     }
+    let col_widths = boundaries
+        .windows(2)
+        .map(|pair| HwpUnit::try_from(pair[1] - pair[0]))
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .map_err(|_| {
+            malformed(
+                &table_record,
+                Some(section),
+                "TABLE column width exceeds the shared geometry range",
+            )
+        })?;
     let derived_rows = derived_rows
         .into_iter()
         .collect::<Option<Vec<_>>>()
@@ -1962,6 +2089,10 @@ fn parse_inline_table(
         keep_together: true,
         col_widths,
         row_heights: derived_rows,
+        // The exact 9×8 attribute carries HWP's no-adjust bit. Its stored row heights are therefore
+        // exact clipping geometry, not merely content-size floors. The other owned HWP5 subsets keep
+        // their historical floor behavior.
+        fixed_row_heights: table_attr == 0x0600_000c,
         outer_margin_left: margins[0] as HwpUnit,
         outer_margin_right: margins[1] as HwpUnit,
         outer_margin_top: margins[2] as HwpUnit,

--- a/crates/hwp-hwp5/tests/layout_semantic.rs
+++ b/crates/hwp-hwp5/tests/layout_semantic.rs
@@ -86,6 +86,18 @@ enum Mutation {
     MultiTableThirdControl,
 }
 
+#[derive(Clone, Copy)]
+enum NestedTableMutation {
+    None,
+    BadAttribute,
+    BadRowCellCount,
+    BadSpan,
+    BadWidth,
+    BadListExtra,
+    MissingNestedTable,
+    TooDeep,
+}
+
 #[test]
 fn parses_page_setup_and_blank_source_line_metrics() {
     let doc = OwnHwp5Parser::new()
@@ -658,6 +670,64 @@ fn multi_table_host_rejects_marker_mismatch_visible_text_unknown_cell_bits_and_s
     ));
 }
 
+#[test]
+fn owns_exact_nine_by_eight_table_with_one_bounded_nested_table() {
+    let doc = OwnHwp5Parser::new()
+        .parse(&nested_table_fixture(NestedTableMutation::None))
+        .expect("strict 9x8 nested-table fixture parses");
+    let [Block::Paragraph(anchor), Block::Table(table)] = doc.sections[0].blocks.as_slice() else {
+        panic!("table host must lower to one anchor and one table")
+    };
+    assert!(anchor.is_table_anchor);
+    assert_eq!((table.rows, table.cols, table.cells.len()), (9, 8, 34));
+    assert!(table.keep_together);
+    assert!(table.fixed_row_heights, "no-adjust reaches shared IR");
+    assert_eq!(
+        table.col_widths,
+        vec![3_182, 6_810, 659, 8_082, 5_346, 10_534, 5_935, 7_435]
+    );
+    assert_eq!(table.row_heights.iter().sum::<i32>(), 24_072);
+    let host = table
+        .cells
+        .iter()
+        .find(|cell| (cell.row, cell.col, cell.col_span) == (1, 3, 5))
+        .expect("exact nested-table host cell");
+    let [Block::Paragraph(_), Block::Paragraph(nested_anchor), Block::Table(nested)] =
+        host.blocks.as_slice()
+    else {
+        panic!("nested host paragraph must be followed by its table")
+    };
+    assert!(nested_anchor.is_table_anchor);
+    assert_eq!((nested.rows, nested.cols, nested.cells.len()), (1, 1, 1));
+}
+
+#[test]
+fn strict_nested_table_slice_rejects_hostile_attributes_topology_and_extensions() {
+    for mutation in [
+        NestedTableMutation::BadAttribute,
+        NestedTableMutation::BadRowCellCount,
+        NestedTableMutation::BadSpan,
+        NestedTableMutation::BadWidth,
+        NestedTableMutation::BadListExtra,
+        NestedTableMutation::MissingNestedTable,
+    ] {
+        assert!(
+            OwnHwp5Parser::new()
+                .parse(&nested_table_fixture(mutation))
+                .is_err(),
+            "hostile nested-table mutation must fail closed"
+        );
+    }
+    assert!(matches!(
+        OwnHwp5Parser::new().parse(&nested_table_fixture(NestedTableMutation::TooDeep)),
+        Err(Error::UnsupportedBodyRecord {
+            tag: TAG_CTRL_HEADER,
+            reason: "table nesting deeper than one level is not owned",
+            ..
+        })
+    ));
+}
+
 fn fixture(mutation: Mutation) -> Vec<u8> {
     let mut header = vec![0; 256];
     header[..HWP_SIGNATURE.len()].copy_from_slice(HWP_SIGNATURE);
@@ -1043,8 +1113,9 @@ fn fixture(mutation: Mutation) -> Vec<u8> {
             table.extend_from_slice(&padding.to_le_bytes());
         }
         if has_large_table {
-            for height in [6_500u16; 9].into_iter().chain([6_909]) {
-                table.extend_from_slice(&height.to_le_bytes());
+            // HWP TABLE stores active-cell counts per row here, not row heights.
+            for count in [1u16, 1, 2, 2, 2, 1, 2, 2, 2, 2] {
+                table.extend_from_slice(&count.to_le_bytes());
             }
         } else {
             table.extend_from_slice(&1u16.to_le_bytes());
@@ -1328,6 +1399,281 @@ fn fixture(mutation: Mutation) -> Vec<u8> {
         stream.write_all(&body).unwrap();
     }
     compound.into_inner().into_inner()
+}
+
+fn nested_table_fixture(mutation: NestedTableMutation) -> Vec<u8> {
+    const COL_WIDTHS: [u32; 8] = [3_182, 6_810, 659, 8_082, 5_346, 10_534, 5_935, 7_435];
+    const ROW_HEIGHTS: [u32; 9] = [
+        2_512, 4_842, 3_744, 2_229, 2_229, 2_129, 2_129, 2_129, 2_129,
+    ];
+    let positions = vec![
+        (0usize, 0usize, 3usize),
+        (0, 3, 5),
+        (1, 0, 3),
+        (1, 3, 5),
+        (2, 0, 3),
+        (2, 3, 2),
+        (2, 5, 1),
+        (2, 6, 2),
+        (3, 0, 8),
+        (4, 0, 1),
+        (4, 1, 1),
+        (4, 2, 2),
+        (4, 4, 3),
+        (4, 7, 1),
+        (5, 0, 1),
+        (5, 1, 1),
+        (5, 2, 2),
+        (5, 4, 3),
+        (5, 7, 1),
+        (6, 0, 1),
+        (6, 1, 1),
+        (6, 2, 2),
+        (6, 4, 3),
+        (6, 7, 1),
+        (7, 0, 1),
+        (7, 1, 1),
+        (7, 2, 2),
+        (7, 4, 3),
+        (7, 7, 1),
+        (8, 0, 1),
+        (8, 1, 1),
+        (8, 2, 2),
+        (8, 4, 3),
+        (8, 7, 1),
+    ];
+
+    let mut header = vec![0; 256];
+    header[..HWP_SIGNATURE.len()].copy_from_slice(HWP_SIGNATURE);
+    header[32..36].copy_from_slice(&[0, 0, 0, 5]);
+
+    let mut doc_info = Vec::new();
+    let mut properties = vec![0; 26];
+    properties[..2].copy_from_slice(&1u16.to_le_bytes());
+    push_record(&mut doc_info, TAG_DOCUMENT_PROPERTIES, 0, &properties);
+    let mut mappings = Vec::new();
+    for count in [0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 1, 0] {
+        mappings.extend_from_slice(&(count as u32).to_le_bytes());
+    }
+    push_record(&mut doc_info, TAG_ID_MAPPINGS, 0, &mappings);
+    for _ in 0..7 {
+        push_record(&mut doc_info, TAG_FACE_NAME, 0, &face_name("Test Sans"));
+    }
+    push_record(&mut doc_info, TAG_BORDER_FILL, 0, &solid_border_fill());
+    push_record(&mut doc_info, TAG_CHAR_SHAPE, 0, &char_shape());
+    push_record(&mut doc_info, TAG_PARA_SHAPE, 0, &para_shape());
+
+    let mut body = Vec::new();
+    let mut host_text = extended_control(0x0002, CTRL_SECTION_DEF);
+    host_text.extend(extended_control(0x000b, CTRL_TABLE));
+    host_text.push(0x000d);
+    push_para_header_with_break(
+        &mut body,
+        host_text.len() as u32,
+        (1 << 2) | (1 << 0x000b),
+        1,
+        0,
+        0x01,
+    );
+    push_record(&mut body, TAG_PARA_TEXT, 1, &utf16_bytes(&host_text));
+    push_record(&mut body, TAG_PARA_CHAR_SHAPE, 1, &shape_refs(&[(0, 0)]));
+
+    let mut section_control = Vec::with_capacity(28);
+    section_control.extend_from_slice(&CTRL_SECTION_DEF.to_le_bytes());
+    section_control.extend([0; 24]);
+    push_record(&mut body, TAG_CTRL_HEADER, 1, &section_control);
+    push_record(&mut body, TAG_PAGE_DEF, 2, &page_def(Mutation::None));
+
+    push_table_common(&mut body, 1, 47_983, 24_072);
+    let mut table = Vec::with_capacity(40);
+    table.extend_from_slice(
+        &if matches!(mutation, NestedTableMutation::BadAttribute) {
+            0x0600_0008u32
+        } else {
+            0x0600_000c
+        }
+        .to_le_bytes(),
+    );
+    table.extend_from_slice(&9u16.to_le_bytes());
+    table.extend_from_slice(&8u16.to_le_bytes());
+    table.extend_from_slice(&0u16.to_le_bytes());
+    for padding in [140i16, 140, 140, 140] {
+        table.extend_from_slice(&padding.to_le_bytes());
+    }
+    let mut row_counts = [2u16, 2, 4, 1, 5, 5, 5, 5, 5];
+    if matches!(mutation, NestedTableMutation::BadRowCellCount) {
+        row_counts[0] = 3;
+    }
+    for count in row_counts {
+        table.extend_from_slice(&count.to_le_bytes());
+    }
+    table.extend_from_slice(&1u16.to_le_bytes());
+    table.extend_from_slice(&0u16.to_le_bytes());
+    push_record(&mut body, TAG_TABLE, 2, &table);
+
+    for (cell_index, &(row, col, original_span)) in positions.iter().enumerate() {
+        let col_span = if cell_index == 0 && matches!(mutation, NestedTableMutation::BadSpan) {
+            2
+        } else {
+            original_span
+        };
+        let mut cell_width = COL_WIDTHS[col..col + col_span].iter().sum::<u32>();
+        if cell_index == 0 && matches!(mutation, NestedTableMutation::BadWidth) {
+            cell_width -= 1;
+        }
+        let nested_host = (row, col, original_span) == (1, 3, 5);
+        let paragraph_count = if nested_host { 2u16 } else { 1 };
+        let mut cell = Vec::with_capacity(47);
+        cell.extend_from_slice(&paragraph_count.to_le_bytes());
+        cell.extend_from_slice(&0x0020_0000u32.to_le_bytes());
+        cell.extend_from_slice(&0x0500u16.to_le_bytes());
+        for value in [col as u16, row as u16, col_span as u16, 1] {
+            cell.extend_from_slice(&value.to_le_bytes());
+        }
+        cell.extend_from_slice(&cell_width.to_le_bytes());
+        cell.extend_from_slice(&ROW_HEIGHTS[row].to_le_bytes());
+        for padding in [141i16, 141, 141, 141] {
+            cell.extend_from_slice(&padding.to_le_bytes());
+        }
+        cell.extend_from_slice(&1u16.to_le_bytes());
+        cell.extend_from_slice(&cell_width.to_le_bytes());
+        cell.extend([0; 9]);
+        if cell_index == 0 && matches!(mutation, NestedTableMutation::BadListExtra) {
+            cell[38] = 1;
+        }
+        push_record(&mut body, TAG_LIST_HEADER, 2, &cell);
+
+        for paragraph_index in 0..paragraph_count as usize {
+            let carries_nested = nested_host
+                && paragraph_index == 1
+                && !matches!(mutation, NestedTableMutation::MissingNestedTable);
+            let paragraph_text = if carries_nested {
+                let mut text = extended_control(0x000b, CTRL_TABLE);
+                text.push(0x000d);
+                text
+            } else {
+                vec!['A' as u16, 0x000d]
+            };
+            push_para_header_at_level(
+                &mut body,
+                2,
+                paragraph_text.len() as u32,
+                if carries_nested { 1 << 0x000b } else { 0 },
+                1,
+                0,
+                0,
+            );
+            push_record(&mut body, TAG_PARA_TEXT, 3, &utf16_bytes(&paragraph_text));
+            push_record(&mut body, TAG_PARA_CHAR_SHAPE, 3, &shape_refs(&[(0, 0)]));
+            if carries_nested {
+                push_nested_one_by_one(
+                    &mut body,
+                    3,
+                    matches!(mutation, NestedTableMutation::TooDeep),
+                );
+            }
+        }
+    }
+
+    let mut compound = CompoundFile::create(Cursor::new(Vec::new())).unwrap();
+    {
+        let mut stream = compound.create_stream("/FileHeader").unwrap();
+        stream.write_all(&header).unwrap();
+    }
+    {
+        let mut stream = compound.create_stream("/DocInfo").unwrap();
+        stream.write_all(&doc_info).unwrap();
+    }
+    compound.create_storage("/BodyText").unwrap();
+    {
+        let mut stream = compound.create_stream("/BodyText/Section0").unwrap();
+        stream.write_all(&body).unwrap();
+    }
+    compound.into_inner().into_inner()
+}
+
+fn push_table_common(out: &mut Vec<u8>, level: u16, width: u32, height: u32) {
+    let mut common = Vec::with_capacity(46);
+    common.extend_from_slice(&CTRL_TABLE.to_le_bytes());
+    common.extend_from_slice(&0x082a_2311u32.to_le_bytes());
+    common.extend_from_slice(&0u32.to_le_bytes());
+    common.extend_from_slice(&0u32.to_le_bytes());
+    common.extend_from_slice(&width.to_le_bytes());
+    common.extend_from_slice(&height.to_le_bytes());
+    common.extend_from_slice(&0i32.to_le_bytes());
+    for margin in [141i16, 141, 141, 141] {
+        common.extend_from_slice(&margin.to_le_bytes());
+    }
+    common.extend_from_slice(&1u32.to_le_bytes());
+    common.extend_from_slice(&0i32.to_le_bytes());
+    common.extend_from_slice(&0u16.to_le_bytes());
+    push_record(out, TAG_CTRL_HEADER, level, &common);
+}
+
+fn push_nested_one_by_one(out: &mut Vec<u8>, control_level: u16, carries_deeper: bool) {
+    push_table_common(out, control_level, 35_500, 1_848);
+    let child_level = control_level + 1;
+    let mut table = Vec::with_capacity(24);
+    table.extend_from_slice(&0x0400_0006u32.to_le_bytes());
+    table.extend_from_slice(&1u16.to_le_bytes());
+    table.extend_from_slice(&1u16.to_le_bytes());
+    table.extend_from_slice(&0u16.to_le_bytes());
+    for padding in [510i16, 510, 141, 141] {
+        table.extend_from_slice(&padding.to_le_bytes());
+    }
+    table.extend_from_slice(&1u16.to_le_bytes());
+    table.extend_from_slice(&1u16.to_le_bytes());
+    table.extend_from_slice(&0u16.to_le_bytes());
+    push_record(out, TAG_TABLE, child_level, &table);
+
+    let mut cell = Vec::with_capacity(47);
+    cell.extend_from_slice(&1u16.to_le_bytes());
+    cell.extend_from_slice(&0x0020_0000u32.to_le_bytes());
+    cell.extend_from_slice(&0x0500u16.to_le_bytes());
+    for value in [0u16, 0, 1, 1] {
+        cell.extend_from_slice(&value.to_le_bytes());
+    }
+    cell.extend_from_slice(&35_500u32.to_le_bytes());
+    cell.extend_from_slice(&1_848u32.to_le_bytes());
+    for padding in [510i16, 510, 141, 141] {
+        cell.extend_from_slice(&padding.to_le_bytes());
+    }
+    cell.extend_from_slice(&1u16.to_le_bytes());
+    cell.extend_from_slice(&35_500u32.to_le_bytes());
+    cell.extend([0; 9]);
+    push_record(out, TAG_LIST_HEADER, child_level, &cell);
+
+    let paragraph_text = if carries_deeper {
+        let mut text = extended_control(0x000b, CTRL_TABLE);
+        text.push(0x000d);
+        text
+    } else {
+        vec!['N' as u16, 0x000d]
+    };
+    push_para_header_at_level(
+        out,
+        child_level,
+        paragraph_text.len() as u32,
+        if carries_deeper { 1 << 0x000b } else { 0 },
+        1,
+        0,
+        0,
+    );
+    push_record(
+        out,
+        TAG_PARA_TEXT,
+        child_level + 1,
+        &utf16_bytes(&paragraph_text),
+    );
+    push_record(
+        out,
+        TAG_PARA_CHAR_SHAPE,
+        child_level + 1,
+        &shape_refs(&[(0, 0)]),
+    );
+    if carries_deeper {
+        push_nested_one_by_one(out, control_level + 2, false);
+    }
 }
 
 fn page_def(mutation: Mutation) -> Vec<u8> {

--- a/crates/hwp-hwp5/tests/public_probe.rs
+++ b/crates/hwp-hwp5/tests/public_probe.rs
@@ -28,17 +28,17 @@ fn public_hwp5_has_bounded_content_free_record_provenance() {
 }
 
 #[test]
-fn explicit_own_parser_owns_bounded_multi_table_then_stops_content_free() {
+fn explicit_own_parser_owns_bounded_nested_table_then_stops_content_free() {
     let probed = probe(&benchmark()).unwrap();
     let next = probed
         .streams
         .iter()
         .flat_map(|stream| &stream.records)
-        .find(|record| record.head == 7_561)
+        .find(|record| record.head == 13_704)
         .unwrap();
     assert_eq!(
         (next.tag, next.level, next.head, next.data, next.end, next.size,),
-        (0x4d, 2, 7_561, 7_565, 7_605, 40)
+        (0x4d, 2, 13_704, 13_708, 13_746, 38)
     );
     let error = OwnHwp5Parser::new().parse(&benchmark()).unwrap_err();
     eprintln!("{error:?}");
@@ -47,8 +47,8 @@ fn explicit_own_parser_owns_bounded_multi_table_then_stops_content_free() {
         Error::MalformedRecord {
             tag: 0x4d,
             section: Some(0),
-            offset: 7561,
-            reason: "TABLE attributes or framing are not owned",
+            offset: 13704,
+            reason: "TABLE attributes or row/column topology are not owned",
             ..
         }
     ));

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -26,8 +26,9 @@
   Vitest **1,018**까지 green이고 샌드박스 포트 EPERM만 허용된 로컬 서버에서 분리 실행해 Chromium
   **85 pass/3 intentional skip/0 fail**이다. 임시 dependency link는 제거했고 production route·
   HWPX parser/serializer·shared typesetter·`external/rhwp`·generated asset diff 0, 공개 금지 원문·
-  경로·hash·raw payload·credential diff 0을 확인했다. **다음:** commit/push/PR #176→required CI·댓글
-  확인→자율 병합→#94 동기화→다음 TABLE `13704..13746` classification-first child.
+  경로·hash·raw payload·credential diff 0을 확인했다. 구현은 commit `52e9fc6`으로 push했고 PR #177을
+  `Closes #176`으로 게시했다. **다음:** required CI·댓글 확인→자율 병합→#94 동기화→다음 TABLE
+  `13704..13746` classification-first child.
 
 - 갱신: 2026-08-24 · Codex(sol) — **PR #173 병합 · #174 multi-table 경계 착수**.
   자체 HWP5 파서가 exact `tbl ` marker/common-object/TABLE/LIST_HEADER/cell paragraph를 검증해

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,6 +3,32 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
+- 갱신: 2026-08-24 · Codex(sol) — **#176 nested TABLE 구현·전체 검증 완료**.
+  #175는 exact head `6711ff9`에서 issue-link/build-test/licenses green, CLEAN/MERGEABLE,
+  review/general/inline 댓글 0을 확인하고 protected main `c917c584`로 squash 병합했다. #174 close와
+  원격 branch 정리 후 #94에 bounded two-table host 소유 근거를 동기화했다. 월요일 #114 감사에서
+  open PR 0, 새 외부 제보·스팸·보안 신호 0, 기존 외부 #50의 Proposal/security 라우팅, desktop
+  signing blocker를 재확인했다. 중복 없는 #176을 R18/P1/area:hwp5/status:ready로 열고 exact latest
+  main의 `codex/issue-176-hwp5-next-table` worktree를 만들었다. **다음:** content-free TABLE
+  `0x4d/7561..7605` header/child topology 분류→faithful shared-IR 표현 가능할 때만 synthetic/hostile
+  fixture와 strict parser 구현. production route·HWPX·shared layout·generated assets·rhwp는 불변.
+  분류 결과 exact 9×8/34 active cells, 행별 count `2/2/4/1/5/5/5/5/5`, 고정 horizontal merge
+  topology, 1~2 cell paragraphs, 단 하나의 depth-1 1×1 nested table이다. attr은 no-split·inert
+  repeat-header·no-adjust의 exact `0x0600000c`이고 shared IR의 keep-together/fixed-row-height/nested
+  Block으로 표현 가능하다. parser는 row count·span/order·record level, zero/mirrored-width 13B cell
+  extension, border refs, row heights, common geometry를 검증하고 span equation graph로 8개 column
+  boundary를 유일하게 복원한다. nested table은 exact cell/paragraph 위치와 depth≤1만 허용한다.
+  synthetic positive + hostile attr/row-count/span/width/extension/missing/deeper-nest 7축을 추가해 HWP5
+  **57 tests** green. 공개 own-parser 경계는 다음 TABLE `0x4d/13704..13746`(8×5)으로 전진했다.
+  focused clippy `-D warnings`·wasm32와 quick의 fork governance, fmt/clippy, Rust workspace,
+  PDF visual **51**, canonical **8/18/24·98.9%+**, public corpus **84**, oracle **82**, HWPX,
+  wasm/licenses가 모두 green이다. full도 wasm 재빌드(7,810,657B), JS build·crosscheck·i18n,
+  Vitest **1,018**까지 green이고 샌드박스 포트 EPERM만 허용된 로컬 서버에서 분리 실행해 Chromium
+  **85 pass/3 intentional skip/0 fail**이다. 임시 dependency link는 제거했고 production route·
+  HWPX parser/serializer·shared typesetter·`external/rhwp`·generated asset diff 0, 공개 금지 원문·
+  경로·hash·raw payload·credential diff 0을 확인했다. **다음:** commit/push/PR #176→required CI·댓글
+  확인→자율 병합→#94 동기화→다음 TABLE `13704..13746` classification-first child.
+
 - 갱신: 2026-08-24 · Codex(sol) — **PR #173 병합 · #174 multi-table 경계 착수**.
   자체 HWP5 파서가 exact `tbl ` marker/common-object/TABLE/LIST_HEADER/cell paragraph를 검증해
   treat-as-character 1×1 표를 source-neutral `Table`/`Cell` IR로 내린다. 셀/개체 geometry,

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,26 @@
 
 ---
 
+## 2026-08-24 (Codex sol) · #176 full green / PR ready
+- full Rust/PDF/corpus/oracle/HWPX/wasm/JS + Vitest 1,018 green.
+- 허용된 로컬 서버 Chromium 85 pass/3 intentional skip/0 fail; 임시 link 제거.
+- route/rhwp/HWPX/generated/security diff 0. 다음 commit/push/PR→CI/merge.
+
+## 2026-08-24 (Codex sol) · #176 quick green
+- focused clippy/wasm32 + quick Rust/PDF51/canonical 8·18·24/98.9%+/corpus84/oracle82 green.
+- HWP5 57, next boundary TABLE 13704..13746; route/rhwp/HWPX/generated unchanged.
+- next full→security/diff→commit/push/PR #176.
+
+## 2026-08-24 (Codex sol) · #176 nested TABLE focused green
+- exact 9×8/34 cells + one depth-1 1×1 nested table → shared Table/Cell/Block IR.
+- row counts/span equations/fixed heights/13B extension/depth bound hostile 7축; HWP5 57 green.
+- public boundary advanced TABLE 7561..7605 → TABLE 13704..13746; next clippy/wasm→quick/full.
+
+## 2026-08-24 (Codex sol) · #175 merged / #176 started
+- #175 main `c917c584`, #174 close·remote branch 정리; required CI/comment audit green.
+- #94/#114 동기화, open PR·신규 community/security signal 0; #176 R18 child 등록.
+- next TABLE 7561..7605 content-free 분류부터 진행; route/rhwp/HWPX 불변.
+
 ## 2026-08-24 (Codex sol) · #174 PR #175 게시
 - bounded multi-table commit `aee1f70` push, PR #175(`Closes #174`) 생성.
 - route/rhwp/HWPX/generated 불변과 quick/full/Vitest 1,018/Chromium 85·3 명시.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,11 @@
 
 ---
 
+## 2026-08-24 (Codex sol) · #176 PR #177 게시
+- bounded nested TABLE commit `52e9fc6` push, PR #177(`Closes #176`) 생성.
+- full/Vitest 1,018/Chromium 85·3, route/rhwp/HWPX/generated 불변을 공개 검증에 명시.
+- 다음 required CI·댓글 추적→green 자율 병합→TABLE 13704 child.
+
 ## 2026-08-24 (Codex sol) · #176 full green / PR ready
 - full Rust/PDF/corpus/oracle/HWPX/wasm/JS + Vitest 1,018 green.
 - 허용된 로컬 서버 Chromium 85 pass/3 intentional skip/0 fail; 임시 link 제거.


### PR DESCRIPTION
Closes #176

Refs #94 #174 #175

## What changed

- own the next strict HWP5 inline TABLE topology as a 9×8 shared-IR table
- preserve its bounded horizontal merges, fixed row heights, and one depth-1 nested 1×1 table
- solve column boundaries from validated span equations instead of source-specific offsets
- fail closed on unowned attributes, row counts, spans, geometry, cell extensions, missing nesting, and deeper nesting
- advance the content-free public probe to the next unsupported TABLE boundary

## Architecture and safety

- the production HWP5 routing contract remains unchanged
- `external/rhwp` remains pinned and unmodified; it is not used as the renderer
- HWPX parsing/serialization, shared typesetting behavior, and generated assets are unchanged
- no source document content, local path, source hash, raw payload, credential, or private fixture is published

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy -p hwp-hwp5 --all-targets -- -D warnings`
- `cargo check -p hwp-hwp5 --target wasm32-unknown-unknown`
- `cargo test -p hwp-hwp5` — 57 passed
- `scripts/verify-local.sh` — green
- `scripts/verify-local.sh --full` — Rust/PDF/corpus/oracle/HWPX/wasm/JS/Vitest 1,018 green; sandbox port binding was separately exercised below
- real Chromium E2E on an allowed local server — 85 passed, 3 intentional skips, 0 failures

## Invariants

- canonical gates remain 8/18/24 with line-break agreement at or above 98.9%
- public corpus remains 84 and layout oracle remains 82
- renderer ownership remains shared IR → own typesetter/render/export
