### PR TITLE
feat: own strict HWP5 8x5 nested table topology

### DIFF
--- a/crates/hwp-hwp5/src/semantic.rs
+++ b/crates/hwp-hwp5/src/semantic.rs
@@ -1559,8 +1559,9 @@ fn parse_new_number_control(
 }
 
 /// Own the bounded binary-table slices seen at the public first-party boundary: strict inline 1×1,
-/// 10×2, and 9×8 tables. The 9×8 slice has 34 active cells, an exact horizontal-merge topology, and
-/// one nested 1×1 table at depth one. A 1×1 cell may use the exact observed cell-own inner-margin bit;
+/// 10×2, 9×8, and 8×5 tables. The 9×8 slice has 34 active cells and one nested 1×1 table; the 8×5
+/// slice has 19 active cells, one bounded vertical merge, and nine nested 1×1 tables. A 1×1 cell may
+/// use the exact observed cell-own inner-margin bit;
 /// protection/header/form bits remain unsupported. Multiple controls in one text-empty host are
 /// emitted in marker/header order by `parse_paragraph`. Anything outside these exact source-neutral
 /// shapes, including deeper nesting, remains fail-closed rather than being approximated.
@@ -1654,51 +1655,72 @@ fn parse_inline_table(
     let cols = read_u16(table_bytes, 6).expect("minimum length checked") as usize;
     let table_attr = read_u32(table_bytes, 0).expect("minimum length checked");
     let expected_positions = match (table_attr, rows, cols) {
-        (0x0400_0006, 1, 1) => vec![(0, 0, 1)],
+        (0x0400_0006, 1, 1) => vec![(0, 0, 1, 1)],
         (0x0400_0006, 10, 2) => (0..10)
             .flat_map(|row| {
                 if matches!(row, 0 | 1 | 5) {
-                    vec![(row, 0, 2)]
+                    vec![(row, 0, 2, 1)]
                 } else {
-                    vec![(row, 0, 1), (row, 1, 1)]
+                    vec![(row, 0, 1, 1), (row, 1, 1, 1)]
                 }
             })
             .collect(),
         (0x0600_000c, 9, 8) => vec![
-            (0, 0, 3),
-            (0, 3, 5),
-            (1, 0, 3),
-            (1, 3, 5),
-            (2, 0, 3),
-            (2, 3, 2),
-            (2, 5, 1),
-            (2, 6, 2),
-            (3, 0, 8),
-            (4, 0, 1),
-            (4, 1, 1),
-            (4, 2, 2),
-            (4, 4, 3),
-            (4, 7, 1),
-            (5, 0, 1),
-            (5, 1, 1),
-            (5, 2, 2),
-            (5, 4, 3),
-            (5, 7, 1),
-            (6, 0, 1),
-            (6, 1, 1),
-            (6, 2, 2),
-            (6, 4, 3),
-            (6, 7, 1),
-            (7, 0, 1),
-            (7, 1, 1),
-            (7, 2, 2),
-            (7, 4, 3),
-            (7, 7, 1),
-            (8, 0, 1),
-            (8, 1, 1),
-            (8, 2, 2),
-            (8, 4, 3),
-            (8, 7, 1),
+            (0, 0, 3, 1),
+            (0, 3, 5, 1),
+            (1, 0, 3, 1),
+            (1, 3, 5, 1),
+            (2, 0, 3, 1),
+            (2, 3, 2, 1),
+            (2, 5, 1, 1),
+            (2, 6, 2, 1),
+            (3, 0, 8, 1),
+            (4, 0, 1, 1),
+            (4, 1, 1, 1),
+            (4, 2, 2, 1),
+            (4, 4, 3, 1),
+            (4, 7, 1, 1),
+            (5, 0, 1, 1),
+            (5, 1, 1, 1),
+            (5, 2, 2, 1),
+            (5, 4, 3, 1),
+            (5, 7, 1, 1),
+            (6, 0, 1, 1),
+            (6, 1, 1, 1),
+            (6, 2, 2, 1),
+            (6, 4, 3, 1),
+            (6, 7, 1, 1),
+            (7, 0, 1, 1),
+            (7, 1, 1, 1),
+            (7, 2, 2, 1),
+            (7, 4, 3, 1),
+            (7, 7, 1, 1),
+            (8, 0, 1, 1),
+            (8, 1, 1, 1),
+            (8, 2, 2, 1),
+            (8, 4, 3, 1),
+            (8, 7, 1, 1),
+        ],
+        (0x0600_000e, 8, 5) => vec![
+            (0, 0, 1, 1),
+            (0, 1, 1, 1),
+            (0, 2, 2, 1),
+            (0, 4, 1, 1),
+            (1, 0, 1, 1),
+            (1, 1, 4, 1),
+            (2, 0, 1, 1),
+            (2, 1, 4, 1),
+            (3, 0, 1, 1),
+            (3, 1, 4, 1),
+            (4, 0, 1, 1),
+            (4, 1, 4, 1),
+            (5, 0, 1, 1),
+            (5, 1, 4, 1),
+            (6, 0, 1, 2),
+            (6, 1, 2, 1),
+            (6, 3, 2, 1),
+            (7, 1, 2, 1),
+            (7, 3, 2, 1),
         ],
         _ => {
             return Err(malformed(
@@ -1754,7 +1776,7 @@ fn parse_inline_table(
         .map(|row| {
             expected_positions
                 .iter()
-                .filter(|(cell_row, _, _)| *cell_row == row)
+                .filter(|(cell_row, _, _, _)| *cell_row == row)
                 .count() as HwpUnit
         })
         .collect::<Vec<_>>();
@@ -1806,12 +1828,7 @@ fn parse_inline_table(
         }
         let paragraph_count = read_u16(list_bytes, 0).expect("exact length checked") as usize;
         let width_ref = read_u16(list_bytes, 6).expect("exact length checked");
-        let owned_width_ref = matches!(width_ref, 0x0000 | 0x0100 | 0x0500)
-            || (width_ref == 0x0501 && (rows, cols) == (1, 1));
-        if !(1..=5).contains(&paragraph_count)
-            || read_u32(list_bytes, 2) != Some(0x0020_0000)
-            || !owned_width_ref
-        {
+        if !(1..=5).contains(&paragraph_count) || read_u32(list_bytes, 2) != Some(0x0020_0000) {
             return Err(malformed(
                 &list_record,
                 Some(section),
@@ -1824,9 +1841,39 @@ fn parse_inline_table(
         let row_span = read_u16(list_bytes, 14).expect("exact length checked") as usize;
         let cell_width = read_u32(list_bytes, 16).expect("exact length checked");
         let cell_height = read_u32(list_bytes, 20).expect("exact length checked");
+        let expected_eight_by_five_width_ref = if (table_attr, rows, cols) == (0x0600_000e, 8, 5) {
+            Some(if row == 0 {
+                0x0100
+            } else if (row, col, col_span, row_span) == (6, 1, 2, 1) {
+                0x0400
+            } else {
+                0x0000
+            })
+        } else {
+            None
+        };
+        let owned_width_ref = expected_eight_by_five_width_ref.map_or_else(
+            || {
+                matches!(width_ref, 0x0000 | 0x0100 | 0x0500)
+                    || (width_ref == 0x0501 && (rows, cols) == (1, 1))
+            },
+            |expected| width_ref == expected,
+        );
+        if !owned_width_ref {
+            return Err(malformed(
+                &list_record,
+                Some(section),
+                if expected_eight_by_five_width_ref.is_some() {
+                    "cell LIST_HEADER width reference differs from its exact owned topology"
+                } else {
+                    "cell LIST_HEADER count, direction, alignment, or width reference is not owned"
+                },
+            ));
+        }
         if col_span == 0
-            || row_span != 1
+            || row_span == 0
             || col.checked_add(col_span).is_none_or(|end| end > cols)
+            || row.checked_add(row_span).is_none_or(|end| end > rows)
             || row >= rows
             || cell_width == 0
             || cell_height == 0
@@ -1841,13 +1888,36 @@ fn parse_inline_table(
         }
         let list_extra = &list_bytes[34..];
         let zero_legacy_extra = list_extra.iter().all(|byte| *byte == 0);
-        let mirrored_width_extra = read_u32(list_extra, 0) == Some(cell_width)
-            && list_extra[4..].iter().all(|byte| *byte == 0);
-        if !(zero_legacy_extra || mirrored_width_extra) {
+        let extension_width = read_u32(list_extra, 0).unwrap_or(0);
+        let width_extension = extension_width > 0 && list_extra[4..].iter().all(|byte| *byte == 0);
+        let stale_core_width_slot = (table_attr, rows, cols, row, col, col_span, row_span)
+            == (0x0600_000e, 8, 5, 6, 3, 2, 1);
+        if !(zero_legacy_extra
+            || (width_extension && (extension_width == cell_width || stale_core_width_slot)))
+        {
             return Err(malformed(
                 &list_record,
                 Some(section),
-                "cell LIST_HEADER extension is not zero or an exact width mirror",
+                "cell LIST_HEADER extension is not zero or an owned layout-width mirror",
+            ));
+        }
+        if stale_core_width_slot && extension_width.checked_sub(cell_width) != Some(176) {
+            return Err(malformed(
+                &list_record,
+                Some(section),
+                "owned stale core cell width does not match its bounded layout-width delta",
+            ));
+        }
+        let layout_width = if width_extension {
+            extension_width
+        } else {
+            cell_width
+        };
+        if layout_width == 0 || layout_width > MAX_OBJECT_HWPUNIT {
+            return Err(malformed(
+                &list_record,
+                Some(section),
+                "cell LIST_HEADER layout width is not positive and bounded",
             ));
         }
         let cell_padding = [24usize, 26, 28, 30]
@@ -1859,8 +1929,9 @@ fn parse_inline_table(
                 "cell stored padding must be nonnegative",
             ));
         }
-        // The bounded 13-byte extension is either the legacy all-zero form or an exact cell-width
-        // mirror followed by reserved zeros. Longer field-bearing tails remain unsupported.
+        // The bounded 13-byte extension is either the legacy all-zero form or a layout-width mirror
+        // followed by reserved zeros. One exact public slot carries a newer layout width over a stale
+        // core width; the global span equations below prove that override instead of trusting it alone.
         debug_assert_eq!(list_extra.len(), 13);
         let cell_border_id = read_u16(list_bytes, 32).expect("exact length checked");
         let cell_fill = table_border(doc, cell_border_id, &list_record, section, "table cell")?;
@@ -1910,10 +1981,27 @@ fn parse_inline_table(
                 ));
             }
             if !parsed.tables.is_empty() {
-                let owned_nested_position = (table_attr, rows, cols) == (0x0600_000c, 9, 8)
-                    && (row, col, col_span) == (1, 3, 5)
-                    && paragraph_index == 1
-                    && parsed.tables.len() == 1;
+                let owned_nested_position = match (table_attr, rows, cols) {
+                    (0x0600_000c, 9, 8) => {
+                        (row, col, col_span, row_span, paragraph_index) == (1, 3, 5, 1, 1)
+                    }
+                    (0x0600_000e, 8, 5) => {
+                        paragraph_index == 0
+                            && matches!(
+                                (row, col, col_span, row_span),
+                                (0, 1, 1, 1)
+                                    | (0, 4, 1, 1)
+                                    | (1, 1, 4, 1)
+                                    | (2, 1, 4, 1)
+                                    | (3, 1, 4, 1)
+                                    | (4, 1, 4, 1)
+                                    | (5, 1, 4, 1)
+                                    | (6, 1, 2, 1)
+                                    | (6, 3, 2, 1)
+                            )
+                    }
+                    _ => false,
+                } && parsed.tables.len() == 1;
                 let has_visible_text = parsed.paragraph.runs.iter().any(|run| {
                     run.content
                         .iter()
@@ -1947,7 +2035,7 @@ fn parse_inline_table(
             // The exact observed low bit is HWP's apply-inner-margin flag. Other cell extension
             // bits (protect/header/form) were rejected with the width-reference word above.
             padding: (width_ref == 0x0501).then_some(cell_padding.map(|value| value as HwpUnit)),
-            width: Some(cell_width as HwpUnit),
+            width: Some(layout_width as HwpUnit),
             ..Cell::default()
         });
     }
@@ -1958,7 +2046,11 @@ fn parse_inline_table(
             "owned TABLE active-cell count differs from its exact topology",
         ));
     }
-    let expected_nested_tables = usize::from((table_attr, rows, cols) == (0x0600_000c, 9, 8));
+    let expected_nested_tables = match (table_attr, rows, cols) {
+        (0x0600_000c, 9, 8) => 1,
+        (0x0600_000e, 8, 5) => 9,
+        _ => 0,
+    };
     if nested_table_count != expected_nested_tables {
         return Err(malformed(
             &table_record,
@@ -1970,7 +2062,7 @@ fn parse_inline_table(
     if cells
         .iter()
         .zip(&expected_positions)
-        .any(|(cell, expected)| (cell.row, cell.col, cell.col_span) != *expected)
+        .any(|(cell, expected)| (cell.row, cell.col, cell.col_span, cell.row_span) != *expected)
     {
         return Err(malformed(
             &table_record,
@@ -1980,16 +2072,19 @@ fn parse_inline_table(
     }
 
     let mut derived_rows = vec![None::<HwpUnit>; rows];
-    for (cell, cell_height) in cells.iter().zip(cell_heights) {
+    for (cell, cell_height) in cells.iter().zip(&cell_heights) {
+        if cell.row_span != 1 {
+            continue;
+        }
         match derived_rows[cell.row] {
-            Some(existing) if existing != cell_height => {
+            Some(existing) if existing != *cell_height => {
                 return Err(malformed(
                     &table_record,
                     Some(section),
                     "cell heights disagree within a TABLE row",
                 ))
             }
-            None => derived_rows[cell.row] = Some(cell_height),
+            None => derived_rows[cell.row] = Some(*cell_height),
             _ => {}
         }
     }
@@ -2070,11 +2165,29 @@ fn parse_inline_table(
                 "TABLE has a row whose stored height cannot be derived from an active cell",
             )
         })?;
-    if derived_rows
+    for (cell, cell_height) in cells.iter().zip(&cell_heights) {
+        if cell.row_span <= 1 {
+            continue;
+        }
+        let end = cell.row + cell.row_span;
+        let span_height = derived_rows[cell.row..end]
+            .iter()
+            .try_fold(0i64, |sum, value| sum.checked_add(i64::from(*value)));
+        if span_height != Some(i64::from(*cell_height)) {
+            return Err(malformed(
+                &table_record,
+                Some(section),
+                "row-spanning cell height disagrees with its covered TABLE rows",
+            ));
+        }
+    }
+    let stored_height = derived_rows
         .iter()
-        .try_fold(0i64, |sum, value| sum.checked_add(i64::from(*value)))
-        != Some(i64::from(height))
-    {
+        .try_fold(0i64, |sum, value| sum.checked_add(i64::from(*value)));
+    let owned_nested_stale_common_height = table_depth == 1
+        && (table_attr, rows, cols, height, stored_height)
+            == (0x0400_0006, 1, 1, 3_882, Some(1_848));
+    if stored_height != Some(i64::from(height)) && !owned_nested_stale_common_height {
         return Err(malformed(
             &table_record,
             Some(section),
@@ -2086,13 +2199,15 @@ fn parse_inline_table(
         rows,
         cols,
         cells,
-        keep_together: true,
+        // The exact 8×5 form follows the current shared row-fragmentation behavior. Its low flag has
+        // conflicting legacy descriptions, so this stays bounded to the observed form; the other
+        // owned forms retain their already-proven keep-together behavior.
+        keep_together: table_attr != 0x0600_000e,
         col_widths,
         row_heights: derived_rows,
-        // The exact 9×8 attribute carries HWP's no-adjust bit. Its stored row heights are therefore
-        // exact clipping geometry, not merely content-size floors. The other owned HWP5 subsets keep
-        // their historical floor behavior.
-        fixed_row_heights: table_attr == 0x0600_000c,
+        // Both exact large-table attributes carry HWP's no-adjust bit. Their stored row heights are
+        // exact clipping geometry, not merely content-size floors.
+        fixed_row_heights: matches!(table_attr, 0x0600_000c | 0x0600_000e),
         outer_margin_left: margins[0] as HwpUnit,
         outer_margin_right: margins[1] as HwpUnit,
         outer_margin_top: margins[2] as HwpUnit,

--- a/crates/hwp-hwp5/tests/layout_semantic.rs
+++ b/crates/hwp-hwp5/tests/layout_semantic.rs
@@ -98,6 +98,19 @@ enum NestedTableMutation {
     TooDeep,
 }
 
+#[derive(Clone, Copy)]
+enum EightByFiveMutation {
+    None,
+    BadAttribute,
+    BadRowCellCount,
+    BadRowSpan,
+    BadLayoutWidthDelta,
+    BadWidthReference,
+    MissingNestedTable,
+    WrongNestedPosition,
+    BadStaleNestedHeight,
+}
+
 #[test]
 fn parses_page_setup_and_blank_source_line_metrics() {
     let doc = OwnHwp5Parser::new()
@@ -726,6 +739,75 @@ fn strict_nested_table_slice_rejects_hostile_attributes_topology_and_extensions(
             ..
         })
     ));
+}
+
+#[test]
+fn owns_exact_eight_by_five_rowspan_and_nine_bounded_nested_tables() {
+    let doc = OwnHwp5Parser::new()
+        .parse(&eight_by_five_fixture(EightByFiveMutation::None))
+        .expect("strict 8x5 nested-table fixture parses");
+    let [Block::Paragraph(anchor), Block::Table(table)] = doc.sections[0].blocks.as_slice() else {
+        panic!("table host must lower to one anchor and one table")
+    };
+    assert!(anchor.is_table_anchor);
+    assert_eq!((table.rows, table.cols, table.cells.len()), (8, 5, 19));
+    assert!(
+        !table.keep_together,
+        "row-boundary policy uses shared row fragmentation"
+    );
+    assert!(table.fixed_row_heights, "no-adjust reaches shared IR");
+    assert_eq!(table.col_widths, vec![7_667, 16_324, 3_879, 3_955, 16_324]);
+    assert_eq!(
+        table.row_heights,
+        vec![5_012, 7_339, 10_169, 10_169, 10_169, 10_169, 11_921, 1_848]
+    );
+    assert_eq!(
+        table
+            .cells
+            .iter()
+            .filter(|cell| cell.row_span == 2)
+            .map(|cell| (cell.row, cell.col, cell.width))
+            .collect::<Vec<_>>(),
+        vec![(6, 0, Some(7_667))]
+    );
+    assert_eq!(
+        table
+            .cells
+            .iter()
+            .filter(|cell| cell
+                .blocks
+                .iter()
+                .any(|block| matches!(block, Block::Table(_))))
+            .count(),
+        9
+    );
+    let corrected = table
+        .cells
+        .iter()
+        .find(|cell| (cell.row, cell.col, cell.col_span) == (6, 3, 2))
+        .expect("exact stale-width slot");
+    assert_eq!(corrected.width, Some(20_279));
+}
+
+#[test]
+fn strict_eight_by_five_slice_rejects_hostile_topology_widths_and_nesting() {
+    for mutation in [
+        EightByFiveMutation::BadAttribute,
+        EightByFiveMutation::BadRowCellCount,
+        EightByFiveMutation::BadRowSpan,
+        EightByFiveMutation::BadLayoutWidthDelta,
+        EightByFiveMutation::BadWidthReference,
+        EightByFiveMutation::MissingNestedTable,
+        EightByFiveMutation::WrongNestedPosition,
+        EightByFiveMutation::BadStaleNestedHeight,
+    ] {
+        assert!(
+            OwnHwp5Parser::new()
+                .parse(&eight_by_five_fixture(mutation))
+                .is_err(),
+            "hostile 8x5 mutation must fail closed"
+        );
+    }
 }
 
 fn fixture(mutation: Mutation) -> Vec<u8> {
@@ -1401,6 +1483,244 @@ fn fixture(mutation: Mutation) -> Vec<u8> {
     compound.into_inner().into_inner()
 }
 
+fn eight_by_five_fixture(mutation: EightByFiveMutation) -> Vec<u8> {
+    const COL_WIDTHS: [u32; 5] = [7_667, 16_324, 3_879, 3_955, 16_324];
+    const ROW_HEIGHTS: [u32; 8] = [5_012, 7_339, 10_169, 10_169, 10_169, 10_169, 11_921, 1_848];
+    const POSITIONS: [(usize, usize, usize, usize); 19] = [
+        (0, 0, 1, 1),
+        (0, 1, 1, 1),
+        (0, 2, 2, 1),
+        (0, 4, 1, 1),
+        (1, 0, 1, 1),
+        (1, 1, 4, 1),
+        (2, 0, 1, 1),
+        (2, 1, 4, 1),
+        (3, 0, 1, 1),
+        (3, 1, 4, 1),
+        (4, 0, 1, 1),
+        (4, 1, 4, 1),
+        (5, 0, 1, 1),
+        (5, 1, 4, 1),
+        (6, 0, 1, 2),
+        (6, 1, 2, 1),
+        (6, 3, 2, 1),
+        (7, 1, 2, 1),
+        (7, 3, 2, 1),
+    ];
+    const NESTED: [(usize, usize); 9] = [
+        (0, 1),
+        (0, 4),
+        (1, 1),
+        (2, 1),
+        (3, 1),
+        (4, 1),
+        (5, 1),
+        (6, 1),
+        (6, 3),
+    ];
+
+    let mut header = vec![0; 256];
+    header[..HWP_SIGNATURE.len()].copy_from_slice(HWP_SIGNATURE);
+    header[32..36].copy_from_slice(&[0, 0, 0, 5]);
+
+    let mut doc_info = Vec::new();
+    let mut properties = vec![0; 26];
+    properties[..2].copy_from_slice(&1u16.to_le_bytes());
+    push_record(&mut doc_info, TAG_DOCUMENT_PROPERTIES, 0, &properties);
+    let mut mappings = Vec::new();
+    for count in [0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 1, 0] {
+        mappings.extend_from_slice(&(count as u32).to_le_bytes());
+    }
+    push_record(&mut doc_info, TAG_ID_MAPPINGS, 0, &mappings);
+    for _ in 0..7 {
+        push_record(&mut doc_info, TAG_FACE_NAME, 0, &face_name("Test Sans"));
+    }
+    push_record(&mut doc_info, TAG_BORDER_FILL, 0, &solid_border_fill());
+    push_record(&mut doc_info, TAG_CHAR_SHAPE, 0, &char_shape());
+    push_record(&mut doc_info, TAG_PARA_SHAPE, 0, &para_shape());
+
+    let mut body = Vec::new();
+    let mut host_text = extended_control(0x0002, CTRL_SECTION_DEF);
+    host_text.extend(extended_control(0x000b, CTRL_TABLE));
+    host_text.push(0x000d);
+    push_para_header_with_break(
+        &mut body,
+        host_text.len() as u32,
+        (1 << 2) | (1 << 0x000b),
+        1,
+        0,
+        0x01,
+    );
+    push_record(&mut body, TAG_PARA_TEXT, 1, &utf16_bytes(&host_text));
+    push_record(&mut body, TAG_PARA_CHAR_SHAPE, 1, &shape_refs(&[(0, 0)]));
+
+    let mut section_control = Vec::with_capacity(28);
+    section_control.extend_from_slice(&CTRL_SECTION_DEF.to_le_bytes());
+    section_control.extend([0; 24]);
+    push_record(&mut body, TAG_CTRL_HEADER, 1, &section_control);
+    push_record(&mut body, TAG_PAGE_DEF, 2, &page_def(Mutation::None));
+
+    push_table_common(&mut body, 1, 48_149, 66_796);
+    let mut table = Vec::with_capacity(38);
+    table.extend_from_slice(
+        &if matches!(mutation, EightByFiveMutation::BadAttribute) {
+            0x0600_000cu32
+        } else {
+            0x0600_000e
+        }
+        .to_le_bytes(),
+    );
+    table.extend_from_slice(&8u16.to_le_bytes());
+    table.extend_from_slice(&5u16.to_le_bytes());
+    table.extend_from_slice(&0u16.to_le_bytes());
+    for padding in [510i16, 510, 141, 141] {
+        table.extend_from_slice(&padding.to_le_bytes());
+    }
+    let mut row_counts = [4u16, 2, 2, 2, 2, 2, 3, 2];
+    if matches!(mutation, EightByFiveMutation::BadRowCellCount) {
+        row_counts[6] = 2;
+    }
+    for count in row_counts {
+        table.extend_from_slice(&count.to_le_bytes());
+    }
+    table.extend_from_slice(&1u16.to_le_bytes());
+    table.extend_from_slice(&0u16.to_le_bytes());
+    push_record(&mut body, TAG_TABLE, 2, &table);
+
+    for &(row, col, col_span, original_row_span) in &POSITIONS {
+        let row_span =
+            if (row, col) == (6, 0) && matches!(mutation, EightByFiveMutation::BadRowSpan) {
+                1
+            } else {
+                original_row_span
+            };
+        let layout_width = COL_WIDTHS[col..col + col_span].iter().sum::<u32>();
+        let stale_width_slot = (row, col, col_span, original_row_span) == (6, 3, 2, 1);
+        let core_width = if stale_width_slot {
+            layout_width
+                - if matches!(mutation, EightByFiveMutation::BadLayoutWidthDelta) {
+                    175
+                } else {
+                    176
+                }
+        } else {
+            layout_width
+        };
+        let cell_height = if original_row_span == 2 {
+            ROW_HEIGHTS[row] + ROW_HEIGHTS[row + 1]
+        } else {
+            ROW_HEIGHTS[row]
+        };
+        let paragraph_count = match (row, col) {
+            (2, 1) | (5, 1) => 4u16,
+            (3, 1) | (4, 1) => 3,
+            _ => 1,
+        };
+        let width_ref = if row == 0 {
+            0x0100u16
+        } else if (row, col) == (6, 1) {
+            if matches!(mutation, EightByFiveMutation::BadWidthReference) {
+                0
+            } else {
+                0x0400
+            }
+        } else {
+            0
+        };
+        let mut cell = Vec::with_capacity(47);
+        cell.extend_from_slice(&paragraph_count.to_le_bytes());
+        cell.extend_from_slice(&0x0020_0000u32.to_le_bytes());
+        cell.extend_from_slice(&width_ref.to_le_bytes());
+        for value in [col as u16, row as u16, col_span as u16, row_span as u16] {
+            cell.extend_from_slice(&value.to_le_bytes());
+        }
+        cell.extend_from_slice(&core_width.to_le_bytes());
+        cell.extend_from_slice(&cell_height.to_le_bytes());
+        for padding in [510i16, 510, 141, 141] {
+            cell.extend_from_slice(&padding.to_le_bytes());
+        }
+        cell.extend_from_slice(&1u16.to_le_bytes());
+        cell.extend_from_slice(&layout_width.to_le_bytes());
+        cell.extend([0; 9]);
+        push_record(&mut body, TAG_LIST_HEADER, 2, &cell);
+
+        let mut nested_here = NESTED.contains(&(row, col));
+        if matches!(mutation, EightByFiveMutation::MissingNestedTable) && (row, col) == (6, 3) {
+            nested_here = false;
+        }
+        if matches!(mutation, EightByFiveMutation::WrongNestedPosition) {
+            if (row, col) == (0, 1) {
+                nested_here = false;
+            }
+            if (row, col) == (0, 0) {
+                nested_here = true;
+            }
+        }
+        for paragraph_index in 0..paragraph_count as usize {
+            let carries_nested = nested_here && paragraph_index == 0;
+            let paragraph_text = if carries_nested {
+                let mut text = extended_control(0x000b, CTRL_TABLE);
+                text.push(0x000d);
+                text
+            } else {
+                vec!['A' as u16, 0x000d]
+            };
+            push_para_header_at_level(
+                &mut body,
+                2,
+                paragraph_text.len() as u32,
+                if carries_nested { 1 << 0x000b } else { 0 },
+                1,
+                0,
+                0,
+            );
+            push_record(&mut body, TAG_PARA_TEXT, 3, &utf16_bytes(&paragraph_text));
+            push_record(&mut body, TAG_PARA_CHAR_SHAPE, 3, &shape_refs(&[(0, 0)]));
+            if carries_nested {
+                let (nested_width, common_height, cell_height) = match (row, col) {
+                    (0, 1) => (
+                        14_275,
+                        if matches!(mutation, EightByFiveMutation::BadStaleNestedHeight) {
+                            3_881
+                        } else {
+                            3_882
+                        },
+                        1_848,
+                    ),
+                    (0, 4) => (14_841, 3_882, 1_848),
+                    (2, 1) => (38_896, 3_631, 3_631),
+                    (5, 1) => (38_896, 3_150, 3_150),
+                    (6, 1) | (6, 3) => (19_086, 5_131, 5_131),
+                    _ => (38_896, 5_131, 5_131),
+                };
+                push_one_by_one_with_geometry(
+                    &mut body,
+                    3,
+                    nested_width,
+                    common_height,
+                    cell_height,
+                );
+            }
+        }
+    }
+
+    let mut compound = CompoundFile::create(Cursor::new(Vec::new())).unwrap();
+    {
+        let mut stream = compound.create_stream("/FileHeader").unwrap();
+        stream.write_all(&header).unwrap();
+    }
+    {
+        let mut stream = compound.create_stream("/DocInfo").unwrap();
+        stream.write_all(&doc_info).unwrap();
+    }
+    compound.create_storage("/BodyText").unwrap();
+    {
+        let mut stream = compound.create_stream("/BodyText/Section0").unwrap();
+        stream.write_all(&body).unwrap();
+    }
+    compound.into_inner().into_inner()
+}
+
 fn nested_table_fixture(mutation: NestedTableMutation) -> Vec<u8> {
     const COL_WIDTHS: [u32; 8] = [3_182, 6_810, 659, 8_082, 5_346, 10_534, 5_935, 7_435];
     const ROW_HEIGHTS: [u32; 9] = [
@@ -1608,6 +1928,60 @@ fn push_table_common(out: &mut Vec<u8>, level: u16, width: u32, height: u32) {
     common.extend_from_slice(&0i32.to_le_bytes());
     common.extend_from_slice(&0u16.to_le_bytes());
     push_record(out, TAG_CTRL_HEADER, level, &common);
+}
+
+fn push_one_by_one_with_geometry(
+    out: &mut Vec<u8>,
+    control_level: u16,
+    width: u32,
+    common_height: u32,
+    cell_height: u32,
+) {
+    push_table_common(out, control_level, width, common_height);
+    let child_level = control_level + 1;
+    let mut table = Vec::with_capacity(24);
+    table.extend_from_slice(&0x0400_0006u32.to_le_bytes());
+    table.extend_from_slice(&1u16.to_le_bytes());
+    table.extend_from_slice(&1u16.to_le_bytes());
+    table.extend_from_slice(&0u16.to_le_bytes());
+    for padding in [510i16, 510, 141, 141] {
+        table.extend_from_slice(&padding.to_le_bytes());
+    }
+    table.extend_from_slice(&1u16.to_le_bytes());
+    table.extend_from_slice(&1u16.to_le_bytes());
+    table.extend_from_slice(&0u16.to_le_bytes());
+    push_record(out, TAG_TABLE, child_level, &table);
+
+    let mut cell = Vec::with_capacity(47);
+    cell.extend_from_slice(&1u16.to_le_bytes());
+    cell.extend_from_slice(&0x0020_0000u32.to_le_bytes());
+    cell.extend_from_slice(&0x0500u16.to_le_bytes());
+    for value in [0u16, 0, 1, 1] {
+        cell.extend_from_slice(&value.to_le_bytes());
+    }
+    cell.extend_from_slice(&width.to_le_bytes());
+    cell.extend_from_slice(&cell_height.to_le_bytes());
+    for padding in [510i16, 510, 141, 141] {
+        cell.extend_from_slice(&padding.to_le_bytes());
+    }
+    cell.extend_from_slice(&1u16.to_le_bytes());
+    cell.extend_from_slice(&width.to_le_bytes());
+    cell.extend([0; 9]);
+    push_record(out, TAG_LIST_HEADER, child_level, &cell);
+
+    push_para_header_at_level(out, child_level, 2, 0, 1, 0, 0);
+    push_record(
+        out,
+        TAG_PARA_TEXT,
+        child_level + 1,
+        &utf16_bytes(&['N' as u16, 0x000d]),
+    );
+    push_record(
+        out,
+        TAG_PARA_CHAR_SHAPE,
+        child_level + 1,
+        &shape_refs(&[(0, 0)]),
+    );
 }
 
 fn push_nested_one_by_one(out: &mut Vec<u8>, control_level: u16, carries_deeper: bool) {

--- a/crates/hwp-hwp5/tests/public_probe.rs
+++ b/crates/hwp-hwp5/tests/public_probe.rs
@@ -28,27 +28,27 @@ fn public_hwp5_has_bounded_content_free_record_provenance() {
 }
 
 #[test]
-fn explicit_own_parser_owns_bounded_nested_table_then_stops_content_free() {
+fn explicit_own_parser_owns_bounded_eight_by_five_table_then_stops_content_free() {
     let probed = probe(&benchmark()).unwrap();
     let next = probed
         .streams
         .iter()
         .flat_map(|stream| &stream.records)
-        .find(|record| record.head == 13_704)
+        .find(|record| record.head == 21_538)
         .unwrap();
     assert_eq!(
         (next.tag, next.level, next.head, next.data, next.end, next.size,),
-        (0x4d, 2, 13_704, 13_708, 13_746, 38)
+        (0x47, 1, 21_538, 21_542, 21_588, 46)
     );
     let error = OwnHwp5Parser::new().parse(&benchmark()).unwrap_err();
     eprintln!("{error:?}");
     assert!(matches!(
         error,
         Error::MalformedRecord {
-            tag: 0x4d,
+            tag: 0x47,
             section: Some(0),
-            offset: 13704,
-            reason: "TABLE attributes or row/column topology are not owned",
+            offset: 21538,
+            reason: "inline table common-object attributes are not owned",
             ..
         }
     ));

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -62,7 +62,9 @@
   Vitest **1,018**까지 green이고 sandbox port EPERM만 허용된 로컬 서버에서 분리한 Chromium도
   **85 pass/3 intentional skip/0 fail**이다. 임시 dependency link를 모두 제거했으며 production
   route·HWPX parser/serializer·shared typesetter·`external/rhwp`·generated asset diff 0을 재확인했다.
-  **다음:** security/diff→commit/push/PR #178→required CI·자율 병합→#94 동기화와 next boundary child.
+  final security/diff review도 source content/path/hash/raw payload/credential 노출 0이며 구현 commit
+  `28d1c55`을 push하고 PR #179를 `Closes #178`로 게시했다. **다음:** PR checkpoint push→exact-head
+  required CI·댓글·mergeability 추적→green 자율 병합→#94 동기화와 next boundary child.
 
 - 갱신: 2026-08-24 · Codex(sol) — **PR #173 병합 · #174 multi-table 경계 착수**.
   자체 HWP5 파서가 exact `tbl ` marker/common-object/TABLE/LIST_HEADER/cell paragraph를 검증해

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,7 +3,7 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
-- 갱신: 2026-08-24 · Codex(sol) — **#176 nested TABLE 구현·전체 검증 완료**.
+- 갱신: 2026-08-24 · Codex(sol) — **PR #177 병합 · #178 next 8×5 TABLE 착수**.
   #175는 exact head `6711ff9`에서 issue-link/build-test/licenses green, CLEAN/MERGEABLE,
   review/general/inline 댓글 0을 확인하고 protected main `c917c584`로 squash 병합했다. #174 close와
   원격 branch 정리 후 #94에 bounded two-table host 소유 근거를 동기화했다. 월요일 #114 감사에서
@@ -27,8 +27,42 @@
   **85 pass/3 intentional skip/0 fail**이다. 임시 dependency link는 제거했고 production route·
   HWPX parser/serializer·shared typesetter·`external/rhwp`·generated asset diff 0, 공개 금지 원문·
   경로·hash·raw payload·credential diff 0을 확인했다. 구현은 commit `52e9fc6`으로 push했고 PR #177을
-  `Closes #176`으로 게시했다. **다음:** required CI·댓글 확인→자율 병합→#94 동기화→다음 TABLE
-  `13704..13746` classification-first child.
+  `Closes #176`으로 게시했다. exact head `e3199a7`에서 issue-link **2s**·build-test **9m12s**·licenses
+  **2m52s** green, MERGEABLE, review/general/inline 댓글 0을 확인하고 protected main `aa7a23f7`로
+  squash 병합했다. #176 close·원격 branch 정리 후 #94에 근거를 동기화하고, 중복 없는 #178을
+  R18/P1/area:hwp5/status:ready로 열었다. exact latest main의
+  `codex/issue-178-hwp5-next-table` worktree와 pinned rhwp oracle을 초기화했다. **다음:** content-free
+  TABLE `0x4d/13704..13746`의 exact flag/topology/geometry/nesting을 먼저 분류→shared IR이 모든 active
+  semantics를 faithful하게 표현할 때만 synthetic/hostile fixture와 strict parser 구현. production route·
+  HWPX·shared layout·generated assets·rhwp는 불변. 1차 분류 결과 attr exact `0x0600000e`, 8×5,
+  active cells **19**, row counts `4/2/2/2/2/2/3/2`, horizontal merges + `(row6,col0)`의 2-row
+  merge, depth-1 1×1 nested table **9개**다. row-span 1 cells가 도출한 높이
+  `5012/7339/10169×4/11921/1848`은 object height **66796**과 정확히 같고 spanning cell height도
+  마지막 두 행 합과 같다. 모든 셀의 stored width는 shared `Cell.width` ragged-row lane으로 보존 가능;
+  row6 마지막 cell의 legacy 13B extension만 core width와 다르며 아래 row/grid width와 일치하므로
+  extension을 geometry로 오인하지 않고 exact bounded discriminator로 다뤄야 한다. low attr=2는 로컬
+  공식 rev1.3 표기와 pinned rhwp의 RowBreak 해석이 충돌하므로 현 shared pagination 의미로 섣불리
+  확정하지 않는다. 다만 repeat-header bit는 active header cell이 없어 inert하고 no-adjust는 exact row
+  heights로 표현 가능하다. one-shot numeric classifier는 제거했다. **다음:** exact topology/
+  width-ref/extension/nested-position synthetic+hostile fixture→strict parser; row-span height constraints와
+  ragged `Cell.width`를 보존하고 global column widths는 기존 lift와 동일한 bounded derivation만 사용.
+  첫 own parse는 top-level을 통과해 nested 1×1 geometry까지 전진했다. 9개 중 7개는 common/cell
+  height가 exact하고, 첫 행의 좁은 2개만 stale common **3882** 대 cell **1848**이다. 폭/extension은
+  전부 일치하고 다른 framing도 같으므로 depth-1 exact height pair만 bounded legacy exception으로
+  소유하며 cell height를 shared IR geometry로 보존한다. 추가 one-shot classifier도 제거했다.
+  strict parser와 합성 회귀를 구현해 exact width-ref pattern, 19-cell row-major span, layout-width
+  override delta, row-span height 합, 9개 nested 위치/개수, 2개 stale common-height pair를 검증한다.
+  13B override를 authoritative `Cell.width=20279`로 내리면 span equations가 5개 열
+  `7667/16324/3879/3955/16324`를 유일하게 복원하고 모든 행 effective width가 object **48149**와
+  일치한다. attr/count/rowspan/delta/width-ref/nested missing·wrong-position/stale-height hostile 8축은
+  fail-closed. HWP5 **59 tests**, fmt, clippy `-D warnings`, wasm32 green이며 public boundary는 다음
+  `CTRL_HEADER 0x47/21538..21588`의 unowned common-object attr로 전진했다. quick의 Rust workspace,
+  PDF visual **51**, canonical **8/18/24·98.9%+**, public corpus **84**, oracle **82**, HWPX,
+  wasm/licenses가 green이다. full은 wasm 재빌드 **7,810,657B**, JS build·crosscheck·i18n,
+  Vitest **1,018**까지 green이고 sandbox port EPERM만 허용된 로컬 서버에서 분리한 Chromium도
+  **85 pass/3 intentional skip/0 fail**이다. 임시 dependency link를 모두 제거했으며 production
+  route·HWPX parser/serializer·shared typesetter·`external/rhwp`·generated asset diff 0을 재확인했다.
+  **다음:** security/diff→commit/push/PR #178→required CI·자율 병합→#94 동기화와 next boundary child.
 
 - 갱신: 2026-08-24 · Codex(sol) — **PR #173 병합 · #174 multi-table 경계 착수**.
   자체 HWP5 파서가 exact `tbl ` marker/common-object/TABLE/LIST_HEADER/cell paragraph를 검증해

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,11 @@
 
 ---
 
+## 2026-08-24 (Codex sol) · #178 PR #179 게시
+- strict 8×5 implementation `28d1c55` push, PR #179(`Closes #178`) 생성.
+- full/Vitest 1,018/Chromium 85·3, route/rhwp/HWPX/generated 불변을 공개 검증에 명시.
+- 다음 exact-head required CI·댓글 추적→green 자율 병합→next boundary.
+
 ## 2026-08-24 (Codex sol) · #178 full green / PR ready
 - quick/full Rust·PDF51·canonical·corpus84·oracle82·HWPX·wasm/JS + Vitest 1,018 green.
 - 허용된 로컬 서버 Chromium 85 pass/3 intentional skip/0 fail; 임시 link 제거.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,26 @@
 
 ---
 
+## 2026-08-24 (Codex sol) · #178 full green / PR ready
+- quick/full Rust·PDF51·canonical·corpus84·oracle82·HWPX·wasm/JS + Vitest 1,018 green.
+- 허용된 로컬 서버 Chromium 85 pass/3 intentional skip/0 fail; 임시 link 제거.
+- route/rhwp/HWPX/generated diff 0. 다음 commit/push/PR→CI/merge→next boundary.
+
+## 2026-08-24 (Codex sol) · #178 focused green
+- strict 8×5/19 cells + rowspan + nested 9; stale extension width를 own geometry로 복원.
+- hostile 8축, HWP5 59/clippy/wasm32 green; next CTRL_HEADER 21538..21588.
+- route/rhwp/HWPX/generated 불변. 다음 quick→full→PR/CI/merge.
+
+## 2026-08-24 (Codex sol) · #178 content-free classified
+- exact 8×5/19 cells, row-span 1개, depth-1 nested 1×1 9개; active topology bounded.
+- row heights sum 66796 exact; ragged stored widths fit Cell.width, one legacy extension differs.
+- one-shot classifier removed. 다음 strict synthetic/hostile→parser; route/rhwp/HWPX 불변.
+
+## 2026-08-24 (Codex sol) · PR #177 merged / #178 started
+- #177 required CI·MERGEABLE·댓글 0 후 main `aa7a23f7`; #176 close·branch 정리.
+- #94 동기화, 중복 없는 8×5 TABLE #178 등록, exact-main worktree 시작.
+- next `13704..13746` content-free classification; route/rhwp/HWPX 불변.
+
 ## 2026-08-24 (Codex sol) · #176 PR #177 게시
 - bounded nested TABLE commit `52e9fc6` push, PR #177(`Closes #176`) 생성.
 - full/Vitest 1,018/Chromium 85·3, route/rhwp/HWPX/generated 불변을 공개 검증에 명시.


### PR DESCRIPTION
Closes #178

Refs #94, #176, #177

## What changed

- own the next exact 8×5 HWP5 TABLE topology as shared `Table`/`Cell` IR
- preserve its 19 active cells, horizontal merges, one two-row span, fixed row heights, and nine bounded depth-1 nested 1×1 tables
- treat the exact 13-byte layout-width mirror as authoritative for one bounded stale-core-width slot only after the global span equations prove the resulting five-column geometry
- advance the content-free public own-parser boundary to the next unsupported common-object control
- add a positive synthetic fixture plus eight hostile mutation axes for topology, width references, layout-width delta, rowspan, and nested-table placement/framing

## Safety and architecture

- fail closed outside the exact observed topology and numeric constraints
- production HWP route remains unchanged
- HWPX parser/serializer and shared typesetter remain unchanged
- `external/rhwp` remains pinned and unmodified; it is still a read-only parsing oracle, not the renderer
- no source document content, private path, hash, or raw payload is published

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy -p hwp-hwp5 --all-targets -- -D warnings`
- `cargo check -p hwp-hwp5 --target wasm32-unknown-unknown`
- `cargo test -p hwp-hwp5` — 59 passed
- `scripts/verify-local.sh` — Rust workspace, PDF visual 51, canonical 8/18/24 and 98.9%+, public corpus 84, oracle 82, HWPX, wasm, licenses green
- `scripts/verify-local.sh --full` — wasm 7,810,657 bytes; JS build/crosscheck/i18n; Vitest 1,018 green
- `npm run test:e2e` — Chromium 85 passed, 3 intentional skips, 0 failed
- generated assets, production route, HWPX, shared typesetter, and `external/rhwp`: diff 0
