### PR TITLE
feat(hwp5): own exact merged 7x3 table

### DIFF
--- a/crates/hwp-hwp5/src/semantic.rs
+++ b/crates/hwp-hwp5/src/semantic.rs
@@ -1559,10 +1559,11 @@ fn parse_new_number_control(
 }
 
 /// Own the bounded binary-table slices seen at the public first-party boundary: strict inline 1×1,
-/// 10×2, 9×8, 8×5, and 6×4 tables. The 9×8 slice has 34 active cells and one nested 1×1 table; the
-/// 8×5 slice has 19 active cells, one bounded vertical merge, and nine nested 1×1 tables. The 6×4
-/// slice is a complete 24-cell grid with one paragraph per cell. A 1×1 cell may use the exact
-/// observed cell-own inner-margin bit;
+/// 10×2, 9×8, 8×5, 6×4, and 7×3 tables. The 9×8 slice has 34 active cells and one nested 1×1 table;
+/// the 8×5 slice has 19 active cells, one bounded vertical merge, and nine nested 1×1 tables. The
+/// 6×4 slice is a complete 24-cell grid. The 7×3 slice has 19 active cells and one vertical plus one
+/// horizontal merge. Both have one paragraph per cell. A 1×1 cell may use the exact observed
+/// cell-own inner-margin bit;
 /// protection/header/form bits remain unsupported. Multiple controls in one text-empty host are
 /// emitted in marker/header order by `parse_paragraph`. Anything outside these exact source-neutral
 /// shapes, including deeper nesting, remains fail-closed rather than being approximated.
