### PR TITLE
feat(hwp5): own exact column-relative 1x2 table

### DIFF
--- a/crates/hwp-hwp5/src/semantic.rs
+++ b/crates/hwp-hwp5/src/semantic.rs
@@ -1591,9 +1591,12 @@ fn parse_inline_table(
             "inline table CTRL_HEADER is not the owned 46-byte record",
         ));
     }
-    // Observed public slice: treat-as-char, para-relative inline placement, top-and-bottom wrapping,
-    // and the known storage high bit. Exact matching prevents a floating object from being flattened.
-    if read_u32(common, 4) != Some(0x082a_2311) {
+    // Observed public slices are treat-as-char, top-and-bottom objects with absolute dimensions and
+    // the known table-numbering high bit. Most store para-relative horizontal placement; one exact
+    // 1×2 form stores column-relative placement. The table tuple below binds each flag word to only
+    // its observed topology so a floating or unrelated object cannot be flattened.
+    let common_attr = read_u32(common, 4).expect("exact length checked");
+    if !matches!(common_attr, 0x082a_2311 | 0x082a_2211) {
         return Err(malformed(
             control,
             Some(section),
@@ -1654,9 +1657,12 @@ fn parse_inline_table(
     let rows = read_u16(table_bytes, 4).expect("minimum length checked") as usize;
     let cols = read_u16(table_bytes, 6).expect("minimum length checked") as usize;
     let table_attr = read_u32(table_bytes, 0).expect("minimum length checked");
-    let expected_positions = match (table_attr, rows, cols) {
-        (0x0400_0006, 1, 1) => vec![(0, 0, 1, 1)],
-        (0x0400_0006, 10, 2) => (0..10)
+    let expected_positions = match (common_attr, table_attr, rows, cols) {
+        (0x082a_2311, 0x0400_0006, 1, 1) => vec![(0, 0, 1, 1)],
+        (0x082a_2211, 0x0400_0004, 1, 2) => {
+            vec![(0, 0, 1, 1), (0, 1, 1, 1)]
+        }
+        (0x082a_2311, 0x0400_0006, 10, 2) => (0..10)
             .flat_map(|row| {
                 if matches!(row, 0 | 1 | 5) {
                     vec![(row, 0, 2, 1)]
@@ -1665,7 +1671,7 @@ fn parse_inline_table(
                 }
             })
             .collect(),
-        (0x0600_000c, 9, 8) => vec![
+        (0x082a_2311, 0x0600_000c, 9, 8) => vec![
             (0, 0, 3, 1),
             (0, 3, 5, 1),
             (1, 0, 3, 1),
@@ -1701,7 +1707,7 @@ fn parse_inline_table(
             (8, 4, 3, 1),
             (8, 7, 1, 1),
         ],
-        (0x0600_000e, 8, 5) => vec![
+        (0x082a_2311, 0x0600_000e, 8, 5) => vec![
             (0, 0, 1, 1),
             (0, 1, 1, 1),
             (0, 2, 2, 1),
@@ -1841,18 +1847,31 @@ fn parse_inline_table(
         let row_span = read_u16(list_bytes, 14).expect("exact length checked") as usize;
         let cell_width = read_u32(list_bytes, 16).expect("exact length checked");
         let cell_height = read_u32(list_bytes, 20).expect("exact length checked");
-        let expected_eight_by_five_width_ref = if (table_attr, rows, cols) == (0x0600_000e, 8, 5) {
-            Some(if row == 0 {
-                0x0100
-            } else if (row, col, col_span, row_span) == (6, 1, 2, 1) {
-                0x0400
+        let expected_one_by_two_width_ref =
+            if (common_attr, table_attr, rows, cols) == (0x082a_2211, 0x0400_0004, 1, 2) {
+                Some(if (row, col, col_span, row_span) == (0, 0, 1, 1) {
+                    0x0500
+                } else {
+                    0x0000
+                })
             } else {
-                0x0000
-            })
-        } else {
-            None
-        };
-        let owned_width_ref = expected_eight_by_five_width_ref.map_or_else(
+                None
+            };
+        let expected_eight_by_five_width_ref =
+            if (common_attr, table_attr, rows, cols) == (0x082a_2311, 0x0600_000e, 8, 5) {
+                Some(if row == 0 {
+                    0x0100
+                } else if (row, col, col_span, row_span) == (6, 1, 2, 1) {
+                    0x0400
+                } else {
+                    0x0000
+                })
+            } else {
+                None
+            };
+        let expected_exact_width_ref =
+            expected_one_by_two_width_ref.or(expected_eight_by_five_width_ref);
+        let owned_width_ref = expected_exact_width_ref.map_or_else(
             || {
                 matches!(width_ref, 0x0000 | 0x0100 | 0x0500)
                     || (width_ref == 0x0501 && (rows, cols) == (1, 1))
@@ -1863,7 +1882,7 @@ fn parse_inline_table(
             return Err(malformed(
                 &list_record,
                 Some(section),
-                if expected_eight_by_five_width_ref.is_some() {
+                if expected_exact_width_ref.is_some() {
                     "cell LIST_HEADER width reference differs from its exact owned topology"
                 } else {
                     "cell LIST_HEADER count, direction, alignment, or width reference is not owned"

--- a/crates/hwp-hwp5/tests/layout_semantic.rs
+++ b/crates/hwp-hwp5/tests/layout_semantic.rs
@@ -111,6 +111,18 @@ enum EightByFiveMutation {
     BadStaleNestedHeight,
 }
 
+#[derive(Clone, Copy)]
+enum OneByTwoMutation {
+    None,
+    BadCommonAttribute,
+    BadTableAttribute,
+    BadRowCellCount,
+    BadWidth,
+    BadWidthReference,
+    BadCellOrder,
+    BadListExtension,
+}
+
 #[test]
 fn parses_page_setup_and_blank_source_line_metrics() {
     let doc = OwnHwp5Parser::new()
@@ -810,6 +822,51 @@ fn strict_eight_by_five_slice_rejects_hostile_topology_widths_and_nesting() {
     }
 }
 
+#[test]
+fn owns_exact_column_relative_one_by_two_header_table() {
+    let doc = OwnHwp5Parser::new()
+        .parse(&one_by_two_fixture(OneByTwoMutation::None))
+        .expect("strict column-relative 1x2 table fixture parses");
+    let [Block::Paragraph(anchor), Block::Table(table)] = doc.sections[0].blocks.as_slice() else {
+        panic!("table host must lower to one anchor and one table")
+    };
+    assert!(anchor.is_table_anchor);
+    assert_eq!((table.rows, table.cols, table.cells.len()), (1, 2, 2));
+    assert!(table.keep_together, "no-split one-row table stays atomic");
+    assert!(!table.fixed_row_heights);
+    assert_eq!(table.col_widths, vec![39_903, 2_261]);
+    assert_eq!(table.row_heights, vec![3_005]);
+    assert_eq!(table.padding, Some([140, 140, 140, 140]));
+    assert_eq!(
+        table
+            .cells
+            .iter()
+            .map(|cell| (cell.row, cell.col, cell.width))
+            .collect::<Vec<_>>(),
+        vec![(0, 0, Some(39_903)), (0, 1, Some(2_261))]
+    );
+}
+
+#[test]
+fn strict_one_by_two_slice_rejects_hostile_flags_topology_widths_and_extensions() {
+    for mutation in [
+        OneByTwoMutation::BadCommonAttribute,
+        OneByTwoMutation::BadTableAttribute,
+        OneByTwoMutation::BadRowCellCount,
+        OneByTwoMutation::BadWidth,
+        OneByTwoMutation::BadWidthReference,
+        OneByTwoMutation::BadCellOrder,
+        OneByTwoMutation::BadListExtension,
+    ] {
+        assert!(
+            OwnHwp5Parser::new()
+                .parse(&one_by_two_fixture(mutation))
+                .is_err(),
+            "hostile 1x2 mutation must fail closed"
+        );
+    }
+}
+
 fn fixture(mutation: Mutation) -> Vec<u8> {
     let mut header = vec![0; 256];
     header[..HWP_SIGNATURE.len()].copy_from_slice(HWP_SIGNATURE);
@@ -1478,6 +1535,155 @@ fn fixture(mutation: Mutation) -> Vec<u8> {
         Mutation::PageNumberMultiSection | Mutation::NewNumberMultiSection
     ) {
         let mut stream = compound.create_stream("/BodyText/Section1").unwrap();
+        stream.write_all(&body).unwrap();
+    }
+    compound.into_inner().into_inner()
+}
+
+fn one_by_two_fixture(mutation: OneByTwoMutation) -> Vec<u8> {
+    let mut header = vec![0; 256];
+    header[..HWP_SIGNATURE.len()].copy_from_slice(HWP_SIGNATURE);
+    header[32..36].copy_from_slice(&[0, 0, 0, 5]);
+
+    let mut doc_info = Vec::new();
+    let mut properties = vec![0; 26];
+    properties[..2].copy_from_slice(&1u16.to_le_bytes());
+    push_record(&mut doc_info, TAG_DOCUMENT_PROPERTIES, 0, &properties);
+    let mut mappings = Vec::new();
+    for count in [0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 1, 0] {
+        mappings.extend_from_slice(&(count as u32).to_le_bytes());
+    }
+    push_record(&mut doc_info, TAG_ID_MAPPINGS, 0, &mappings);
+    for _ in 0..7 {
+        push_record(&mut doc_info, TAG_FACE_NAME, 0, &face_name("Test Sans"));
+    }
+    push_record(&mut doc_info, TAG_BORDER_FILL, 0, &solid_border_fill());
+    push_record(&mut doc_info, TAG_CHAR_SHAPE, 0, &char_shape());
+    push_record(&mut doc_info, TAG_PARA_SHAPE, 0, &para_shape());
+
+    let mut body = Vec::new();
+    let mut host_text = extended_control(0x0002, CTRL_SECTION_DEF);
+    host_text.extend(extended_control(0x000b, CTRL_TABLE));
+    host_text.push(0x000d);
+    push_para_header_with_break(
+        &mut body,
+        host_text.len() as u32,
+        (1 << 2) | (1 << 0x000b),
+        1,
+        0,
+        0x01,
+    );
+    push_record(&mut body, TAG_PARA_TEXT, 1, &utf16_bytes(&host_text));
+    push_record(&mut body, TAG_PARA_CHAR_SHAPE, 1, &shape_refs(&[(0, 0)]));
+
+    let mut section_control = Vec::with_capacity(28);
+    section_control.extend_from_slice(&CTRL_SECTION_DEF.to_le_bytes());
+    section_control.extend([0; 24]);
+    push_record(&mut body, TAG_CTRL_HEADER, 1, &section_control);
+    push_record(&mut body, TAG_PAGE_DEF, 2, &page_def(Mutation::None));
+
+    let mut common = Vec::with_capacity(46);
+    common.extend_from_slice(&CTRL_TABLE.to_le_bytes());
+    common.extend_from_slice(
+        &if matches!(mutation, OneByTwoMutation::BadCommonAttribute) {
+            0x082a_2311u32
+        } else {
+            0x082a_2211
+        }
+        .to_le_bytes(),
+    );
+    common.extend_from_slice(&0u32.to_le_bytes());
+    common.extend_from_slice(&0u32.to_le_bytes());
+    common.extend_from_slice(&42_164u32.to_le_bytes());
+    common.extend_from_slice(&3_005u32.to_le_bytes());
+    common.extend_from_slice(&0i32.to_le_bytes());
+    for margin in [140i16, 140, 140, 140] {
+        common.extend_from_slice(&margin.to_le_bytes());
+    }
+    common.extend_from_slice(&1u32.to_le_bytes());
+    common.extend_from_slice(&0i32.to_le_bytes());
+    common.extend_from_slice(&0u16.to_le_bytes());
+    push_record(&mut body, TAG_CTRL_HEADER, 1, &common);
+
+    let mut table = Vec::with_capacity(24);
+    table.extend_from_slice(
+        &if matches!(mutation, OneByTwoMutation::BadTableAttribute) {
+            0x0400_0006u32
+        } else {
+            0x0400_0004
+        }
+        .to_le_bytes(),
+    );
+    table.extend_from_slice(&1u16.to_le_bytes());
+    table.extend_from_slice(&2u16.to_le_bytes());
+    table.extend_from_slice(&0u16.to_le_bytes());
+    for padding in [140i16, 140, 140, 140] {
+        table.extend_from_slice(&padding.to_le_bytes());
+    }
+    table.extend_from_slice(
+        &if matches!(mutation, OneByTwoMutation::BadRowCellCount) {
+            1u16
+        } else {
+            2
+        }
+        .to_le_bytes(),
+    );
+    table.extend_from_slice(&1u16.to_le_bytes());
+    table.extend_from_slice(&0u16.to_le_bytes());
+    push_record(&mut body, TAG_TABLE, 2, &table);
+
+    let mut cells = vec![(0u16, 39_903u32, 0x0500u16), (1, 2_261, 0)];
+    if matches!(mutation, OneByTwoMutation::BadCellOrder) {
+        cells.swap(0, 1);
+    }
+    for (index, (col, mut width, mut width_ref)) in cells.into_iter().enumerate() {
+        if index == 0 && matches!(mutation, OneByTwoMutation::BadWidth) {
+            width -= 1;
+        }
+        if index == 0 && matches!(mutation, OneByTwoMutation::BadWidthReference) {
+            width_ref = 0;
+        }
+        let mut cell = Vec::with_capacity(47);
+        cell.extend_from_slice(&1u16.to_le_bytes());
+        cell.extend_from_slice(&0x0020_0000u32.to_le_bytes());
+        cell.extend_from_slice(&width_ref.to_le_bytes());
+        for value in [col, 0, 1, 1] {
+            cell.extend_from_slice(&value.to_le_bytes());
+        }
+        cell.extend_from_slice(&width.to_le_bytes());
+        cell.extend_from_slice(&3_005u32.to_le_bytes());
+        for padding in [141i16, 141, 141, 141] {
+            cell.extend_from_slice(&padding.to_le_bytes());
+        }
+        cell.extend_from_slice(&1u16.to_le_bytes());
+        cell.extend_from_slice(&width.to_le_bytes());
+        cell.extend([0; 9]);
+        if index == 0 && matches!(mutation, OneByTwoMutation::BadListExtension) {
+            cell[38] = 1;
+        }
+        push_record(&mut body, TAG_LIST_HEADER, 2, &cell);
+        push_para_header_at_level(&mut body, 2, 2, 0, 1, 0, 0);
+        push_record(
+            &mut body,
+            TAG_PARA_TEXT,
+            3,
+            &utf16_bytes(&[u16::from(b'A') + index as u16, 0x000d]),
+        );
+        push_record(&mut body, TAG_PARA_CHAR_SHAPE, 3, &shape_refs(&[(0, 0)]));
+    }
+
+    let mut compound = CompoundFile::create(Cursor::new(Vec::new())).unwrap();
+    {
+        let mut stream = compound.create_stream("/FileHeader").unwrap();
+        stream.write_all(&header).unwrap();
+    }
+    {
+        let mut stream = compound.create_stream("/DocInfo").unwrap();
+        stream.write_all(&doc_info).unwrap();
+    }
+    compound.create_storage("/BodyText").unwrap();
+    {
+        let mut stream = compound.create_stream("/BodyText/Section0").unwrap();
         stream.write_all(&body).unwrap();
     }
     compound.into_inner().into_inner()

--- a/crates/hwp-hwp5/tests/public_probe.rs
+++ b/crates/hwp-hwp5/tests/public_probe.rs
@@ -28,27 +28,27 @@ fn public_hwp5_has_bounded_content_free_record_provenance() {
 }
 
 #[test]
-fn explicit_own_parser_owns_bounded_eight_by_five_table_then_stops_content_free() {
+fn explicit_own_parser_owns_bounded_one_by_two_table_then_stops_content_free() {
     let probed = probe(&benchmark()).unwrap();
     let next = probed
         .streams
         .iter()
         .flat_map(|stream| &stream.records)
-        .find(|record| record.head == 21_538)
+        .find(|record| record.head == 25_952)
         .unwrap();
     assert_eq!(
         (next.tag, next.level, next.head, next.data, next.end, next.size,),
-        (0x47, 1, 21_538, 21_542, 21_588, 46)
+        (0x4d, 2, 25_952, 25_956, 25_990, 34)
     );
     let error = OwnHwp5Parser::new().parse(&benchmark()).unwrap_err();
     eprintln!("{error:?}");
     assert!(matches!(
         error,
         Error::MalformedRecord {
-            tag: 0x47,
+            tag: 0x4d,
             section: Some(0),
-            offset: 21538,
-            reason: "inline table common-object attributes are not owned",
+            offset: 25952,
+            reason: "TABLE attributes or row/column topology are not owned",
             ..
         }
     ));

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,7 +3,7 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
-- 갱신: 2026-08-24 · Codex(sol) — **PR #177 병합 · #178 next 8×5 TABLE 착수**.
+- 갱신: 2026-08-24 · Codex(sol) — **PR #179 병합 · #180 next common-object 착수**.
   #175는 exact head `6711ff9`에서 issue-link/build-test/licenses green, CLEAN/MERGEABLE,
   review/general/inline 댓글 0을 확인하고 protected main `c917c584`로 squash 병합했다. #174 close와
   원격 branch 정리 후 #94에 bounded two-table host 소유 근거를 동기화했다. 월요일 #114 감사에서
@@ -63,8 +63,31 @@
   **85 pass/3 intentional skip/0 fail**이다. 임시 dependency link를 모두 제거했으며 production
   route·HWPX parser/serializer·shared typesetter·`external/rhwp`·generated asset diff 0을 재확인했다.
   final security/diff review도 source content/path/hash/raw payload/credential 노출 0이며 구현 commit
-  `28d1c55`을 push하고 PR #179를 `Closes #178`로 게시했다. **다음:** PR checkpoint push→exact-head
-  required CI·댓글·mergeability 추적→green 자율 병합→#94 동기화와 next boundary child.
+  `28d1c55`을 push하고 PR #179를 `Closes #178`로 게시했다. exact head `4b999b1`에서 issue-link
+  **5s**·build-test **9m08s**·licenses **2m18s** green, CLEAN/MERGEABLE, review/general/inline
+  댓글 0을 확인하고 protected main `22b6979a`로 squash 병합했다. #178 close·원격 branch 정리 후
+  #94에 근거를 동기화하고 중복 없는 #180을 R18/P1/area:hwp5/status:ready로 열었다. exact latest
+  main의 `codex/issue-180-hwp5-common-object` worktree와 pinned rhwp oracle을 초기화했다. **다음:**
+  content-free `CTRL_HEADER 0x47/21538..21588`의 common-object flags·child topology를 분류하고,
+  shared IR/SVG/PDF가 active semantics를 모두 표현할 때만 strict synthetic/hostile slice를 구현.
+  production route·HWPX·shared layout defaults·generated assets·rhwp는 불변. 분류 결과 common attr
+  exact `0x082a2211`은 기존 owned inline table의 `0x082a2311`과 horizontal relative 기준만
+  column/paragraph로 다르고 treat-as-char·top-and-bottom·absolute size·zero offsets는 같다. child는
+  exact TABLE `0x04000004`, 1×2/2 active cells, no-split + repeat-header이며 첫 셀만 header flag다.
+  단일 행 전체가 atomic이라 반복 의미는 비활성이고 shared IR로 손실 없이 표현 가능하다. 폭
+  `39903+2261=42164`, 양 cell height와 object height **3005**, mirrored 13B extension, padding·border
+  refs가 모두 일치한다. common/table pair를 함께 exact match하고 첫/둘째 width-ref를 `0x0500/0`으로
+  고정했다. common attr/table attr/row count/width/width-ref/order/extension hostile **7축**은
+  fail-closed. one-shot classifier는 제거했다. HWP5 **61 tests**, fmt, clippy `-D warnings`, wasm32
+  green이며 public boundary는 다음 TABLE `0x4d/25952..25990`의 unowned topology로 전진했다.
+  quick의 Rust workspace, PDF visual **51**, canonical **8/18/24·98.9%+**, public corpus **84**,
+  oracle **82**, HWPX, wasm/licenses가 green이다. full도 wasm 재빌드 **7,810,657B**, JS
+  build·crosscheck·i18n, Vitest **1,018**까지 green이고 sandbox port EPERM만 허용된 로컬 서버에서
+  분리한 Chromium **85 pass/3 intentional skip/0 fail**이다. 임시 dependency link를 제거했고
+  production route·rhwp·HWPX parser/serializer·shared typesetter·generated asset diff 0을 확인했다.
+  final security/diff review도 source content/path/hash/raw payload/credential 노출 0, silent fallback 0,
+  변경 파일은 parser/tests/state 5개뿐이다. **다음:** commit/push/PR #180→required CI·자율 병합→
+  #94 동기화와 next child.
 
 - 갱신: 2026-08-24 · Codex(sol) — **PR #173 병합 · #174 multi-table 경계 착수**.
   자체 HWP5 파서가 exact `tbl ` marker/common-object/TABLE/LIST_HEADER/cell paragraph를 검증해

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,7 +3,7 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
-- 갱신: 2026-08-24 · Codex(sol) — **PR #179 병합 · #180 next common-object 착수**.
+- 갱신: 2026-08-24 · Codex(sol) — **PR #181 게시 · #180 CI 추적 중**.
   #175는 exact head `6711ff9`에서 issue-link/build-test/licenses green, CLEAN/MERGEABLE,
   review/general/inline 댓글 0을 확인하고 protected main `c917c584`로 squash 병합했다. #174 close와
   원격 branch 정리 후 #94에 bounded two-table host 소유 근거를 동기화했다. 월요일 #114 감사에서
@@ -86,8 +86,10 @@
   분리한 Chromium **85 pass/3 intentional skip/0 fail**이다. 임시 dependency link를 제거했고
   production route·rhwp·HWPX parser/serializer·shared typesetter·generated asset diff 0을 확인했다.
   final security/diff review도 source content/path/hash/raw payload/credential 노출 0, silent fallback 0,
-  변경 파일은 parser/tests/state 5개뿐이다. **다음:** commit/push/PR #180→required CI·자율 병합→
-  #94 동기화와 next child.
+  변경 파일은 parser/tests/state 5개뿐이다. 구현 commit `c64bbf3`을 push하고 PR #181을
+  `Closes #180`으로 게시했다. exact head `c64bbf3217dbf48f5800e52fdec2476484a56edb`는
+  MERGEABLE, review/general 댓글 0이며 issue-link green, build-test/licenses 진행 중이다. **다음:**
+  exact-head required CI와 inline 댓글까지 추적→green 자율 병합→#94 동기화와 next child.
 
 - 갱신: 2026-08-24 · Codex(sol) — **PR #173 병합 · #174 multi-table 경계 착수**.
   자체 HWP5 파서가 exact `tbl ` marker/common-object/TABLE/LIST_HEADER/cell paragraph를 검증해

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,21 @@
 
 ---
 
+## 2026-08-24 (Codex sol) · #180 full green / PR ready
+- quick/full Rust·PDF51·canonical·corpus84·oracle82·HWPX·wasm/JS + Vitest 1,018 green.
+- 허용된 로컬 서버 Chromium 85 pass/3 intentional skip/0 fail; 임시 link 제거.
+- route/rhwp/HWPX/generated diff 0. 다음 commit/push/PR→CI/merge→next child.
+
+## 2026-08-24 (Codex sol) · #180 classified / focused green
+- exact column-relative 1×2/2 cells; one-row no-split makes repeat-header inert and faithfully owned.
+- hostile 7축, HWP5 61/clippy/wasm32 green; next TABLE 25952..25990.
+- one-shot classifier removed; route/rhwp/HWPX/generated 불변. 다음 quick→full→PR/CI/merge.
+
+## 2026-08-24 (Codex sol) · PR #179 merged / #180 started
+- #179 required CI·CLEAN/MERGEABLE·댓글 0 후 main `22b6979a`; #178 close·branch 정리.
+- #94 동기화, next common-object boundary #180 등록, exact-main worktree 시작.
+- `0x47/21538..21588` content-free classification; route/rhwp/HWPX 불변.
+
 ## 2026-08-24 (Codex sol) · #178 PR #179 게시
 - strict 8×5 implementation `28d1c55` push, PR #179(`Closes #178`) 생성.
 - full/Vitest 1,018/Chromium 85·3, route/rhwp/HWPX/generated 불변을 공개 검증에 명시.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,11 @@
 
 ---
 
+## 2026-08-24 (Codex sol) · #180 PR #181 게시
+- exact parser/test/state commit `c64bbf3` push, PR #181(`Closes #180`) 생성.
+- exact head `c64bbf3217dbf48f5800e52fdec2476484a56edb`, MERGEABLE, issue-link green.
+- build-test/licenses·inline 댓글 추적→green 자율 병합→#94/next child.
+
 ## 2026-08-24 (Codex sol) · #180 full green / PR ready
 - quick/full Rust·PDF51·canonical·corpus84·oracle82·HWPX·wasm/JS + Vitest 1,018 green.
 - 허용된 로컬 서버 Chromium 85 pass/3 intentional skip/0 fail; 임시 link 제거.


### PR DESCRIPTION
Closes #180

Refs #94 #178 #179

## What changed

- Own the next content-free HWP5 common-object/table boundary as one exact pair:
  - common-object attribute `0x082a2211`
  - table attribute `0x04000004`
  - one row, two cells, exact row-major topology
- Preserve the observed geometry in shared IR: widths `39903 + 2261 = 42164`, row/object height `3005`, inherited padding, border references, and mirrored cell-extension widths.
- Require the exact first/second-cell width-reference pattern (`0x0500`, `0`) and keep unrelated common/table combinations fail-closed.
- Treat repeat-header as inactive only for this exact atomic one-row table; no shared model or pagination default is broadened.
- Advance the public own-parser boundary to the next unowned TABLE record without exposing source content, paths, hashes, or raw payloads.

## Regression coverage

- Positive synthetic 1×2 fixture.
- Seven hostile axes: common-attribute pairing, table attribute, row cell count, stored width, width reference, cell order, and cell extension.
- HWP5 suite: 61 tests.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy -p hwp-hwp5 --all-targets -- -D warnings`
- wasm32 check
- `scripts/verify-local.sh`
- `scripts/verify-local.sh --full`
- Chromium E2E: 85 passed, 3 intentional skips, 0 failed
- PDF visual 51, canonical 8/18/24 and 98.9%+ line-wrap gate, public corpus 84, oracle 82
- Vitest 1,018; rebuilt wasm 7,810,657 bytes

Production HWP routing, HWPX parser/serializer, shared typesetter defaults, generated assets, and `external/rhwp` are unchanged.
