### PR TITLE
feat(hwp5): own exact atomic 6x4 table

### DIFF
--- a/crates/hwp-hwp5/src/semantic.rs
+++ b/crates/hwp-hwp5/src/semantic.rs
@@ -1559,9 +1559,10 @@ fn parse_new_number_control(
 }
 
 /// Own the bounded binary-table slices seen at the public first-party boundary: strict inline 1×1,
-/// 10×2, 9×8, and 8×5 tables. The 9×8 slice has 34 active cells and one nested 1×1 table; the 8×5
-/// slice has 19 active cells, one bounded vertical merge, and nine nested 1×1 tables. A 1×1 cell may
-/// use the exact observed cell-own inner-margin bit;
+/// 10×2, 9×8, 8×5, and 6×4 tables. The 9×8 slice has 34 active cells and one nested 1×1 table; the
+/// 8×5 slice has 19 active cells, one bounded vertical merge, and nine nested 1×1 tables. The 6×4
+/// slice is a complete 24-cell grid with one paragraph per cell. A 1×1 cell may use the exact
+/// observed cell-own inner-margin bit;
 /// protection/header/form bits remain unsupported. Multiple controls in one text-empty host are
 /// emitted in marker/header order by `parse_paragraph`. Anything outside these exact source-neutral
 /// shapes, including deeper nesting, remains fail-closed rather than being approximated.
