### PR TITLE
feat(hwp5): own control-host terminator shape

### DIFF
--- a/crates/hwp-hwp5/src/semantic.rs
+++ b/crates/hwp-hwp5/src/semantic.rs
@@ -3212,10 +3212,28 @@ fn make_runs(
                 content: Vec::new(),
                 ..Run::default()
             }]),
+            [(0, control_shape), (terminator, terminator_shape)]
+                if !decoded.structural_controls.is_empty()
+                    && decoded.structural_controls[0].0 == 0
+                    && decoded.terminator == Some(*terminator) =>
+            {
+                Ok(vec![
+                    Run {
+                        char_shape: *control_shape,
+                        content: Vec::new(),
+                        ..Run::default()
+                    },
+                    Run {
+                        char_shape: *terminator_shape,
+                        content: Vec::new(),
+                        ..Run::default()
+                    },
+                ])
+            }
             _ => Err(malformed(
                 &record.expect("non-empty refs have a source record"),
                 Some(section),
-                "empty paragraph has invalid PARA_CHAR_SHAPE boundaries",
+                "text-empty control host has invalid PARA_CHAR_SHAPE boundaries",
             )),
         };
     }

--- a/crates/hwp-hwp5/tests/layout_semantic.rs
+++ b/crates/hwp-hwp5/tests/layout_semantic.rs
@@ -63,6 +63,10 @@ enum Mutation {
     DuplicatePageNumber,
     IdempotentPageNumberControls,
     Table,
+    TableTerminatorCharShape,
+    TableBadTerminatorShapeBoundary,
+    TableBadTerminatorShapeReference,
+    TableBadDeclaredTerminatorShapeCount,
     BadTableAttr,
     BadTableTopology,
     BadTableGeometry,
@@ -596,6 +600,61 @@ fn owns_strict_inline_one_by_one_table_as_anchor_plus_shared_ir() {
 }
 
 #[test]
+fn owns_exact_terminator_char_shape_for_text_empty_control_host() {
+    let doc = OwnHwp5Parser::new()
+        .parse(&fixture(Mutation::TableTerminatorCharShape))
+        .expect("control marker and terminator shape boundaries parse");
+    let [Block::Paragraph(anchor), Block::Table(_), Block::Paragraph(_)] =
+        doc.sections[0].blocks.as_slice()
+    else {
+        panic!("table host, table, and trailing blank paragraph expected")
+    };
+    assert!(anchor.is_table_anchor);
+    assert_eq!(anchor.runs.len(), 2);
+    assert_eq!(
+        anchor
+            .runs
+            .iter()
+            .map(|run| run.char_shape)
+            .collect::<Vec<_>>(),
+        vec![1, 2]
+    );
+    assert!(anchor.runs.iter().all(|run| run.content.is_empty()));
+}
+
+#[test]
+fn strict_text_empty_control_host_rejects_bad_terminator_shape_boundaries_and_counts() {
+    assert!(matches!(
+        OwnHwp5Parser::new().parse(&fixture(Mutation::TableBadTerminatorShapeBoundary)),
+        Err(Error::MalformedRecord {
+            tag: TAG_PARA_CHAR_SHAPE,
+            section: Some(0),
+            reason: "text-empty control host has invalid PARA_CHAR_SHAPE boundaries",
+            ..
+        })
+    ));
+    assert!(matches!(
+        OwnHwp5Parser::new().parse(&fixture(Mutation::TableBadTerminatorShapeReference)),
+        Err(Error::InvalidReference {
+            kind: "character shape",
+            index: 2,
+            pool_len: 2,
+            section: Some(0),
+            ..
+        })
+    ));
+    assert!(matches!(
+        OwnHwp5Parser::new().parse(&fixture(Mutation::TableBadDeclaredTerminatorShapeCount)),
+        Err(Error::MalformedRecord {
+            tag: TAG_PARA_HEADER,
+            section: Some(0),
+            reason: "PARA_HEADER character-shape count differs from PARA_CHAR_SHAPE",
+            ..
+        })
+    ));
+}
+
+#[test]
 fn strict_inline_table_rejects_unowned_attributes_topology_geometry_alignment_and_refs() {
     for mutation in [
         Mutation::BadTableAttr,
@@ -1055,6 +1114,10 @@ fn fixture(mutation: Mutation) -> Vec<u8> {
     let has_table = matches!(
         mutation,
         Mutation::Table
+            | Mutation::TableTerminatorCharShape
+            | Mutation::TableBadTerminatorShapeBoundary
+            | Mutation::TableBadTerminatorShapeReference
+            | Mutation::TableBadDeclaredTerminatorShapeCount
             | Mutation::BadTableAttr
             | Mutation::BadTableTopology
             | Mutation::BadTableGeometry
@@ -1106,6 +1169,13 @@ fn fixture(mutation: Mutation) -> Vec<u8> {
             | Mutation::MultiTableStrayChild
             | Mutation::MultiTableThirdControl
     );
+    let has_terminal_shape = matches!(
+        mutation,
+        Mutation::TableTerminatorCharShape
+            | Mutation::TableBadTerminatorShapeBoundary
+            | Mutation::TableBadTerminatorShapeReference
+            | Mutation::TableBadDeclaredTerminatorShapeCount
+    );
     let mut doc_info = Vec::new();
     let mut properties = vec![0; 26];
     let section_count = if matches!(
@@ -1129,7 +1199,11 @@ fn fixture(mutation: Mutation) -> Vec<u8> {
         1,
         1,
         usize::from(has_table),
-        if has_large_table { 2 } else { 1 },
+        if has_large_table || has_terminal_shape {
+            2
+        } else {
+            1
+        },
         0,
         0,
         0,
@@ -1146,7 +1220,7 @@ fn fixture(mutation: Mutation) -> Vec<u8> {
         push_record(&mut doc_info, TAG_BORDER_FILL, 0, &solid_border_fill());
     }
     push_record(&mut doc_info, TAG_CHAR_SHAPE, 0, &char_shape());
-    if has_large_table {
+    if has_large_table || has_terminal_shape {
         push_record(&mut doc_info, TAG_CHAR_SHAPE, 0, &char_shape());
     }
     push_record(&mut doc_info, TAG_PARA_SHAPE, 0, &para_shape());
@@ -1244,7 +1318,12 @@ fn fixture(mutation: Mutation) -> Vec<u8> {
                 0
             }
             | if has_table { 1 << 0x000b } else { 0 },
-        1,
+        if has_terminal_shape && !matches!(mutation, Mutation::TableBadDeclaredTerminatorShapeCount)
+        {
+            2
+        } else {
+            1
+        },
         0,
         if has_columns {
             0x03
@@ -1255,7 +1334,27 @@ fn fixture(mutation: Mutation) -> Vec<u8> {
         },
     );
     push_record(&mut body, TAG_PARA_TEXT, 1, &utf16_bytes(&section_text));
-    push_record(&mut body, TAG_PARA_CHAR_SHAPE, 1, &shape_refs(&[(0, 0)]));
+    let host_shape_refs = if has_terminal_shape {
+        let terminator = section_text.len() as u32 - 1;
+        shape_refs(&[
+            (0, 0),
+            (
+                if matches!(mutation, Mutation::TableBadTerminatorShapeBoundary) {
+                    terminator - 1
+                } else {
+                    terminator
+                },
+                if matches!(mutation, Mutation::TableBadTerminatorShapeReference) {
+                    2
+                } else {
+                    1
+                },
+            ),
+        ])
+    } else {
+        shape_refs(&[(0, 0)])
+    };
+    push_record(&mut body, TAG_PARA_CHAR_SHAPE, 1, &host_shape_refs);
     let mut section_control = Vec::with_capacity(28);
     section_control.extend_from_slice(&CTRL_SECTION_DEF.to_le_bytes());
     section_control.extend([0; 24]);

--- a/crates/hwp-hwp5/tests/public_probe.rs
+++ b/crates/hwp-hwp5/tests/public_probe.rs
@@ -28,27 +28,27 @@ fn public_hwp5_has_bounded_content_free_record_provenance() {
 }
 
 #[test]
-fn explicit_own_parser_owns_bounded_six_by_four_width_reference_variant_then_stops_content_free() {
+fn explicit_own_parser_owns_bounded_control_host_terminator_shape_then_stops_content_free() {
     let probed = probe(&benchmark()).unwrap();
     let next = probed
         .streams
         .iter()
         .flat_map(|stream| &stream.records)
-        .find(|record| record.head == 44_479)
+        .find(|record| record.head == 45_487)
         .unwrap();
     assert_eq!(
         (next.tag, next.level, next.head, next.data, next.end, next.size,),
-        (0x44, 1, 44_479, 44_483, 44_499, 16)
+        (0x48, 2, 45_487, 45_491, 45_538, 47)
     );
     let error = OwnHwp5Parser::new().parse(&benchmark()).unwrap_err();
     eprintln!("{error:?}");
     assert!(matches!(
         error,
         Error::MalformedRecord {
-            tag: 0x44,
+            tag: 0x48,
             section: Some(0),
-            offset: 44479,
-            reason: "empty paragraph has invalid PARA_CHAR_SHAPE boundaries",
+            offset: 45487,
+            reason: "cell LIST_HEADER count, direction, alignment, or width reference is not owned",
             ..
         }
     ));

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -192,7 +192,8 @@
   **85 passed/3 skipped/0 failed**. full의 sandbox bind EPERM만 별도 허용된 Playwright 실행으로 대체
   검증했고 임시 node_modules symlink 6개는 제거했다. 최종 diff/check와 공개 보안 감사 clean,
   strict parser/tests/state 5개만 변경되며 production route·rhwp·HWPX·typesetter·generated diff 0.
-  **다음:** commit/push/PR→exact-head CI·댓글·mergeability 감사→merge→#94/next child.
+  구현 commit `ae3ea4f`를 push하고 PR #189를 `Closes #188`로 게시했다. **다음:** exact-head
+  CI·댓글·mergeability 감사→merge→#94 동기화→next LIST_HEADER child.
 
 - 갱신: 2026-08-24 · Codex(sol) — **PR #173 병합 · #174 multi-table 경계 착수**.
   자체 HWP5 파서가 exact `tbl ` marker/common-object/TABLE/LIST_HEADER/cell paragraph를 검증해

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -170,8 +170,15 @@
   **1,018**, Chromium **85 passed/3 skipped/0 failed**. full의 sandbox bind EPERM만 별도 허용된
   Playwright 실행으로 대체 검증했고 임시 node_modules symlink 6개는 모두 제거했다. 최종 diff/check와
   공개 보안 감사도 clean이며 strict parser/tests/state 5개만 변경된다. 구현 commit `2b387e2`를
-  push하고 PR #187을 `Closes #186`로 게시했다. **다음:** exact-head CI·댓글·mergeability 감사→
-  merge→#94 동기화→PARA_CHAR_SHAPE next child.
+  push하고 PR #187을 `Closes #186`로 게시했다. exact head `1436566f`에서 issue-link **3s**·
+  build-test **7m55s**·licenses **2m15s** green, MERGEABLE/CLEAN, review/general/inline 댓글 0을
+  확인하고 protected main `55fc41aa`로 squash 병합했다. #186 close·원격 branch 정리 후 #94에
+  content-free 근거를 동기화했다. 중복 없는 #188을 R18/P1/area:hwp5/status:ready로 열고 exact
+  latest main의 `codex/issue-188-hwp5-empty-char-shape` worktree를 초기화했다. **다음:** 빈 문단
+  PARA_CHAR_SHAPE `0x44/44479..44499`의 enclosing paragraph framing·count/index sequence를 두 번
+  content-free 분류하고, active semantics를 손실 없이 shared IR로 표현할 수 있을 때만 atomic exact
+  discriminator와 positive/hostile fixture를 구현. production route·rhwp·HWPX·shared typesetter·
+  generated assets·public fixtures 불변.
 
 - 갱신: 2026-08-24 · Codex(sol) — **PR #173 병합 · #174 multi-table 경계 착수**.
   자체 HWP5 파서가 exact `tbl ` marker/common-object/TABLE/LIST_HEADER/cell paragraph를 검증해

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -178,7 +178,21 @@
   PARA_CHAR_SHAPE `0x44/44479..44499`의 enclosing paragraph framing·count/index sequence를 두 번
   content-free 분류하고, active semantics를 손실 없이 shared IR로 표현할 수 있을 때만 atomic exact
   discriminator와 positive/hostile fixture를 구현. production route·rhwp·HWPX·shared typesetter·
-  generated assets·public fixtures 불변.
+  generated assets·public fixtures 불변. 두 probe run은 exact 동일했다: 이 레코드는 일반 빈 문단이
+  아니라 단일 `tbl ` structural marker 8 UTF-16 units와 종결자만 가진 text-empty host이며,
+  PARA_HEADER는 char-count 9/control-mask `0x800`/declared-shapes 2, shape sequence는 marker start와
+  terminator에 대응하는 두 유효 pool ref다. 앞선 table host 20개는 모두 단일 start ref였고 이 form만
+  terminal insertion style을 별도 보존한다. parser는 visible text·geometry를 만들지 않고, 첫 structural
+  control이 offset 0이며 두 번째 boundary가 exact terminator일 때만 두 empty typed run으로 내린다.
+  malformed terminal offset, out-of-pool ref, declared-count mismatch는 각각 typed fail-closed fixture로
+  고정했다. HWP5 **68 tests** green이고 공개 boundary는 다음 cell LIST_HEADER
+  `0x48/45487..45538`로 전진했다. temporary classifiers는 제거되어 probe diff 0. fmt, workspace
+  clippy `-D warnings`, wasm32, quick/full 모두 green: PDF visual **51**, canonical **8/18/24 + 98.9%+**,
+  public corpus **84**, oracle **82**, wasm optimized **7,810,657B**, Vitest **1,018**, Chromium
+  **85 passed/3 skipped/0 failed**. full의 sandbox bind EPERM만 별도 허용된 Playwright 실행으로 대체
+  검증했고 임시 node_modules symlink 6개는 제거했다. 최종 diff/check와 공개 보안 감사 clean,
+  strict parser/tests/state 5개만 변경되며 production route·rhwp·HWPX·typesetter·generated diff 0.
+  **다음:** commit/push/PR→exact-head CI·댓글·mergeability 감사→merge→#94/next child.
 
 - 갱신: 2026-08-24 · Codex(sol) — **PR #173 병합 · #174 multi-table 경계 착수**.
   자체 HWP5 파서가 exact `tbl ` marker/common-object/TABLE/LIST_HEADER/cell paragraph를 검증해

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,10 @@
 
 ---
 
+## 2026-08-24 (Codex sol) · #188 PR #189 게시
+- verified parser/test/state commit `ae3ea4f` push, PR #189(`Closes #188`) 생성.
+- 다음 exact-head required CI·review/general/inline·mergeability 추적→병합→#94/next child.
+
 ## 2026-08-24 (Codex sol) · #188 full green
 - quick/full green: PDF51, canonical gates, corpus84/oracle82, wasm 7,810,657B, Vitest1,018.
 - sandbox bind만 별도 Playwright로 검증: Chromium 85 passed/3 skipped/0 failed.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,11 @@
 
 ---
 
+## 2026-08-24 (Codex sol) · PR #187 merged / #188 started
+- #187 exact-head required CI·MERGEABLE/CLEAN·댓글 0 후 main `55fc41aa`; #186 close·branch 정리.
+- #94 근거 동기화, next empty PARA_CHAR_SHAPE boundary #188 등록, exact-main worktree 시작.
+- 다음 content-free count/index/framing 2회 분류; route/rhwp/HWPX/typesetter/generated 불변.
+
 ## 2026-08-24 (Codex sol) · #186 PR #187 게시
 - verified parser/test/state commit `2b387e2` push, PR #187(`Closes #186`) 생성.
 - 다음 exact-head required CI·review/general/inline·mergeability 추적→병합→#94/next child.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,16 @@
 
 ---
 
+## 2026-08-24 (Codex sol) · #188 full green
+- quick/full green: PDF51, canonical gates, corpus84/oracle82, wasm 7,810,657B, Vitest1,018.
+- sandbox bind만 별도 Playwright로 검증: Chromium 85 passed/3 skipped/0 failed.
+- temp links removed; route/rhwp/HWPX/typesetter/generated/security diff clean. 다음 PR/CI/merge.
+
+## 2026-08-24 (Codex sol) · #188 classified / focused green
+- two runs exact: one table marker at 0 + terminator at 8; active text/geometry none, rhwp preserves refs.
+- exact terminal pair → two empty typed runs; bad boundary/ref/count fail closed; HWP5 68 green.
+- next LIST_HEADER 45487..45538; classifiers removed/probe diff 0. 다음 full gates→PR/CI/merge.
+
 ## 2026-08-24 (Codex sol) · PR #187 merged / #188 started
 - #187 exact-head required CI·MERGEABLE/CLEAN·댓글 0 후 main `55fc41aa`; #186 close·branch 정리.
 - #94 근거 동기화, next empty PARA_CHAR_SHAPE boundary #188 등록, exact-main worktree 시작.


### PR DESCRIPTION
Closes #188

## What changed
- classify the next strict HWP5 boundary as a text-empty table-control host with separate marker and paragraph-terminator character-shape references
- lower that exact two-boundary form to two typed empty runs without inventing visible text or layout geometry
- fail closed on a non-terminal second boundary, an out-of-pool shape reference, or a declared shape-count mismatch
- advance the public content-free parser boundary to the next cell `LIST_HEADER`

## Why this is safe
- the accepted form requires at least one owned structural control at offset zero and exactly two shape boundaries, with the second equal to the decoded paragraph terminator
- both output runs are content-empty; table topology and geometry continue through the existing owned table path
- production routing, vendored rhwp, HWPX, shared typesetting, generated wasm/assets, and public fixtures are unchanged
- no source document content, path, digest, or raw payload is published

## Verification
- `scripts/verify-local.sh`
- `scripts/verify-local.sh --full` (all non-server phases green; sandbox bind restriction independently covered below)
- Rust HWP5: 68 tests
- PDF visual: 51; canonical layout: 8/18/24 and 98.9%+; public corpus: 84; oracle: 82
- wasm optimized: 7,810,657 bytes; Vitest: 1,018
- Chromium Playwright: 85 passed, 3 skipped, 0 failed

Parent: #94
Predecessor: #186 / #187
