### PR TITLE
feat(hwp5): own exact 6x4 width-reference variants

### DIFF
--- a/crates/hwp-hwp5/src/semantic.rs
+++ b/crates/hwp-hwp5/src/semantic.rs
@@ -1830,8 +1830,13 @@ fn parse_inline_table(
     }
     let table_fill = table_border(doc, table_border_id, &table_record, section, "table")?;
 
+    let exact_six_by_four =
+        (common_attr, table_attr, rows, cols) == (0x082a_2311, 0x0400_0004, 6, 4);
+    let exact_seven_by_three =
+        (common_attr, table_attr, rows, cols) == (0x082a_2311, 0x0600_000c, 7, 3);
     let mut cells = Vec::with_capacity(expected_cells);
     let mut cell_heights = Vec::with_capacity(expected_cells);
+    let mut cell_width_refs = Vec::with_capacity(expected_cells);
     let mut nested_table_count = 0usize;
     let mut cursor = 1usize;
     while cursor < children.len() {
@@ -1867,10 +1872,6 @@ fn parse_inline_table(
                 "cell LIST_HEADER count, direction, alignment, or width reference is not owned",
             ));
         }
-        let exact_six_by_four =
-            (common_attr, table_attr, rows, cols) == (0x082a_2311, 0x0400_0004, 6, 4);
-        let exact_seven_by_three =
-            (common_attr, table_attr, rows, cols) == (0x082a_2311, 0x0600_000c, 7, 3);
         if (exact_six_by_four || exact_seven_by_three) && paragraph_count != 1 {
             return Err(malformed(
                 &list_record,
@@ -1906,13 +1907,10 @@ fn parse_inline_table(
             } else {
                 None
             };
-        let expected_six_by_four_width_ref =
-            exact_six_by_four.then_some(if row == 0 { 0x0100 } else { 0x0500 });
         let expected_seven_by_three_width_ref =
             exact_seven_by_three.then_some(if col == 2 { 0x0100 } else { 0x0500 });
         let expected_exact_width_ref = expected_one_by_two_width_ref
             .or(expected_eight_by_five_width_ref)
-            .or(expected_six_by_four_width_ref)
             .or(expected_seven_by_three_width_ref);
         let owned_width_ref = expected_exact_width_ref.map_or_else(
             || {
@@ -2083,6 +2081,7 @@ fn parse_inline_table(
             blocks.extend(parsed.tables.into_iter().map(Block::Table));
         }
         cell_heights.push(cell_height as HwpUnit);
+        cell_width_refs.push(width_ref);
         cells.push(Cell {
             row,
             col,
@@ -2107,6 +2106,20 @@ fn parse_inline_table(
             Some(section),
             "owned TABLE active-cell count differs from its exact topology",
         ));
+    }
+    if exact_six_by_four {
+        let row_header_then_body = cells
+            .iter()
+            .zip(&cell_width_refs)
+            .all(|(cell, width_ref)| *width_ref == if cell.row == 0 { 0x0100 } else { 0x0500 });
+        let all_body_reference = cell_width_refs.iter().all(|width_ref| *width_ref == 0x0500);
+        if !(row_header_then_body || all_body_reference) {
+            return Err(malformed(
+                &table_record,
+                Some(section),
+                "6x4 cell width-reference sequence differs from its exact owned variants",
+            ));
+        }
     }
     let expected_nested_tables = match (table_attr, rows, cols) {
         (0x0600_000c, 9, 8) => 1,

--- a/crates/hwp-hwp5/tests/layout_semantic.rs
+++ b/crates/hwp-hwp5/tests/layout_semantic.rs
@@ -126,6 +126,7 @@ enum OneByTwoMutation {
 #[derive(Clone, Copy)]
 enum SixByFourMutation {
     None,
+    AllBodyWidthReferences,
     BadCommonAttribute,
     BadTableAttribute,
     BadRowCellCount,
@@ -133,6 +134,7 @@ enum SixByFourMutation {
     BadRowHeight,
     BadParagraphCount,
     BadWidthReference,
+    BadAllBodyWidthReference,
     BadCellOrder,
     BadListExtension,
 }
@@ -928,6 +930,26 @@ fn owns_exact_six_by_four_atomic_full_grid_table() {
 }
 
 #[test]
+fn owns_exact_six_by_four_all_body_width_reference_variant() {
+    let doc = OwnHwp5Parser::new()
+        .parse(&six_by_four_fixture(
+            SixByFourMutation::AllBodyWidthReferences,
+        ))
+        .expect("strict all-body-reference 6x4 table fixture parses");
+    let [Block::Paragraph(anchor), Block::Table(table)] = doc.sections[0].blocks.as_slice() else {
+        panic!("table host must lower to one anchor and one table")
+    };
+    assert!(anchor.is_table_anchor);
+    assert_eq!((table.rows, table.cols, table.cells.len()), (6, 4, 24));
+    assert_eq!(table.col_widths, vec![3_238, 14_908, 11_795, 18_021]);
+    assert_eq!(
+        table.row_heights,
+        vec![1_946, 1_846, 1_846, 1_846, 1_846, 1_846]
+    );
+    assert!(table.cells.iter().all(|cell| cell.padding.is_none()));
+}
+
+#[test]
 fn strict_six_by_four_slice_rejects_hostile_pairing_topology_geometry_and_extensions() {
     for mutation in [
         SixByFourMutation::BadCommonAttribute,
@@ -937,6 +959,7 @@ fn strict_six_by_four_slice_rejects_hostile_pairing_topology_geometry_and_extens
         SixByFourMutation::BadRowHeight,
         SixByFourMutation::BadParagraphCount,
         SixByFourMutation::BadWidthReference,
+        SixByFourMutation::BadAllBodyWidthReference,
         SixByFourMutation::BadCellOrder,
         SixByFourMutation::BadListExtension,
     ] {
@@ -1949,7 +1972,15 @@ fn six_by_four_fixture(mutation: SixByFourMutation) -> Vec<u8> {
     for (index, (row, col)) in positions.into_iter().enumerate() {
         let mut width = COL_WIDTHS[col];
         let mut height = ROW_HEIGHTS[row];
-        let mut width_ref = if row == 0 { 0x0100u16 } else { 0x0500 };
+        let all_body_width_references = matches!(
+            mutation,
+            SixByFourMutation::AllBodyWidthReferences | SixByFourMutation::BadAllBodyWidthReference
+        );
+        let mut width_ref = if all_body_width_references || row != 0 {
+            0x0500u16
+        } else {
+            0x0100
+        };
         if index == 0 && matches!(mutation, SixByFourMutation::BadWidth) {
             width -= 1;
         }
@@ -1958,6 +1989,9 @@ fn six_by_four_fixture(mutation: SixByFourMutation) -> Vec<u8> {
         }
         if index == 0 && matches!(mutation, SixByFourMutation::BadWidthReference) {
             width_ref = 0x0500;
+        }
+        if index == 0 && matches!(mutation, SixByFourMutation::BadAllBodyWidthReference) {
+            width_ref = 0x0100;
         }
         let mut cell = Vec::with_capacity(47);
         cell.extend_from_slice(

--- a/crates/hwp-hwp5/tests/public_probe.rs
+++ b/crates/hwp-hwp5/tests/public_probe.rs
@@ -28,27 +28,27 @@ fn public_hwp5_has_bounded_content_free_record_provenance() {
 }
 
 #[test]
-fn explicit_own_parser_owns_bounded_seven_by_three_table_then_stops_content_free() {
+fn explicit_own_parser_owns_bounded_six_by_four_width_reference_variant_then_stops_content_free() {
     let probed = probe(&benchmark()).unwrap();
     let next = probed
         .streams
         .iter()
         .flat_map(|stream| &stream.records)
-        .find(|record| record.head == 40_865)
+        .find(|record| record.head == 44_479)
         .unwrap();
     assert_eq!(
         (next.tag, next.level, next.head, next.data, next.end, next.size,),
-        (0x48, 2, 40_865, 40_869, 40_916, 47)
+        (0x44, 1, 44_479, 44_483, 44_499, 16)
     );
     let error = OwnHwp5Parser::new().parse(&benchmark()).unwrap_err();
     eprintln!("{error:?}");
     assert!(matches!(
         error,
         Error::MalformedRecord {
-            tag: 0x48,
+            tag: 0x44,
             section: Some(0),
-            offset: 40865,
-            reason: "cell LIST_HEADER width reference differs from its exact owned topology",
+            offset: 44479,
+            reason: "empty paragraph has invalid PARA_CHAR_SHAPE boundaries",
             ..
         }
     ));

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -151,7 +151,15 @@
   LIST_HEADER `0x48/40865..40916`가 속한 6×4 variant의 전체 width-ref pattern·topology·geometry·
   framing을 먼저 분류하고 active semantic을 shared IR/SVG/PDF로 faithful하게 표현할 수 있을 때만
   exact discriminator와 synthetic/hostile fixture를 구현. production route·HWPX·shared layout
-  defaults·generated assets·rhwp는 불변.
+  defaults·generated assets·rhwp는 불변. 분류 결과 enclosing common/TABLE attr, 6×4/24-cell
+  row-major topology, 1문단/cell, widths/heights, padding·border, mirrored 13B extension은 #182 form과
+  exact 동일하다. 유일한 차이는 #182 form이 row0=`0x0100`/rows1..5=`0x0500`인 반면 이번 form은
+  24개 width-ref가 전부 `0x0500`이다. 두 값의 차이 `0x0400`은 pinned rhwp도 raw roundtrip hint로
+  보존할 뿐 렌더에서 해석하는 low active bits(own-margin/protect/header/form)를 바꾸지 않는다. absolute
+  cell/object geometry도 완전히 같아 shared IR/SVG/PDF의 active semantic 손실이 없다. one-shot numeric
+  classifier는 두 번 동일 결과를 확인한 뒤 제거했다. **다음:** 6×4 전체 width-ref sequence를
+  row0/body pattern 또는 all-`0x0500` 두 exact variant로만 원자 검증하고, 셀별 혼합·다른 word는
+  fail-closed하는 synthetic positive/hostile 회귀 구현; route/rhwp/HWPX/generated 불변.
 
 - 갱신: 2026-08-24 · Codex(sol) — **PR #173 병합 · #174 multi-table 경계 착수**.
   자체 HWP5 파서가 exact `tbl ` marker/common-object/TABLE/LIST_HEADER/cell paragraph를 검증해

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -169,8 +169,9 @@
   **8/18/24 + 98.9%+**, public corpus **84**, oracle **82**, wasm optimized **7,810,657B**, Vitest
   **1,018**, Chromium **85 passed/3 skipped/0 failed**. full의 sandbox bind EPERM만 별도 허용된
   Playwright 실행으로 대체 검증했고 임시 node_modules symlink 6개는 모두 제거했다. 최종 diff/check와
-  공개 보안 감사도 clean이며 strict parser/tests/state 5개만 변경된다. **다음:** commit/push/PR→
-  exact-head CI·댓글·mergeability 감사→merge→#94 동기화→PARA_CHAR_SHAPE next child.
+  공개 보안 감사도 clean이며 strict parser/tests/state 5개만 변경된다. 구현 commit `2b387e2`를
+  push하고 PR #187을 `Closes #186`로 게시했다. **다음:** exact-head CI·댓글·mergeability 감사→
+  merge→#94 동기화→PARA_CHAR_SHAPE next child.
 
 - 갱신: 2026-08-24 · Codex(sol) — **PR #173 병합 · #174 multi-table 경계 착수**.
   자체 HWP5 파서가 exact `tbl ` marker/common-object/TABLE/LIST_HEADER/cell paragraph를 검증해

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -143,8 +143,15 @@
   link는 모두 제거했다. final diff/security review에서 production route·rhwp·HWPX parser/serializer·
   shared typesetter·generated asset diff 0, source content/path/hash/raw payload/credential 노출 0을
   확인했고 변경 파일은 strict HWP5 parser/tests/state 5개뿐이다. 구현 commit `2f0c7ba`을 push하고
-  PR #185를 `Closes #184`로 게시했다. **다음:** exact-head CI·댓글·mergeability→자율 병합→
-  #94 동기화→next child.
+  PR #185를 `Closes #184`로 게시했다. exact head `a2825e6f`에서 issue-link **2s**·build-test
+  **7m34s**·licenses **2m16s** green, MERGEABLE, review/general/inline 댓글 0을 확인하고 protected
+  main `ee28afa2`로 squash 병합했다. #184 close·원격 branch 정리 후 #94에 exact 근거와 다음
+  boundary를 동기화했다. 중복 없는 #186을 R18/P1/area:hwp5/status:ready로 열고 exact latest main의
+  `codex/issue-186-hwp5-width-ref` worktree와 pinned rhwp oracle을 초기화했다. **다음:** content-free
+  LIST_HEADER `0x48/40865..40916`가 속한 6×4 variant의 전체 width-ref pattern·topology·geometry·
+  framing을 먼저 분류하고 active semantic을 shared IR/SVG/PDF로 faithful하게 표현할 수 있을 때만
+  exact discriminator와 synthetic/hostile fixture를 구현. production route·HWPX·shared layout
+  defaults·generated assets·rhwp는 불변.
 
 - 갱신: 2026-08-24 · Codex(sol) — **PR #173 병합 · #174 multi-table 경계 착수**.
   자체 HWP5 파서가 exact `tbl ` marker/common-object/TABLE/LIST_HEADER/cell paragraph를 검증해

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -159,7 +159,18 @@
   cell/object geometry도 완전히 같아 shared IR/SVG/PDF의 active semantic 손실이 없다. one-shot numeric
   classifier는 두 번 동일 결과를 확인한 뒤 제거했다. **다음:** 6×4 전체 width-ref sequence를
   row0/body pattern 또는 all-`0x0500` 두 exact variant로만 원자 검증하고, 셀별 혼합·다른 word는
-  fail-closed하는 synthetic positive/hostile 회귀 구현; route/rhwp/HWPX/generated 불변.
+  fail-closed하는 synthetic positive/hostile 회귀 구현; route/rhwp/HWPX/generated 불변. parser는
+  24-cell width-ref sequence 전체를 수집해 row0/body 또는 all-`0x0500`일 때만 수용하고, 두 pattern을
+  셀별로 섞은 hostile 변형은 양방향 모두 fail-closed한다. all-body synthetic positive도 기존 form과
+  동일한 shared geometry·no cell-own padding으로 내려감을 검증한다. HWP5 **66 tests**, fmt, workspace
+  clippy `-D warnings`, wasm32 green이며 공개 own-parser boundary는 표 밖 빈 문단의
+  PARA_CHAR_SHAPE `0x44/44479..44499` invalid boundary로 전진했다. temporary classifier diff 0,
+  production route·rhwp·HWPX/generated diff 0. quick와 full은 모두 green: PDF visual **51**, canonical
+  **8/18/24 + 98.9%+**, public corpus **84**, oracle **82**, wasm optimized **7,810,657B**, Vitest
+  **1,018**, Chromium **85 passed/3 skipped/0 failed**. full의 sandbox bind EPERM만 별도 허용된
+  Playwright 실행으로 대체 검증했고 임시 node_modules symlink 6개는 모두 제거했다. 최종 diff/check와
+  공개 보안 감사도 clean이며 strict parser/tests/state 5개만 변경된다. **다음:** commit/push/PR→
+  exact-head CI·댓글·mergeability 감사→merge→#94 동기화→PARA_CHAR_SHAPE next child.
 
 - 갱신: 2026-08-24 · Codex(sol) — **PR #173 병합 · #174 multi-table 경계 착수**.
   자체 HWP5 파서가 exact `tbl ` marker/common-object/TABLE/LIST_HEADER/cell paragraph를 검증해

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,16 @@
 
 ---
 
+## 2026-08-24 (Codex sol) · #186 full green
+- quick/full green: PDF51, canonical gates, corpus84/oracle82, wasm 7,810,657B, Vitest1,018.
+- sandbox bind만 별도 Playwright로 검증: Chromium 85 passed/3 skipped/0 failed.
+- temporary links removed; final security/diff clean. 다음 commit/push/PR/CI/merge.
+
+## 2026-08-24 (Codex sol) · #186 focused green
+- two whole 6×4 width-ref patterns only; mixed patterns rejected both directions, output geometry same.
+- HWP5 66/fmt/workspace clippy/wasm32 green; next PARA_CHAR_SHAPE 44479..44499.
+- classifier/route/rhwp/HWPX/generated diff 0. 다음 quick→full→PR/CI/merge.
+
 ## 2026-08-24 (Codex sol) · #186 classified
 - #182와 geometry/topology exact 동일한 6×4; 차이는 width-ref 24개가 모두 `0x0500`.
 - 0x0100↔0x0500 차이는 active low cell bits 불변·raw roundtrip hint; 렌더 geometry 손실 없음.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,11 @@
 
 ---
 
+## 2026-08-24 (Codex sol) · PR #185 merged / #186 started
+- #185 exact-head required CI·MERGEABLE·댓글 0 후 main `ee28afa2`; #184 close·branch 정리.
+- #94 근거 동기화, next LIST_HEADER width-ref boundary #186 등록, exact-main worktree 시작.
+- 다음 enclosing 6×4 variant content-free classification; route/rhwp/HWPX 불변.
+
 ## 2026-08-24 (Codex sol) · #184 PR #185 게시
 - verified parser/test/state commit `2f0c7ba` push, PR #185(`Closes #184`) 생성.
 - 다음 exact-head required CI·review/general/inline·mergeability 추적→병합→#94/next child.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,11 @@
 
 ---
 
+## 2026-08-24 (Codex sol) · #186 classified
+- #182와 geometry/topology exact 동일한 6×4; 차이는 width-ref 24개가 모두 `0x0500`.
+- 0x0100↔0x0500 차이는 active low cell bits 불변·raw roundtrip hint; 렌더 geometry 손실 없음.
+- classifier 제거. 다음 two whole-pattern allowlist + mixed/unknown hostile; route/rhwp/HWPX 불변.
+
 ## 2026-08-24 (Codex sol) · PR #185 merged / #186 started
 - #185 exact-head required CI·MERGEABLE·댓글 0 후 main `ee28afa2`; #184 close·branch 정리.
 - #94 근거 동기화, next LIST_HEADER width-ref boundary #186 등록, exact-main worktree 시작.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,10 @@
 
 ---
 
+## 2026-08-24 (Codex sol) · #186 PR #187 게시
+- verified parser/test/state commit `2b387e2` push, PR #187(`Closes #186`) 생성.
+- 다음 exact-head required CI·review/general/inline·mergeability 추적→병합→#94/next child.
+
 ## 2026-08-24 (Codex sol) · #186 full green
 - quick/full green: PDF51, canonical gates, corpus84/oracle82, wasm 7,810,657B, Vitest1,018.
 - sandbox bind만 별도 Playwright로 검증: Chromium 85 passed/3 skipped/0 failed.


### PR DESCRIPTION
Closes #186

## What changed
- accept the newly classified exact 6×4 HWP5 table only when its complete 24-cell width-reference sequence matches one of two known forms
- preserve the existing row-header/body form and add the all-body-reference form without changing their shared IR geometry
- reject mixed sequences in both directions with synthetic hostile regression coverage
- advance the content-free public boundary to the next empty-paragraph `PARA_CHAR_SHAPE` record

## Why this is safe
- both accepted forms have identical topology, dimensions, padding, border, and active low cell-property bits
- validation is atomic across the whole cell sequence; unknown or partially mixed forms remain fail-closed
- production routing, vendored rhwp, HWPX, shared typesetting defaults, generated wasm, and public fixtures are unchanged
- no source document content, path, digest, or raw payload is published

## Verification
- `scripts/verify-local.sh`
- `scripts/verify-local.sh --full` (all non-server phases green; sandbox bind restriction independently covered below)
- Rust HWP5: 66 tests
- PDF visual: 51; canonical layout: 8/18/24 and 98.9%+; public corpus: 84; oracle: 82
- wasm optimized: 7,810,657 bytes; Vitest: 1,018
- Chromium Playwright: 85 passed, 3 skipped, 0 failed

Parent: #94
Predecessor: #184 / #185