@@ -1662,6 +1663,9 @@ fn parse_inline_table(
         (0x082a_2211, 0x0400_0004, 1, 2) => {
             vec![(0, 0, 1, 1), (0, 1, 1, 1)]
         }
+        (0x082a_2311, 0x0400_0004, 6, 4) => (0..6)
+            .flat_map(|row| (0..4).map(move |col| (row, col, 1, 1)))
+            .collect(),
         (0x082a_2311, 0x0400_0006, 10, 2) => (0..10)
             .flat_map(|row| {
                 if matches!(row, 0 | 1 | 5) {
@@ -1841,6 +1845,15 @@ fn parse_inline_table(
                 "cell LIST_HEADER count, direction, alignment, or width reference is not owned",
             ));
         }
+        let exact_six_by_four =
+            (common_attr, table_attr, rows, cols) == (0x082a_2311, 0x0400_0004, 6, 4);
+        if exact_six_by_four && paragraph_count != 1 {
+            return Err(malformed(
+                &list_record,
+                Some(section),
+                "6x4 cell paragraph count differs from its exact owned topology",
+            ));
+        }
         let col = read_u16(list_bytes, 8).expect("exact length checked") as usize;
         let row = read_u16(list_bytes, 10).expect("exact length checked") as usize;
         let col_span = read_u16(list_bytes, 12).expect("exact length checked") as usize;
@@ -1869,8 +1882,11 @@ fn parse_inline_table(
             } else {
                 None
             };
-        let expected_exact_width_ref =
-            expected_one_by_two_width_ref.or(expected_eight_by_five_width_ref);
+        let expected_six_by_four_width_ref =
+            exact_six_by_four.then_some(if row == 0 { 0x0100 } else { 0x0500 });
+        let expected_exact_width_ref = expected_one_by_two_width_ref
+            .or(expected_eight_by_five_width_ref)
+            .or(expected_six_by_four_width_ref);
         let owned_width_ref = expected_exact_width_ref.map_or_else(
             || {
                 matches!(width_ref, 0x0000 | 0x0100 | 0x0500)

--- a/crates/hwp-hwp5/tests/layout_semantic.rs
+++ b/crates/hwp-hwp5/tests/layout_semantic.rs
@@ -123,6 +123,20 @@ enum OneByTwoMutation {
     BadListExtension,
 }
 
+#[derive(Clone, Copy)]
+enum SixByFourMutation {
+    None,
+    BadCommonAttribute,
+    BadTableAttribute,
+    BadRowCellCount,
+    BadWidth,
+    BadRowHeight,
+    BadParagraphCount,
+    BadWidthReference,
+    BadCellOrder,
+    BadListExtension,
+}
+
 #[test]
 fn parses_page_setup_and_blank_source_line_metrics() {
     let doc = OwnHwp5Parser::new()
@@ -863,6 +877,59 @@ fn strict_one_by_two_slice_rejects_hostile_flags_topology_widths_and_extensions(
                 .parse(&one_by_two_fixture(mutation))
                 .is_err(),
             "hostile 1x2 mutation must fail closed"
+        );
+    }
+}
+
+#[test]
+fn owns_exact_six_by_four_atomic_full_grid_table() {
+    let doc = OwnHwp5Parser::new()
+        .parse(&six_by_four_fixture(SixByFourMutation::None))
+        .expect("strict 6x4 full-grid table fixture parses");
+    let [Block::Paragraph(anchor), Block::Table(table)] = doc.sections[0].blocks.as_slice() else {
+        panic!("table host must lower to one anchor and one table")
+    };
+    assert!(anchor.is_table_anchor);
+    assert_eq!((table.rows, table.cols, table.cells.len()), (6, 4, 24));
+    assert!(table.keep_together, "no-split table stays atomic");
+    assert!(!table.fixed_row_heights);
+    assert_eq!(table.col_widths, vec![3_238, 14_908, 11_795, 18_021]);
+    assert_eq!(
+        table.row_heights,
+        vec![1_946, 1_846, 1_846, 1_846, 1_846, 1_846]
+    );
+    assert_eq!(table.padding, Some([140, 140, 140, 140]));
+    assert!(table
+        .cells
+        .iter()
+        .enumerate()
+        .all(|(index, cell)| (cell.row, cell.col) == (index / 4, index % 4)));
+    assert!(table.cells.iter().all(|cell| {
+        cell.row_span == 1
+            && cell.col_span == 1
+            && cell.blocks.len() == 1
+            && matches!(cell.blocks[0], Block::Paragraph(_))
+    }));
+}
+
+#[test]
+fn strict_six_by_four_slice_rejects_hostile_pairing_topology_geometry_and_extensions() {
+    for mutation in [
+        SixByFourMutation::BadCommonAttribute,
+        SixByFourMutation::BadTableAttribute,
+        SixByFourMutation::BadRowCellCount,
+        SixByFourMutation::BadWidth,
+        SixByFourMutation::BadRowHeight,
+        SixByFourMutation::BadParagraphCount,
+        SixByFourMutation::BadWidthReference,
+        SixByFourMutation::BadCellOrder,
+        SixByFourMutation::BadListExtension,
+    ] {
+        assert!(
+            OwnHwp5Parser::new()
+                .parse(&six_by_four_fixture(mutation))
+                .is_err(),
+            "hostile 6x4 mutation must fail closed"
         );
     }
 }
@@ -1659,6 +1726,172 @@ fn one_by_two_fixture(mutation: OneByTwoMutation) -> Vec<u8> {
         cell.extend_from_slice(&width.to_le_bytes());
         cell.extend([0; 9]);
         if index == 0 && matches!(mutation, OneByTwoMutation::BadListExtension) {
+            cell[38] = 1;
+        }
+        push_record(&mut body, TAG_LIST_HEADER, 2, &cell);
+        push_para_header_at_level(&mut body, 2, 2, 0, 1, 0, 0);
+        push_record(
+            &mut body,
+            TAG_PARA_TEXT,
+            3,
+            &utf16_bytes(&[u16::from(b'A') + index as u16, 0x000d]),
+        );
+        push_record(&mut body, TAG_PARA_CHAR_SHAPE, 3, &shape_refs(&[(0, 0)]));
+    }
+
+    let mut compound = CompoundFile::create(Cursor::new(Vec::new())).unwrap();
+    {
+        let mut stream = compound.create_stream("/FileHeader").unwrap();
+        stream.write_all(&header).unwrap();
+    }
+    {
+        let mut stream = compound.create_stream("/DocInfo").unwrap();
+        stream.write_all(&doc_info).unwrap();
+    }
+    compound.create_storage("/BodyText").unwrap();
+    {
+        let mut stream = compound.create_stream("/BodyText/Section0").unwrap();
+        stream.write_all(&body).unwrap();
+    }
+    compound.into_inner().into_inner()
+}
+
+fn six_by_four_fixture(mutation: SixByFourMutation) -> Vec<u8> {
+    const COL_WIDTHS: [u32; 4] = [3_238, 14_908, 11_795, 18_021];
+    const ROW_HEIGHTS: [u32; 6] = [1_946, 1_846, 1_846, 1_846, 1_846, 1_846];
+
+    let mut header = vec![0; 256];
+    header[..HWP_SIGNATURE.len()].copy_from_slice(HWP_SIGNATURE);
+    header[32..36].copy_from_slice(&[0, 0, 0, 5]);
+
+    let mut doc_info = Vec::new();
+    let mut properties = vec![0; 26];
+    properties[..2].copy_from_slice(&1u16.to_le_bytes());
+    push_record(&mut doc_info, TAG_DOCUMENT_PROPERTIES, 0, &properties);
+    let mut mappings = Vec::new();
+    for count in [0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 1, 0] {
+        mappings.extend_from_slice(&(count as u32).to_le_bytes());
+    }
+    push_record(&mut doc_info, TAG_ID_MAPPINGS, 0, &mappings);
+    for _ in 0..7 {
+        push_record(&mut doc_info, TAG_FACE_NAME, 0, &face_name("Test Sans"));
+    }
+    push_record(&mut doc_info, TAG_BORDER_FILL, 0, &solid_border_fill());
+    push_record(&mut doc_info, TAG_CHAR_SHAPE, 0, &char_shape());
+    push_record(&mut doc_info, TAG_PARA_SHAPE, 0, &para_shape());
+
+    let mut body = Vec::new();
+    let mut host_text = extended_control(0x0002, CTRL_SECTION_DEF);
+    host_text.extend(extended_control(0x000b, CTRL_TABLE));
+    host_text.push(0x000d);
+    push_para_header_with_break(
+        &mut body,
+        host_text.len() as u32,
+        (1 << 2) | (1 << 0x000b),
+        1,
+        0,
+        0x01,
+    );
+    push_record(&mut body, TAG_PARA_TEXT, 1, &utf16_bytes(&host_text));
+    push_record(&mut body, TAG_PARA_CHAR_SHAPE, 1, &shape_refs(&[(0, 0)]));
+
+    let mut section_control = Vec::with_capacity(28);
+    section_control.extend_from_slice(&CTRL_SECTION_DEF.to_le_bytes());
+    section_control.extend([0; 24]);
+    push_record(&mut body, TAG_CTRL_HEADER, 1, &section_control);
+    push_record(&mut body, TAG_PAGE_DEF, 2, &page_def(Mutation::None));
+
+    let mut common = Vec::with_capacity(46);
+    common.extend_from_slice(&CTRL_TABLE.to_le_bytes());
+    common.extend_from_slice(
+        &if matches!(mutation, SixByFourMutation::BadCommonAttribute) {
+            0x082a_2211u32
+        } else {
+            0x082a_2311
+        }
+        .to_le_bytes(),
+    );
+    common.extend_from_slice(&0u32.to_le_bytes());
+    common.extend_from_slice(&0u32.to_le_bytes());
+    common.extend_from_slice(&47_962u32.to_le_bytes());
+    common.extend_from_slice(&11_176u32.to_le_bytes());
+    common.extend_from_slice(&0i32.to_le_bytes());
+    for margin in [138i16, 138, 138, 138] {
+        common.extend_from_slice(&margin.to_le_bytes());
+    }
+    common.extend_from_slice(&1u32.to_le_bytes());
+    common.extend_from_slice(&0i32.to_le_bytes());
+    common.extend_from_slice(&0u16.to_le_bytes());
+    push_record(&mut body, TAG_CTRL_HEADER, 1, &common);
+
+    let mut table = Vec::with_capacity(34);
+    table.extend_from_slice(
+        &if matches!(mutation, SixByFourMutation::BadTableAttribute) {
+            0x0400_0006u32
+        } else {
+            0x0400_0004
+        }
+        .to_le_bytes(),
+    );
+    table.extend_from_slice(&6u16.to_le_bytes());
+    table.extend_from_slice(&4u16.to_le_bytes());
+    table.extend_from_slice(&0u16.to_le_bytes());
+    for padding in [140i16, 140, 140, 140] {
+        table.extend_from_slice(&padding.to_le_bytes());
+    }
+    let mut row_counts = [4u16; 6];
+    if matches!(mutation, SixByFourMutation::BadRowCellCount) {
+        row_counts[2] = 3;
+    }
+    for count in row_counts {
+        table.extend_from_slice(&count.to_le_bytes());
+    }
+    table.extend_from_slice(&1u16.to_le_bytes());
+    table.extend_from_slice(&0u16.to_le_bytes());
+    push_record(&mut body, TAG_TABLE, 2, &table);
+
+    let mut positions = (0usize..6)
+        .flat_map(|row| (0usize..4).map(move |col| (row, col)))
+        .collect::<Vec<_>>();
+    if matches!(mutation, SixByFourMutation::BadCellOrder) {
+        positions.swap(0, 1);
+    }
+    for (index, (row, col)) in positions.into_iter().enumerate() {
+        let mut width = COL_WIDTHS[col];
+        let mut height = ROW_HEIGHTS[row];
+        let mut width_ref = if row == 0 { 0x0100u16 } else { 0x0500 };
+        if index == 0 && matches!(mutation, SixByFourMutation::BadWidth) {
+            width -= 1;
+        }
+        if index == 0 && matches!(mutation, SixByFourMutation::BadRowHeight) {
+            height -= 1;
+        }
+        if index == 0 && matches!(mutation, SixByFourMutation::BadWidthReference) {
+            width_ref = 0x0500;
+        }
+        let mut cell = Vec::with_capacity(47);
+        cell.extend_from_slice(
+            &if index == 0 && matches!(mutation, SixByFourMutation::BadParagraphCount) {
+                2u16
+            } else {
+                1
+            }
+            .to_le_bytes(),
+        );
+        cell.extend_from_slice(&0x0020_0000u32.to_le_bytes());
+        cell.extend_from_slice(&width_ref.to_le_bytes());
+        for value in [col as u16, row as u16, 1, 1] {
+            cell.extend_from_slice(&value.to_le_bytes());
+        }
+        cell.extend_from_slice(&width.to_le_bytes());
+        cell.extend_from_slice(&height.to_le_bytes());
+        for padding in [141i16, 141, 141, 141] {
+            cell.extend_from_slice(&padding.to_le_bytes());
+        }
+        cell.extend_from_slice(&1u16.to_le_bytes());
+        cell.extend_from_slice(&width.to_le_bytes());
+        cell.extend([0; 9]);
+        if index == 0 && matches!(mutation, SixByFourMutation::BadListExtension) {
             cell[38] = 1;
         }
         push_record(&mut body, TAG_LIST_HEADER, 2, &cell);

--- a/crates/hwp-hwp5/tests/public_probe.rs
+++ b/crates/hwp-hwp5/tests/public_probe.rs
@@ -28,17 +28,17 @@ fn public_hwp5_has_bounded_content_free_record_provenance() {
 }
 
 #[test]
-fn explicit_own_parser_owns_bounded_one_by_two_table_then_stops_content_free() {
+fn explicit_own_parser_owns_bounded_six_by_four_table_then_stops_content_free() {
     let probed = probe(&benchmark()).unwrap();
     let next = probed
         .streams
         .iter()
         .flat_map(|stream| &stream.records)
-        .find(|record| record.head == 25_952)
+        .find(|record| record.head == 30_321)
         .unwrap();
     assert_eq!(
         (next.tag, next.level, next.head, next.data, next.end, next.size,),
-        (0x4d, 2, 25_952, 25_956, 25_990, 34)
+        (0x4d, 2, 30_321, 30_325, 30_361, 36)
     );
     let error = OwnHwp5Parser::new().parse(&benchmark()).unwrap_err();
     eprintln!("{error:?}");
@@ -47,7 +47,7 @@ fn explicit_own_parser_owns_bounded_one_by_two_table_then_stops_content_free() {
         Error::MalformedRecord {
             tag: 0x4d,
             section: Some(0),
-            offset: 25952,
+            offset: 30321,
             reason: "TABLE attributes or row/column topology are not owned",
             ..
         }

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,7 +3,7 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
-- 갱신: 2026-08-24 · Codex(sol) — **PR #181 게시 · #180 CI 추적 중**.
+- 갱신: 2026-08-24 · Codex(sol) — **PR #181 병합 · #182 next TABLE 착수**.
   #175는 exact head `6711ff9`에서 issue-link/build-test/licenses green, CLEAN/MERGEABLE,
   review/general/inline 댓글 0을 확인하고 protected main `c917c584`로 squash 병합했다. #174 close와
   원격 branch 정리 후 #94에 bounded two-table host 소유 근거를 동기화했다. 월요일 #114 감사에서
@@ -86,10 +86,14 @@
   분리한 Chromium **85 pass/3 intentional skip/0 fail**이다. 임시 dependency link를 제거했고
   production route·rhwp·HWPX parser/serializer·shared typesetter·generated asset diff 0을 확인했다.
   final security/diff review도 source content/path/hash/raw payload/credential 노출 0, silent fallback 0,
-  변경 파일은 parser/tests/state 5개뿐이다. 구현 commit `c64bbf3`을 push하고 PR #181을
-  `Closes #180`으로 게시했다. exact head `c64bbf3217dbf48f5800e52fdec2476484a56edb`는
-  MERGEABLE, review/general 댓글 0이며 issue-link green, build-test/licenses 진행 중이다. **다음:**
-  exact-head required CI와 inline 댓글까지 추적→green 자율 병합→#94 동기화와 next child.
+  변경 파일은 parser/tests/state 5개뿐이다. PR #181 exact head `10f2b0a0`에서 issue-link **5s**·
+  build-test **9m08s**·licenses **2m04s** green, CLEAN/MERGEABLE, review/general/inline 댓글 0을
+  확인하고 protected main `09e71a07`로 squash 병합했다. #180 close·원격 branch 정리 후 #94에
+  exact 근거를 동기화하고, 중복 없는 #182를 R18/P1/area:hwp5/status:ready로 열었다. exact latest
+  main의 `codex/issue-182-hwp5-next-table` worktree와 pinned rhwp oracle을 초기화했다. **다음:**
+  content-free TABLE `0x4d/25952..25990`의 flags·topology·geometry·nesting을 먼저 분류하고 shared
+  IR/SVG/PDF가 모든 active semantics를 faithful하게 표현할 때만 strict synthetic/hostile slice를 구현.
+  production route·HWPX·shared layout defaults·generated assets·rhwp는 불변.
 
 - 갱신: 2026-08-24 · Codex(sol) — **PR #173 병합 · #174 multi-table 경계 착수**.
   자체 HWP5 파서가 exact `tbl ` marker/common-object/TABLE/LIST_HEADER/cell paragraph를 검증해

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -112,8 +112,8 @@
   fail**이다. 임시 dependency link는 모두 제거했다. final diff/security review에서 one-shot
   classifier·production route·rhwp·HWPX parser/serializer·shared typesetter·generated asset diff
   0, source content/path/hash/raw payload/credential 노출 0을 확인했고 변경 파일은 strict HWP5
-  parser/tests/state 5개뿐이다. **다음:** commit/push/PR→exact-head CI·댓글·mergeability→자율
-  병합→#94 동기화→next child.
+  parser/tests/state 5개뿐이다. 구현 commit `4aa018b`을 push하고 PR #183을 `Closes #182`로
+  게시했다. **다음:** exact-head CI·댓글·mergeability→자율 병합→#94 동기화→next child.
 
 - 갱신: 2026-08-24 · Codex(sol) — **PR #173 병합 · #174 multi-table 경계 착수**.
   자체 HWP5 파서가 exact `tbl ` marker/common-object/TABLE/LIST_HEADER/cell paragraph를 검증해

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -93,7 +93,14 @@
   main의 `codex/issue-182-hwp5-next-table` worktree와 pinned rhwp oracle을 초기화했다. **다음:**
   content-free TABLE `0x4d/25952..25990`의 flags·topology·geometry·nesting을 먼저 분류하고 shared
   IR/SVG/PDF가 모든 active semantics를 faithful하게 표현할 때만 strict synthetic/hostile slice를 구현.
-  production route·HWPX·shared layout defaults·generated assets·rhwp는 불변.
+  production route·HWPX·shared layout defaults·generated assets·rhwp는 불변. 분류 결과 exact common
+  attr `0x082a2311` + TABLE attr `0x04000004`, 6×4 완전 격자/24 active cells, row counts 전부 4,
+  병합·중첩 없음, 모든 셀 1문단이다. col widths `3238/14908/11795/18021` 합은 object **47962**,
+  row heights `1946/1846×5` 합은 object **11176**과 exact다. mirrored 13B extension과 padding·border
+  refs도 일치한다. row0 width-ref는 모두 `0x0100`, rows1..5는 `0x0500`; repeat-header attr은 active
+  header cell이 없어 inert이고 no-split은 shared `keep_together`로 보존 가능하다. one-shot numeric
+  classifier는 제거했다. **다음:** exact tuple/24-cell row-major/width-ref/geometry synthetic+hostile
+  fixture→strict parser; route/rhwp/HWPX/generated 불변.
 
 - 갱신: 2026-08-24 · Codex(sol) — **PR #173 병합 · #174 multi-table 경계 착수**.
   자체 HWP5 파서가 exact `tbl ` marker/common-object/TABLE/LIST_HEADER/cell paragraph를 검증해

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -100,7 +100,20 @@
   refs도 일치한다. row0 width-ref는 모두 `0x0100`, rows1..5는 `0x0500`; repeat-header attr은 active
   header cell이 없어 inert이고 no-split은 shared `keep_together`로 보존 가능하다. one-shot numeric
   classifier는 제거했다. **다음:** exact tuple/24-cell row-major/width-ref/geometry synthetic+hostile
-  fixture→strict parser; route/rhwp/HWPX/generated 불변.
+  fixture→strict parser; route/rhwp/HWPX/generated 불변. strict parser와 합성 회귀를 구현해 exact
+  common/table pair, 24-cell row-major full grid, row counts, 1-paragraph cells, row0/body width refs,
+  mirrored extension, column/row/object geometry를 검증한다. common/table attr·row count·width·height·
+  paragraph count·width-ref·order·extension hostile **9축**은 fail-closed. HWP5 **63 tests**, fmt,
+  clippy `-D warnings`, wasm32 green이며 public boundary는 다음 TABLE `0x4d/30321..30361`의 unowned
+  topology로 전진했다. quick의 Rust workspace, PDF visual **51**, canonical
+  **8/18/24·98.9%+**, public corpus **84**, oracle **82**, HWPX, wasm/licenses가 모두 green이다.
+  full도 wasm 재빌드 **7,810,657B**, JS build·crosscheck·i18n, Vitest **1,018**까지 green이고
+  sandbox port EPERM만 허용된 로컬 서버에서 분리한 Chromium **85 pass/3 intentional skip/0
+  fail**이다. 임시 dependency link는 모두 제거했다. final diff/security review에서 one-shot
+  classifier·production route·rhwp·HWPX parser/serializer·shared typesetter·generated asset diff
+  0, source content/path/hash/raw payload/credential 노출 0을 확인했고 변경 파일은 strict HWP5
+  parser/tests/state 5개뿐이다. **다음:** commit/push/PR→exact-head CI·댓글·mergeability→자율
+  병합→#94 동기화→next child.
 
 - 갱신: 2026-08-24 · Codex(sol) — **PR #173 병합 · #174 multi-table 경계 착수**.
   자체 HWP5 파서가 exact `tbl ` marker/common-object/TABLE/LIST_HEADER/cell paragraph를 검증해

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,11 @@
 
 ---
 
+## 2026-08-24 (Codex sol) · #182 classified
+- exact 6×4/24 full-grid table; no merge/nesting, 1 paragraph per cell.
+- column/row sums equal object geometry; row0/body width-ref pattern exact; repeat-header inert.
+- one-shot classifier removed. 다음 synthetic hostile→strict parser; route/rhwp/HWPX 불변.
+
 ## 2026-08-24 (Codex sol) · PR #181 merged / #182 started
 - #181 exact-head required CI·CLEAN/MERGEABLE·댓글 0 후 main `09e71a07`; #180 close·branch 정리.
 - #94 동기화, next TABLE boundary #182 등록, exact-main worktree 시작.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,10 @@
 
 ---
 
+## 2026-08-24 (Codex sol) · #182 PR #183 게시
+- verified parser/test/state commit `4aa018b` push, PR #183(`Closes #182`) 생성.
+- 다음 exact-head required CI·review/general/inline·mergeability 추적→병합→#94/next child.
+
 ## 2026-08-24 (Codex sol) · #182 full green / PR ready
 - quick/full: Rust·PDF51·canonical·corpus84·oracle82·HWPX·wasm/JS + Vitest 1,018 green.
 - 허용된 로컬 서버 Chromium 85 pass/3 intentional skip/0 fail; 임시 link 제거.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,11 @@
 
 ---
 
+## 2026-08-24 (Codex sol) · PR #181 merged / #182 started
+- #181 exact-head required CI·CLEAN/MERGEABLE·댓글 0 후 main `09e71a07`; #180 close·branch 정리.
+- #94 동기화, next TABLE boundary #182 등록, exact-main worktree 시작.
+- `0x4d/25952..25990` content-free classification; route/rhwp/HWPX 불변.
+
 ## 2026-08-24 (Codex sol) · #180 PR #181 게시
 - exact parser/test/state commit `c64bbf3` push, PR #181(`Closes #180`) 생성.
 - exact head `c64bbf3217dbf48f5800e52fdec2476484a56edb`, MERGEABLE, issue-link green.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,16 @@
 
 ---
 
+## 2026-08-24 (Codex sol) · #182 full green / PR ready
+- quick/full: Rust·PDF51·canonical·corpus84·oracle82·HWPX·wasm/JS + Vitest 1,018 green.
+- 허용된 로컬 서버 Chromium 85 pass/3 intentional skip/0 fail; 임시 link 제거.
+- route/rhwp/HWPX/shared typesetter/generated/security diff 0. 다음 commit/push/PR→CI/merge.
+
+## 2026-08-24 (Codex sol) · #182 focused green
+- strict 6×4/24 full grid + exact width-ref/geometry/1-paragraph ownership; hostile 9축.
+- HWP5 63/fmt/clippy/wasm32 green; next TABLE 30321..30361.
+- one-shot classifier/route/rhwp/HWPX/generated diff 0. 다음 quick→full→PR/CI/merge.
+
 ## 2026-08-24 (Codex sol) · #182 classified
 - exact 6×4/24 full-grid table; no merge/nesting, 1 paragraph per cell.
 - column/row sums equal object geometry; row0/body width-ref pattern exact; repeat-header inert.


### PR DESCRIPTION
Closes #182

Refs #94 #180 #181

## What changed

- own the exact bounded HWP5 common-object/TABLE pair for a 6×4 atomic full grid
- validate all 24 row-major cells, one paragraph per cell, exact row/header width-reference pattern, mirrored cell extension, and object/row/column geometry
- preserve the active no-split semantic as shared-IR `keep_together`; the source repeat-header flag is inert because no cell carries the active header marker
- keep every nearby or mutated topology fail-closed with nine hostile synthetic axes
- advance the content-free public own-parser boundary to the next unsupported TABLE record

## Verification

- `cargo fmt --all -- --check`
- HWP5: 63 tests green
- focused clippy `-D warnings` and wasm32 green
- `scripts/verify-local.sh`: Rust workspace, PDF visual 51, canonical 8/18/24 and 98.9%+, public corpus 84, oracle 82, HWPX, wasm, licenses green
- `scripts/verify-local.sh --full`: wasm rebuild 7,810,657 bytes, JS builds/crosscheck/i18n, Vitest 1,018 green; its only interruption was the sandbox denying the local E2E server port
- separate permitted Chromium E2E: 85 passed, 3 intentional skips, 0 failed

## Scope and safety

- no production route, HWPX parser/serializer, shared typesetter, generated asset, or vendored `external/rhwp` change
- no source document content, local path, hash, or raw payload is published
- unsupported flags, topology, geometry, and framing continue to return a typed fail-closed error