@@ -1666,6 +1667,27 @@ fn parse_inline_table(
         (0x082a_2311, 0x0400_0004, 6, 4) => (0..6)
             .flat_map(|row| (0..4).map(move |col| (row, col, 1, 1)))
             .collect(),
+        (0x082a_2311, 0x0600_000c, 7, 3) => vec![
+            (0, 0, 1, 1),
+            (0, 1, 1, 1),
+            (0, 2, 1, 1),
+            (1, 0, 1, 2),
+            (1, 1, 1, 1),
+            (1, 2, 1, 1),
+            (2, 1, 1, 1),
+            (2, 2, 1, 1),
+            (3, 0, 1, 1),
+            (3, 1, 1, 1),
+            (3, 2, 1, 1),
+            (4, 0, 1, 1),
+            (4, 1, 1, 1),
+            (4, 2, 1, 1),
+            (5, 0, 1, 1),
+            (5, 1, 1, 1),
+            (5, 2, 1, 1),
+            (6, 0, 2, 1),
+            (6, 2, 1, 1),
+        ],
         (0x082a_2311, 0x0400_0006, 10, 2) => (0..10)
             .flat_map(|row| {
                 if matches!(row, 0 | 1 | 5) {
@@ -1847,11 +1869,13 @@ fn parse_inline_table(
         }
         let exact_six_by_four =
             (common_attr, table_attr, rows, cols) == (0x082a_2311, 0x0400_0004, 6, 4);
-        if exact_six_by_four && paragraph_count != 1 {
+        let exact_seven_by_three =
+            (common_attr, table_attr, rows, cols) == (0x082a_2311, 0x0600_000c, 7, 3);
+        if (exact_six_by_four || exact_seven_by_three) && paragraph_count != 1 {
             return Err(malformed(
                 &list_record,
                 Some(section),
-                "6x4 cell paragraph count differs from its exact owned topology",
+                "bounded atomic-table cell paragraph count differs from its exact owned topology",
             ));
         }
         let col = read_u16(list_bytes, 8).expect("exact length checked") as usize;
@@ -1884,9 +1908,12 @@ fn parse_inline_table(
             };
         let expected_six_by_four_width_ref =
             exact_six_by_four.then_some(if row == 0 { 0x0100 } else { 0x0500 });
+        let expected_seven_by_three_width_ref =
+            exact_seven_by_three.then_some(if col == 2 { 0x0100 } else { 0x0500 });
         let expected_exact_width_ref = expected_one_by_two_width_ref
             .or(expected_eight_by_five_width_ref)
-            .or(expected_six_by_four_width_ref);
+            .or(expected_six_by_four_width_ref)
+            .or(expected_seven_by_three_width_ref);
         let owned_width_ref = expected_exact_width_ref.map_or_else(
             || {
                 matches!(width_ref, 0x0000 | 0x0100 | 0x0500)

--- a/crates/hwp-hwp5/tests/layout_semantic.rs
+++ b/crates/hwp-hwp5/tests/layout_semantic.rs
@@ -137,6 +137,21 @@ enum SixByFourMutation {
     BadListExtension,
 }
 
+#[derive(Clone, Copy)]
+enum SevenByThreeMutation {
+    None,
+    BadCommonAttribute,
+    BadTableAttribute,
+    BadRowCellCount,
+    BadWidth,
+    BadRowHeight,
+    BadSpanHeight,
+    BadParagraphCount,
+    BadWidthReference,
+    BadCellOrder,
+    BadListExtension,
+}
+
 #[test]
 fn parses_page_setup_and_blank_source_line_metrics() {
     let doc = OwnHwp5Parser::new()
@@ -930,6 +945,81 @@ fn strict_six_by_four_slice_rejects_hostile_pairing_topology_geometry_and_extens
                 .parse(&six_by_four_fixture(mutation))
                 .is_err(),
             "hostile 6x4 mutation must fail closed"
+        );
+    }
+}
+
+#[test]
+fn owns_exact_seven_by_three_merged_atomic_table() {
+    let doc = OwnHwp5Parser::new()
+        .parse(&seven_by_three_fixture(SevenByThreeMutation::None))
+        .expect("strict 7x3 merged table fixture parses");
+    let [Block::Paragraph(anchor), Block::Table(table)] = doc.sections[0].blocks.as_slice() else {
+        panic!("table host must lower to one anchor and one table")
+    };
+    assert!(anchor.is_table_anchor);
+    assert_eq!((table.rows, table.cols, table.cells.len()), (7, 3, 19));
+    assert!(table.keep_together, "no-split table stays atomic");
+    assert!(table.fixed_row_heights, "no-adjust rows remain exact");
+    assert_eq!(table.col_widths, vec![6_509, 31_215, 10_200]);
+    assert_eq!(
+        table.row_heights,
+        vec![2_229, 2_129, 2_129, 2_129, 2_129, 2_129, 2_229]
+    );
+    assert_eq!(table.padding, Some([140, 140, 140, 140]));
+    assert!(table
+        .cells
+        .iter()
+        .all(|cell| { cell.blocks.len() == 1 && matches!(cell.blocks[0], Block::Paragraph(_)) }));
+    assert_eq!(
+        table
+            .cells
+            .iter()
+            .map(|cell| (cell.row, cell.col, cell.col_span, cell.row_span))
+            .collect::<Vec<_>>(),
+        vec![
+            (0, 0, 1, 1),
+            (0, 1, 1, 1),
+            (0, 2, 1, 1),
+            (1, 0, 1, 2),
+            (1, 1, 1, 1),
+            (1, 2, 1, 1),
+            (2, 1, 1, 1),
+            (2, 2, 1, 1),
+            (3, 0, 1, 1),
+            (3, 1, 1, 1),
+            (3, 2, 1, 1),
+            (4, 0, 1, 1),
+            (4, 1, 1, 1),
+            (4, 2, 1, 1),
+            (5, 0, 1, 1),
+            (5, 1, 1, 1),
+            (5, 2, 1, 1),
+            (6, 0, 2, 1),
+            (6, 2, 1, 1),
+        ]
+    );
+}
+
+#[test]
+fn strict_seven_by_three_slice_rejects_hostile_pairing_topology_geometry_and_extensions() {
+    for mutation in [
+        SevenByThreeMutation::BadCommonAttribute,
+        SevenByThreeMutation::BadTableAttribute,
+        SevenByThreeMutation::BadRowCellCount,
+        SevenByThreeMutation::BadWidth,
+        SevenByThreeMutation::BadRowHeight,
+        SevenByThreeMutation::BadSpanHeight,
+        SevenByThreeMutation::BadParagraphCount,
+        SevenByThreeMutation::BadWidthReference,
+        SevenByThreeMutation::BadCellOrder,
+        SevenByThreeMutation::BadListExtension,
+    ] {
+        assert!(
+            OwnHwp5Parser::new()
+                .parse(&seven_by_three_fixture(mutation))
+                .is_err(),
+            "hostile 7x3 mutation must fail closed"
         );
     }
 }
@@ -1892,6 +1982,194 @@ fn six_by_four_fixture(mutation: SixByFourMutation) -> Vec<u8> {
         cell.extend_from_slice(&width.to_le_bytes());
         cell.extend([0; 9]);
         if index == 0 && matches!(mutation, SixByFourMutation::BadListExtension) {
+            cell[38] = 1;
+        }
+        push_record(&mut body, TAG_LIST_HEADER, 2, &cell);
+        push_para_header_at_level(&mut body, 2, 2, 0, 1, 0, 0);
+        push_record(
+            &mut body,
+            TAG_PARA_TEXT,
+            3,
+            &utf16_bytes(&[u16::from(b'A') + index as u16, 0x000d]),
+        );
+        push_record(&mut body, TAG_PARA_CHAR_SHAPE, 3, &shape_refs(&[(0, 0)]));
+    }
+
+    let mut compound = CompoundFile::create(Cursor::new(Vec::new())).unwrap();
+    {
+        let mut stream = compound.create_stream("/FileHeader").unwrap();
+        stream.write_all(&header).unwrap();
+    }
+    {
+        let mut stream = compound.create_stream("/DocInfo").unwrap();
+        stream.write_all(&doc_info).unwrap();
+    }
+    compound.create_storage("/BodyText").unwrap();
+    {
+        let mut stream = compound.create_stream("/BodyText/Section0").unwrap();
+        stream.write_all(&body).unwrap();
+    }
+    compound.into_inner().into_inner()
+}
+
+fn seven_by_three_fixture(mutation: SevenByThreeMutation) -> Vec<u8> {
+    const COL_WIDTHS: [u32; 3] = [6_509, 31_215, 10_200];
+    const ROW_HEIGHTS: [u32; 7] = [2_229, 2_129, 2_129, 2_129, 2_129, 2_129, 2_229];
+    const POSITIONS: [(usize, usize, usize, usize); 19] = [
+        (0, 0, 1, 1),
+        (0, 1, 1, 1),
+        (0, 2, 1, 1),
+        (1, 0, 1, 2),
+        (1, 1, 1, 1),
+        (1, 2, 1, 1),
+        (2, 1, 1, 1),
+        (2, 2, 1, 1),
+        (3, 0, 1, 1),
+        (3, 1, 1, 1),
+        (3, 2, 1, 1),
+        (4, 0, 1, 1),
+        (4, 1, 1, 1),
+        (4, 2, 1, 1),
+        (5, 0, 1, 1),
+        (5, 1, 1, 1),
+        (5, 2, 1, 1),
+        (6, 0, 2, 1),
+        (6, 2, 1, 1),
+    ];
+
+    let mut header = vec![0; 256];
+    header[..HWP_SIGNATURE.len()].copy_from_slice(HWP_SIGNATURE);
+    header[32..36].copy_from_slice(&[0, 0, 0, 5]);
+
+    let mut doc_info = Vec::new();
+    let mut properties = vec![0; 26];
+    properties[..2].copy_from_slice(&1u16.to_le_bytes());
+    push_record(&mut doc_info, TAG_DOCUMENT_PROPERTIES, 0, &properties);
+    let mut mappings = Vec::new();
+    for count in [0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 1, 0] {
+        mappings.extend_from_slice(&(count as u32).to_le_bytes());
+    }
+    push_record(&mut doc_info, TAG_ID_MAPPINGS, 0, &mappings);
+    for _ in 0..7 {
+        push_record(&mut doc_info, TAG_FACE_NAME, 0, &face_name("Test Sans"));
+    }
+    push_record(&mut doc_info, TAG_BORDER_FILL, 0, &solid_border_fill());
+    push_record(&mut doc_info, TAG_CHAR_SHAPE, 0, &char_shape());
+    push_record(&mut doc_info, TAG_PARA_SHAPE, 0, &para_shape());
+
+    let mut body = Vec::new();
+    let mut host_text = extended_control(0x0002, CTRL_SECTION_DEF);
+    host_text.extend(extended_control(0x000b, CTRL_TABLE));
+    host_text.push(0x000d);
+    push_para_header_with_break(
+        &mut body,
+        host_text.len() as u32,
+        (1 << 2) | (1 << 0x000b),
+        1,
+        0,
+        0x01,
+    );
+    push_record(&mut body, TAG_PARA_TEXT, 1, &utf16_bytes(&host_text));
+    push_record(&mut body, TAG_PARA_CHAR_SHAPE, 1, &shape_refs(&[(0, 0)]));
+
+    let mut section_control = Vec::with_capacity(28);
+    section_control.extend_from_slice(&CTRL_SECTION_DEF.to_le_bytes());
+    section_control.extend([0; 24]);
+    push_record(&mut body, TAG_CTRL_HEADER, 1, &section_control);
+    push_record(&mut body, TAG_PAGE_DEF, 2, &page_def(Mutation::None));
+
+    let mut common = Vec::with_capacity(46);
+    common.extend_from_slice(&CTRL_TABLE.to_le_bytes());
+    common.extend_from_slice(
+        &if matches!(mutation, SevenByThreeMutation::BadCommonAttribute) {
+            0x082a_2211u32
+        } else {
+            0x082a_2311
+        }
+        .to_le_bytes(),
+    );
+    common.extend_from_slice(&0u32.to_le_bytes());
+    common.extend_from_slice(&0u32.to_le_bytes());
+    common.extend_from_slice(&47_924u32.to_le_bytes());
+    common.extend_from_slice(&15_103u32.to_le_bytes());
+    common.extend_from_slice(&0i32.to_le_bytes());
+    for margin in [141i16, 141, 141, 141] {
+        common.extend_from_slice(&margin.to_le_bytes());
+    }
+    common.extend_from_slice(&1u32.to_le_bytes());
+    common.extend_from_slice(&0i32.to_le_bytes());
+    common.extend_from_slice(&0u16.to_le_bytes());
+    push_record(&mut body, TAG_CTRL_HEADER, 1, &common);
+
+    let mut table = Vec::with_capacity(36);
+    table.extend_from_slice(
+        &if matches!(mutation, SevenByThreeMutation::BadTableAttribute) {
+            0x0600_000eu32
+        } else {
+            0x0600_000c
+        }
+        .to_le_bytes(),
+    );
+    table.extend_from_slice(&7u16.to_le_bytes());
+    table.extend_from_slice(&3u16.to_le_bytes());
+    table.extend_from_slice(&0u16.to_le_bytes());
+    for padding in [140i16, 140, 140, 140] {
+        table.extend_from_slice(&padding.to_le_bytes());
+    }
+    let mut row_counts = [3u16, 3, 2, 3, 3, 3, 2];
+    if matches!(mutation, SevenByThreeMutation::BadRowCellCount) {
+        row_counts[2] = 3;
+    }
+    for count in row_counts {
+        table.extend_from_slice(&count.to_le_bytes());
+    }
+    table.extend_from_slice(&1u16.to_le_bytes());
+    table.extend_from_slice(&0u16.to_le_bytes());
+    push_record(&mut body, TAG_TABLE, 2, &table);
+
+    let mut positions = POSITIONS.to_vec();
+    if matches!(mutation, SevenByThreeMutation::BadCellOrder) {
+        positions.swap(0, 1);
+    }
+    for (index, (row, col, col_span, row_span)) in positions.into_iter().enumerate() {
+        let mut width = COL_WIDTHS[col..col + col_span].iter().sum::<u32>();
+        let mut height = ROW_HEIGHTS[row..row + row_span].iter().sum::<u32>();
+        let mut width_ref = if col == 2 { 0x0100u16 } else { 0x0500 };
+        if index == 0 && matches!(mutation, SevenByThreeMutation::BadWidth) {
+            width -= 1;
+        }
+        if index == 0 && matches!(mutation, SevenByThreeMutation::BadRowHeight) {
+            height -= 1;
+        }
+        if (row, col) == (1, 0) && matches!(mutation, SevenByThreeMutation::BadSpanHeight) {
+            height -= 1;
+        }
+        if index == 0 && matches!(mutation, SevenByThreeMutation::BadWidthReference) {
+            width_ref = 0x0100;
+        }
+        let mut cell = Vec::with_capacity(47);
+        cell.extend_from_slice(
+            &if index == 0 && matches!(mutation, SevenByThreeMutation::BadParagraphCount) {
+                2u16
+            } else {
+                1
+            }
+            .to_le_bytes(),
+        );
+        cell.extend_from_slice(&0x0020_0000u32.to_le_bytes());
+        cell.extend_from_slice(&width_ref.to_le_bytes());
+        for value in [col as u16, row as u16, col_span as u16, row_span as u16] {
+            cell.extend_from_slice(&value.to_le_bytes());
+        }
+        cell.extend_from_slice(&width.to_le_bytes());
+        cell.extend_from_slice(&height.to_le_bytes());
+        for padding in [141i16, 141, 141, 141] {
+            cell.extend_from_slice(&padding.to_le_bytes());
+        }
+        cell.extend_from_slice(&1u16.to_le_bytes());
+        cell.extend_from_slice(&width.to_le_bytes());
+        cell.extend([0; 9]);
+        if index == 0 && matches!(mutation, SevenByThreeMutation::BadListExtension) {
             cell[38] = 1;
         }
         push_record(&mut body, TAG_LIST_HEADER, 2, &cell);

--- a/crates/hwp-hwp5/tests/public_probe.rs
+++ b/crates/hwp-hwp5/tests/public_probe.rs
@@ -28,27 +28,27 @@ fn public_hwp5_has_bounded_content_free_record_provenance() {
 }
 
 #[test]
-fn explicit_own_parser_owns_bounded_six_by_four_table_then_stops_content_free() {
+fn explicit_own_parser_owns_bounded_seven_by_three_table_then_stops_content_free() {
     let probed = probe(&benchmark()).unwrap();
     let next = probed
         .streams
         .iter()
         .flat_map(|stream| &stream.records)
-        .find(|record| record.head == 30_321)
+        .find(|record| record.head == 40_865)
         .unwrap();
     assert_eq!(
         (next.tag, next.level, next.head, next.data, next.end, next.size,),
-        (0x4d, 2, 30_321, 30_325, 30_361, 36)
+        (0x48, 2, 40_865, 40_869, 40_916, 47)
     );
     let error = OwnHwp5Parser::new().parse(&benchmark()).unwrap_err();
     eprintln!("{error:?}");
     assert!(matches!(
         error,
         Error::MalformedRecord {
-            tag: 0x4d,
+            tag: 0x48,
             section: Some(0),
-            offset: 30321,
-            reason: "TABLE attributes or row/column topology are not owned",
+            offset: 40865,
+            reason: "cell LIST_HEADER width reference differs from its exact owned topology",
             ..
         }
     ));

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -113,7 +113,14 @@
   classifier·production route·rhwp·HWPX parser/serializer·shared typesetter·generated asset diff
   0, source content/path/hash/raw payload/credential 노출 0을 확인했고 변경 파일은 strict HWP5
   parser/tests/state 5개뿐이다. 구현 commit `4aa018b`을 push하고 PR #183을 `Closes #182`로
-  게시했다. **다음:** exact-head CI·댓글·mergeability→자율 병합→#94 동기화→next child.
+  게시했다. exact head `75f49e9f`에서 issue-link **3s**·build-test **7m46s**·licenses **2m48s**
+  green, MERGEABLE, review/general/inline 댓글 0을 확인하고 protected main `c95fef7c`로 squash
+  병합했다. #182 close·원격 branch 정리 후 #94에 exact 근거와 다음 boundary를 동기화했다.
+  중복 없는 #184를 R18/P1/area:hwp5/status:ready로 열고 exact latest main의
+  `codex/issue-184-hwp5-next-table` worktree와 pinned rhwp oracle을 초기화했다. **다음:**
+  content-free TABLE `0x4d/30321..30361`의 flags·topology·geometry·nesting을 먼저 분류하고,
+  shared IR/SVG/PDF가 모든 active semantics를 faithful하게 표현할 때만 synthetic/hostile fixture와
+  strict parser를 구현. production route·HWPX·shared layout defaults·generated assets·rhwp는 불변.
 
 - 갱신: 2026-08-24 · Codex(sol) — **PR #173 병합 · #174 multi-table 경계 착수**.
   자체 HWP5 파서가 exact `tbl ` marker/common-object/TABLE/LIST_HEADER/cell paragraph를 검증해

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -130,7 +130,20 @@
   shared `keep_together=true`/`fixed_row_heights=true`로 보존되고 repeat-header는 active header cell이
   없어 inert하다. one-shot numeric classifier는 두 번 동일 결과를 확인한 뒤 제거했다. **다음:**
   exact tuple/19-cell topology/width-ref/span/geometry/extension synthetic+hostile fixture→strict parser;
-  route/rhwp/HWPX/generated 불변.
+  route/rhwp/HWPX/generated 불변. strict parser와 합성 회귀를 구현해 exact common/table pair,
+  19-cell row-major merge topology, row counts, 1-paragraph cells, column-bound width refs, mirrored
+  extension, column/row/span/object geometry를 검증한다. common/table attr·row count·width·row height·
+  vertical-span height·paragraph count·width-ref·order·extension hostile **10축**은 fail-closed.
+  HWP5 **65 tests**, fmt, workspace clippy `-D warnings`, wasm32 green이며 공개 own-parser boundary는
+  다음 6×4 변형의 LIST_HEADER `0x48/40865..40916` width-ref 불일치로 전진했다. temporary classifier
+  diff 0. quick의 Rust workspace, PDF visual **51**, canonical **8/18/24·98.9%+**, public corpus
+  **84**, oracle **82**, HWPX, wasm/licenses가 모두 green이다. full도 wasm 재빌드
+  **7,810,657B**, JS build·crosscheck·i18n, Vitest **1,018**까지 green이고 sandbox port EPERM만
+  허용된 로컬 서버에서 분리한 Chromium **85 pass/3 intentional skip/0 fail**이다. 임시 dependency
+  link는 모두 제거했다. final diff/security review에서 production route·rhwp·HWPX parser/serializer·
+  shared typesetter·generated asset diff 0, source content/path/hash/raw payload/credential 노출 0을
+  확인했고 변경 파일은 strict HWP5 parser/tests/state 5개뿐이다. **다음:** commit/push/PR→
+  exact-head CI·댓글·mergeability→자율 병합→#94 동기화→next child.
 
 - 갱신: 2026-08-24 · Codex(sol) — **PR #173 병합 · #174 multi-table 경계 착수**.
   자체 HWP5 파서가 exact `tbl ` marker/common-object/TABLE/LIST_HEADER/cell paragraph를 검증해

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -142,8 +142,9 @@
   허용된 로컬 서버에서 분리한 Chromium **85 pass/3 intentional skip/0 fail**이다. 임시 dependency
   link는 모두 제거했다. final diff/security review에서 production route·rhwp·HWPX parser/serializer·
   shared typesetter·generated asset diff 0, source content/path/hash/raw payload/credential 노출 0을
-  확인했고 변경 파일은 strict HWP5 parser/tests/state 5개뿐이다. **다음:** commit/push/PR→
-  exact-head CI·댓글·mergeability→자율 병합→#94 동기화→next child.
+  확인했고 변경 파일은 strict HWP5 parser/tests/state 5개뿐이다. 구현 commit `2f0c7ba`을 push하고
+  PR #185를 `Closes #184`로 게시했다. **다음:** exact-head CI·댓글·mergeability→자율 병합→
+  #94 동기화→next child.
 
 - 갱신: 2026-08-24 · Codex(sol) — **PR #173 병합 · #174 multi-table 경계 착수**.
   자체 HWP5 파서가 exact `tbl ` marker/common-object/TABLE/LIST_HEADER/cell paragraph를 검증해

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -121,6 +121,16 @@
   content-free TABLE `0x4d/30321..30361`의 flags·topology·geometry·nesting을 먼저 분류하고,
   shared IR/SVG/PDF가 모든 active semantics를 faithful하게 표현할 때만 synthetic/hostile fixture와
   strict parser를 구현. production route·HWPX·shared layout defaults·generated assets·rhwp는 불변.
+  분류 결과 exact common attr `0x082a2311` + TABLE attr `0x0600000c`, 7×3/active cells **19**,
+  row counts `3/3/2/3/3/3/2`다. `(row1,col0)`의 2-row vertical merge와
+  `(row6,col0)`의 2-column horizontal merge만 있고 중첩 표는 없다. 모든 셀 1문단, mirrored 13B
+  extension이며 col widths `6509/31215/10200` 합은 object **47924**와 exact다. row heights
+  `2229/2129×5/2229` 합은 object **15103**과 exact이고 vertical span height **4258**도 두 행 합과
+  같다. width-ref는 col0/1 `0x0500`, col2 `0x0100`으로 고정된다. attr의 no-split/no-adjust는 기존
+  shared `keep_together=true`/`fixed_row_heights=true`로 보존되고 repeat-header는 active header cell이
+  없어 inert하다. one-shot numeric classifier는 두 번 동일 결과를 확인한 뒤 제거했다. **다음:**
+  exact tuple/19-cell topology/width-ref/span/geometry/extension synthetic+hostile fixture→strict parser;
+  route/rhwp/HWPX/generated 불변.
 
 - 갱신: 2026-08-24 · Codex(sol) — **PR #173 병합 · #174 multi-table 경계 착수**.
   자체 HWP5 파서가 exact `tbl ` marker/common-object/TABLE/LIST_HEADER/cell paragraph를 검증해

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,10 @@
 
 ---
 
+## 2026-08-24 (Codex sol) · #184 PR #185 게시
+- verified parser/test/state commit `2f0c7ba` push, PR #185(`Closes #184`) 생성.
+- 다음 exact-head required CI·review/general/inline·mergeability 추적→병합→#94/next child.
+
 ## 2026-08-24 (Codex sol) · #184 full green / PR ready
 - quick/full: Rust·PDF51·canonical·corpus84·oracle82·HWPX·wasm/JS + Vitest 1,018 green.
 - 허용된 로컬 서버 Chromium 85 pass/3 intentional skip/0 fail; 임시 link 제거.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,11 @@
 
 ---
 
+## 2026-08-24 (Codex sol) · #184 classified
+- exact 7×3/19 cells; vertical span 1 + final-row horizontal span 1, no nesting, 1 paragraph/cell.
+- column/row/span sums equal object geometry; exact width-ref pattern; no-split/no-adjust faithfully modeled.
+- one-shot classifier removed. 다음 synthetic hostile→strict parser; route/rhwp/HWPX 불변.
+
 ## 2026-08-24 (Codex sol) · PR #183 merged / #184 started
 - #183 exact-head required CI·MERGEABLE·댓글 0 후 main `c95fef7c`; #182 close·branch 정리.
 - #94 근거 동기화, next TABLE boundary #184 등록, exact-main worktree 시작.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,16 @@
 
 ---
 
+## 2026-08-24 (Codex sol) · #184 full green / PR ready
+- quick/full: Rust·PDF51·canonical·corpus84·oracle82·HWPX·wasm/JS + Vitest 1,018 green.
+- 허용된 로컬 서버 Chromium 85 pass/3 intentional skip/0 fail; 임시 link 제거.
+- route/rhwp/HWPX/shared typesetter/generated/security diff 0. 다음 commit/push/PR→CI/merge.
+
+## 2026-08-24 (Codex sol) · #184 focused green
+- strict 7×3/19 merged cells + exact width-ref/span/geometry/1-paragraph ownership; hostile 10축.
+- HWP5 65/fmt/workspace clippy/wasm32 green; next LIST_HEADER 40865..40916.
+- classifier/route/rhwp/HWPX/generated diff 0. 다음 quick→full→PR/CI/merge.
+
 ## 2026-08-24 (Codex sol) · #184 classified
 - exact 7×3/19 cells; vertical span 1 + final-row horizontal span 1, no nesting, 1 paragraph/cell.
 - column/row/span sums equal object geometry; exact width-ref pattern; no-split/no-adjust faithfully modeled.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,11 @@
 
 ---
 
+## 2026-08-24 (Codex sol) · PR #183 merged / #184 started
+- #183 exact-head required CI·MERGEABLE·댓글 0 후 main `c95fef7c`; #182 close·branch 정리.
+- #94 근거 동기화, next TABLE boundary #184 등록, exact-main worktree 시작.
+- 다음 `0x4d/30321..30361` content-free classification; route/rhwp/HWPX 불변.
+
 ## 2026-08-24 (Codex sol) · #182 PR #183 게시
 - verified parser/test/state commit `4aa018b` push, PR #183(`Closes #182`) 생성.
 - 다음 exact-head required CI·review/general/inline·mergeability 추적→병합→#94/next child.


### PR DESCRIPTION
Closes #184

Refs #94 #182 #183

## What changed

- own the exact bounded HWP5 common-object/TABLE pair for a 7×3 atomic merged table
- validate all 19 row-major active cells, the single vertical merge and final-row horizontal merge, one paragraph per cell, column-bound width-reference pattern, mirrored cell extension, and object/row/column/span geometry
- preserve the active no-split and no-adjust semantics as shared-IR `keep_together` plus fixed row heights; the source repeat-header flag is inert because no cell carries the active header marker
- keep nearby or mutated structures fail-closed with ten independent hostile synthetic axes
- advance the content-free public own-parser boundary to the next unsupported LIST_HEADER record

## Verification

- HWP5: 65 tests green
- focused fmt, workspace clippy `-D warnings`, and wasm32 green
- `scripts/verify-local.sh`: Rust workspace, PDF visual 51, canonical 8/18/24 and 98.9%+, public corpus 84, oracle 82, HWPX, wasm, licenses green
- `scripts/verify-local.sh --full`: wasm rebuild 7,810,657 bytes, JS builds/crosscheck/i18n, Vitest 1,018 green; its only interruption was the sandbox denying the local E2E server port
- separate permitted Chromium E2E: 85 passed, 3 intentional skips, 0 failed

## Scope and safety

- no production route, HWPX parser/serializer, shared typesetter, generated asset, or vendored `external/rhwp` change
- no source document content, local path, hash, or raw payload is published
- unsupported flags, topology, geometry, framing, and width-reference variants continue to return a typed fail-closed error
