### PR TITLE
feat: own exact HWP5 six-paragraph cell

### DIFF
--- a/crates/hwp-hwp5/src/semantic.rs
+++ b/crates/hwp-hwp5/src/semantic.rs
@@ -1834,6 +1834,8 @@ fn parse_inline_table(
         (common_attr, table_attr, rows, cols) == (0x082a_2311, 0x0400_0004, 6, 4);
     let exact_seven_by_three =
         (common_attr, table_attr, rows, cols) == (0x082a_2311, 0x0600_000c, 7, 3);
+    let exact_one_by_one =
+        (common_attr, table_attr, rows, cols) == (0x082a_2311, 0x0400_0006, 1, 1);
     let mut cells = Vec::with_capacity(expected_cells);
     let mut cell_heights = Vec::with_capacity(expected_cells);
     let mut cell_width_refs = Vec::with_capacity(expected_cells);
@@ -1865,7 +1867,9 @@ fn parse_inline_table(
         }
         let paragraph_count = read_u16(list_bytes, 0).expect("exact length checked") as usize;
         let width_ref = read_u16(list_bytes, 6).expect("exact length checked");
-        if !(1..=5).contains(&paragraph_count) || read_u32(list_bytes, 2) != Some(0x0020_0000) {
+        let owned_paragraph_count = (1..=5).contains(&paragraph_count)
+            || (exact_one_by_one && paragraph_count == 6 && width_ref == 0x0500);
+        if !owned_paragraph_count || read_u32(list_bytes, 2) != Some(0x0020_0000) {
             return Err(malformed(
                 &list_record,
                 Some(section),

--- a/crates/hwp-hwp5/tests/layout_semantic.rs
+++ b/crates/hwp-hwp5/tests/layout_semantic.rs
@@ -67,6 +67,11 @@ enum Mutation {
     TableBadTerminatorShapeBoundary,
     TableBadTerminatorShapeReference,
     TableBadDeclaredTerminatorShapeCount,
+    SixParagraphTable,
+    SixParagraphBadWidthReference,
+    SixParagraphBadGeometry,
+    SixParagraphBadExtension,
+    SevenParagraphTable,
     BadTableAttr,
     BadTableTopology,
     BadTableGeometry,
@@ -668,6 +673,40 @@ fn strict_inline_table_rejects_unowned_attributes_topology_geometry_alignment_an
 }
 
 #[test]
+fn owns_exact_six_paragraph_one_by_one_cell() {
+    let doc = OwnHwp5Parser::new()
+        .parse(&fixture(Mutation::SixParagraphTable))
+        .expect("exact six-paragraph cell parses");
+    let Block::Table(table) = &doc.sections[0].blocks[1] else {
+        panic!("table host must be followed by a shared table block")
+    };
+    assert_eq!((table.rows, table.cols, table.cells.len()), (1, 1, 1));
+    assert_eq!(table.col_widths, vec![20_000]);
+    assert_eq!(table.row_heights, vec![2_000]);
+    assert_eq!(table.cells[0].width, Some(20_000));
+    assert_eq!(table.cells[0].blocks.len(), 6);
+    assert!(table.cells[0]
+        .blocks
+        .iter()
+        .all(|block| matches!(block, Block::Paragraph(_))));
+}
+
+#[test]
+fn six_paragraph_cell_rejects_unowned_count_pairing_and_geometry() {
+    for mutation in [
+        Mutation::SevenParagraphTable,
+        Mutation::SixParagraphBadWidthReference,
+        Mutation::SixParagraphBadGeometry,
+        Mutation::SixParagraphBadExtension,
+    ] {
+        assert!(
+            OwnHwp5Parser::new().parse(&fixture(mutation)).is_err(),
+            "hostile six-paragraph mutation must fail closed"
+        );
+    }
+}
+
+#[test]
 fn owns_strict_inline_ten_by_two_table_with_horizontal_merges_and_multiple_paragraphs() {
     let doc = OwnHwp5Parser::new()
         .parse(&fixture(Mutation::LargeTable))
@@ -1118,6 +1157,11 @@ fn fixture(mutation: Mutation) -> Vec<u8> {
             | Mutation::TableBadTerminatorShapeBoundary
             | Mutation::TableBadTerminatorShapeReference
             | Mutation::TableBadDeclaredTerminatorShapeCount
+            | Mutation::SixParagraphTable
+            | Mutation::SixParagraphBadWidthReference
+            | Mutation::SixParagraphBadGeometry
+            | Mutation::SixParagraphBadExtension
+            | Mutation::SevenParagraphTable
             | Mutation::BadTableAttr
             | Mutation::BadTableTopology
             | Mutation::BadTableGeometry
@@ -1577,7 +1621,17 @@ fn fixture(mutation: Mutation) -> Vec<u8> {
             positions.swap(2, 3);
         }
         for (cell_index, (row, col, col_span)) in positions.into_iter().enumerate() {
-            let paragraph_count = if has_large_table && cell_index == 0 {
+            let paragraph_count = if matches!(mutation, Mutation::SevenParagraphTable) {
+                7u16
+            } else if matches!(
+                mutation,
+                Mutation::SixParagraphTable
+                    | Mutation::SixParagraphBadWidthReference
+                    | Mutation::SixParagraphBadGeometry
+                    | Mutation::SixParagraphBadExtension
+            ) {
+                6
+            } else if has_large_table && cell_index == 0 {
                 if matches!(mutation, Mutation::LargeTableBadParagraphCount) {
                     6u16
                 } else {
@@ -1586,14 +1640,15 @@ fn fixture(mutation: Mutation) -> Vec<u8> {
             } else {
                 1
             };
-            let width_ref =
-                if matches!(mutation, Mutation::LargeTableBadWidthRef) && cell_index == 0 {
-                    0x0200u16
-                } else if has_large_table {
-                    [0x0000u16, 0x0100, 0x0500][cell_index % 3]
-                } else {
-                    0x0500
-                };
+            let width_ref = if matches!(mutation, Mutation::SixParagraphBadWidthReference) {
+                0x0100u16
+            } else if matches!(mutation, Mutation::LargeTableBadWidthRef) && cell_index == 0 {
+                0x0200u16
+            } else if has_large_table {
+                [0x0000u16, 0x0100, 0x0500][cell_index % 3]
+            } else {
+                0x0500
+            };
             let mut cell_width = if has_large_table {
                 [9_361u32, 38_552][col..col + col_span].iter().sum()
             } else {
@@ -1602,7 +1657,9 @@ fn fixture(mutation: Mutation) -> Vec<u8> {
             if cell_index == 0
                 && matches!(
                     mutation,
-                    Mutation::BadTableGeometry | Mutation::LargeTableBadWidth
+                    Mutation::BadTableGeometry
+                        | Mutation::LargeTableBadWidth
+                        | Mutation::SixParagraphBadGeometry
                 )
             {
                 cell_width -= 1;
@@ -1647,7 +1704,18 @@ fn fixture(mutation: Mutation) -> Vec<u8> {
                 }
                 .to_le_bytes(),
             );
-            cell.extend([0; 13]);
+            if matches!(
+                mutation,
+                Mutation::SixParagraphTable | Mutation::SixParagraphBadExtension
+            ) {
+                cell.extend_from_slice(&cell_width.to_le_bytes());
+                cell.extend([0; 9]);
+                if matches!(mutation, Mutation::SixParagraphBadExtension) {
+                    cell[38] = 1;
+                }
+            } else {
+                cell.extend([0; 13]);
+            }
             push_record(&mut body, TAG_LIST_HEADER, 2, &cell);
 
             for paragraph in 0..paragraph_count {

--- a/crates/hwp-hwp5/tests/public_probe.rs
+++ b/crates/hwp-hwp5/tests/public_probe.rs
@@ -28,27 +28,27 @@ fn public_hwp5_has_bounded_content_free_record_provenance() {
 }
 
 #[test]
-fn explicit_own_parser_owns_bounded_control_host_terminator_shape_then_stops_content_free() {
+fn explicit_own_parser_owns_six_paragraph_cell_then_stops_content_free() {
     let probed = probe(&benchmark()).unwrap();
     let next = probed
         .streams
         .iter()
         .flat_map(|stream| &stream.records)
-        .find(|record| record.head == 45_487)
+        .find(|record| record.head == 47_738)
         .unwrap();
     assert_eq!(
-        (next.tag, next.level, next.head, next.data, next.end, next.size,),
-        (0x48, 2, 45_487, 45_491, 45_538, 47)
+        (next.tag, next.level, next.head, next.data, next.end, next.size),
+        (0x47, 1, 47_738, 47_742, 47_788, 46)
     );
     let error = OwnHwp5Parser::new().parse(&benchmark()).unwrap_err();
     eprintln!("{error:?}");
     assert!(matches!(
         error,
         Error::MalformedRecord {
-            tag: 0x48,
+            tag: 0x47,
             section: Some(0),
-            offset: 45487,
-            reason: "cell LIST_HEADER count, direction, alignment, or width reference is not owned",
+            offset: 47738,
+            reason: "inline table common-object attributes are not owned",
             ..
         }
     ));

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -209,7 +209,12 @@
   방정식이 single-cell 폭·높이를 common geometry와 검증하므로 새 렌더 의미나 추측이 필요 없다.
   one-shot classifier는 제거되어 probe diff 0. **다음:** 이 exact 1×1 tuple에서 width-ref `0x0500`일
   때만 count 6을 허용하고, 7문단·다른 width-ref·geometry/extension drift를 fail-closed synthetic
-  회귀로 고정한 뒤 public own-parser boundary를 다음 레코드로 전진시킨다.
+  회귀로 고정한 뒤 public own-parser boundary를 다음 레코드로 전진시킨다. 구현은 generic 1~5 count를
+  유지하면서 exact tuple+`0x0500`의 count 6만 additive로 소유한다. positive fixture는 여섯 Block을
+  shared IR에 보존하며 count 7, `0x0100` pairing, cell/common geometry drift, 13B extension drift의
+  hostile 4축은 fail-closed한다. HWP5 **70 tests**, fmt, clippy `-D warnings`, wasm32 green이며 공개
+  boundary는 다음 common-object `CTRL_HEADER 0x47/47738`로 전진했다. **다음:** quick/full gate와
+  final diff/security audit→commit/push/PR/CI/merge; route·rhwp·HWPX·typesetter·generated 불변.
 
 - 갱신: 2026-08-24 · Codex(sol) — **PR #173 병합 · #174 multi-table 경계 착수**.
   자체 HWP5 파서가 exact `tbl ` marker/common-object/TABLE/LIST_HEADER/cell paragraph를 검증해

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -192,8 +192,15 @@
   **85 passed/3 skipped/0 failed**. full의 sandbox bind EPERM만 별도 허용된 Playwright 실행으로 대체
   검증했고 임시 node_modules symlink 6개는 제거했다. 최종 diff/check와 공개 보안 감사 clean,
   strict parser/tests/state 5개만 변경되며 production route·rhwp·HWPX·typesetter·generated diff 0.
-  구현 commit `ae3ea4f`를 push하고 PR #189를 `Closes #188`로 게시했다. **다음:** exact-head
-  CI·댓글·mergeability 감사→merge→#94 동기화→next LIST_HEADER child.
+  구현 commit `ae3ea4f`를 push하고 PR #189를 `Closes #188`로 게시했다. exact head `81eb33f7`에서
+  issue-link **2s**·build-test **7m41s**·licenses **2m58s** green, MERGEABLE/CLEAN,
+  review/general/inline 댓글 0을 확인하고 protected main `1263805e`로 squash 병합했다. #188 close·
+  원격 branch 정리 후 #94에 content-free 근거를 동기화했다. 중복 없는 #190을
+  R18/P1/area:hwp5/status:ready로 열고 exact latest main의 `codex/issue-190-hwp5-cell-property`
+  worktree를 초기화했다. **다음:** cell LIST_HEADER `0x48/45487..45538`의 enclosing common/TABLE,
+  전체 active-cell topology/order, geometry, flags, width-ref sequence, extension framing을 두 번
+  content-free 분류하고 shared IR로 active semantics를 lossless 표현할 수 있을 때만 atomic exact
+  discriminator와 positive/hostile fixture를 구현. route·rhwp·HWPX·typesetter·generated 불변.
 
 - 갱신: 2026-08-24 · Codex(sol) — **PR #173 병합 · #174 multi-table 경계 착수**.
   자체 HWP5 파서가 exact `tbl ` marker/common-object/TABLE/LIST_HEADER/cell paragraph를 검증해

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -213,8 +213,12 @@
   유지하면서 exact tuple+`0x0500`의 count 6만 additive로 소유한다. positive fixture는 여섯 Block을
   shared IR에 보존하며 count 7, `0x0100` pairing, cell/common geometry drift, 13B extension drift의
   hostile 4축은 fail-closed한다. HWP5 **70 tests**, fmt, clippy `-D warnings`, wasm32 green이며 공개
-  boundary는 다음 common-object `CTRL_HEADER 0x47/47738`로 전진했다. **다음:** quick/full gate와
-  final diff/security audit→commit/push/PR/CI/merge; route·rhwp·HWPX·typesetter·generated 불변.
+  boundary는 다음 common-object `CTRL_HEADER 0x47/47738`로 전진했다. quick/full 모두 green:
+  PDF visual **51**, canonical **8/18/24 + 98.9%+**, public corpus **84**, oracle **82**, HWPX,
+  wasm optimized **7,810,657B**, Vitest **1,007**, Chromium **85 passed/3 skipped/0 failed**. full의
+  sandbox bind EPERM만 허용된 Playwright 실행으로 분리 검증했고 임시 node_modules link 4개는 모두
+  제거했다. generated asset·production route·rhwp·HWPX·typesetter diff 0. **다음:** final
+  diff/security audit→verification evidence commit/push/PR/CI/merge.
 
 - 갱신: 2026-08-24 · Codex(sol) — **PR #173 병합 · #174 multi-table 경계 착수**.
   자체 HWP5 파서가 exact `tbl ` marker/common-object/TABLE/LIST_HEADER/cell paragraph를 검증해

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -218,7 +218,9 @@
   wasm optimized **7,810,657B**, Vitest **1,007**, Chromium **85 passed/3 skipped/0 failed**. full의
   sandbox bind EPERM만 허용된 Playwright 실행으로 분리 검증했고 임시 node_modules link 4개는 모두
   제거했다. generated asset·production route·rhwp·HWPX·typesetter diff 0. **다음:** final
-  diff/security audit→verification evidence commit/push/PR/CI/merge.
+  diff/security audit도 source content/path/hash/raw payload/credential 노출 0으로 clean하다. 구현·근거
+  commit `6bf0333`까지 push하고 PR #191을 `Closes #190`으로 게시했다. **다음:** exact-head required
+  CI(issue-link/build-test/licenses), review/general/inline 댓글, mergeability 확인→green이면 squash merge.
 
 - 갱신: 2026-08-24 · Codex(sol) — **PR #173 병합 · #174 multi-table 경계 착수**.
   자체 HWP5 파서가 exact `tbl ` marker/common-object/TABLE/LIST_HEADER/cell paragraph를 검증해

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -201,6 +201,15 @@
   전체 active-cell topology/order, geometry, flags, width-ref sequence, extension framing을 두 번
   content-free 분류하고 shared IR로 active semantics를 lossless 표현할 수 있을 때만 atomic exact
   discriminator와 positive/hostile fixture를 구현. route·rhwp·HWPX·typesetter·generated 불변.
+  두 독립 분류 run은 exact 동일했다. enclosing form은 common attr `0x082a2311` + TABLE attr
+  `0x04000006`, 1×1/active cell 1개이며 cell은 row/col 0, span 1×1, width-ref `0x0500`, exact
+  object/cell geometry, mirrored 13B layout-width extension을 가진다. 새 경계는 기존 최대 5개보다 긴
+  **6개 cell paragraph**뿐이고, 여섯 문단 모두 strict PARA_HEADER/TEXT/CHAR_SHAPE/LINE_SEG framing으로
+  구조 해석 가능하다. shared IR의 `Cell.blocks`는 임의 길이를 이미 lossless 보존하고 전역 span/row
+  방정식이 single-cell 폭·높이를 common geometry와 검증하므로 새 렌더 의미나 추측이 필요 없다.
+  one-shot classifier는 제거되어 probe diff 0. **다음:** 이 exact 1×1 tuple에서 width-ref `0x0500`일
+  때만 count 6을 허용하고, 7문단·다른 width-ref·geometry/extension drift를 fail-closed synthetic
+  회귀로 고정한 뒤 public own-parser boundary를 다음 레코드로 전진시킨다.
 
 - 갱신: 2026-08-24 · Codex(sol) — **PR #173 병합 · #174 multi-table 경계 착수**.
   자체 HWP5 파서가 exact `tbl ` marker/common-object/TABLE/LIST_HEADER/cell paragraph를 검증해

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,11 @@
 
 ---
 
+## 2026-08-24 (Codex sol) · #190 classified
+- two content-free runs exact: owned 1×1 table, `0x0500`, exact geometry/extension, 6 cell paragraphs.
+- shared `Cell.blocks` is lossless; global span/row equations already prove geometry; classifier removed.
+- next exact six-count discriminator + count/width-ref/geometry/extension hostile tests, then full gates/PR.
+
 ## 2026-08-24 (Codex sol) · PR #189 merged / #190 started
 - #189 exact-head required CI·MERGEABLE/CLEAN·댓글 0 후 main `1263805e`; #188 close·branch 정리.
 - #94 근거 동기화, next cell LIST_HEADER boundary #190 등록, exact-main worktree 시작.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,10 @@
 
 ---
 
+## 2026-08-24 (Codex sol) · #190 PR #191 posted
+- final diff/security audit clean; verified commits through `6bf0333` pushed.
+- PR #191 created with `Closes #190`; next required CI/comments/mergeability→merge.
+
 ## 2026-08-24 (Codex sol) · #190 full green
 - quick/full green: PDF51, canonical gates, corpus84/oracle82, wasm 7,810,657B, Vitest1,007.
 - sandbox bind only separated: Chromium 85 passed/3 skipped/0 failed; temp links removed.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,11 @@
 
 ---
 
+## 2026-08-24 (Codex sol) · PR #189 merged / #190 started
+- #189 exact-head required CI·MERGEABLE/CLEAN·댓글 0 후 main `1263805e`; #188 close·branch 정리.
+- #94 근거 동기화, next cell LIST_HEADER boundary #190 등록, exact-main worktree 시작.
+- 다음 enclosing table 전체 content-free 2회 분류; route/rhwp/HWPX/typesetter/generated 불변.
+
 ## 2026-08-24 (Codex sol) · #188 PR #189 게시
 - verified parser/test/state commit `ae3ea4f` push, PR #189(`Closes #188`) 생성.
 - 다음 exact-head required CI·review/general/inline·mergeability 추적→병합→#94/next child.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,11 @@
 
 ---
 
+## 2026-08-24 (Codex sol) · #190 full green
+- quick/full green: PDF51, canonical gates, corpus84/oracle82, wasm 7,810,657B, Vitest1,007.
+- sandbox bind only separated: Chromium 85 passed/3 skipped/0 failed; temp links removed.
+- route/rhwp/HWPX/typesetter/generated diff 0; next audit→evidence commit→PR/CI/merge.
+
 ## 2026-08-24 (Codex sol) · #190 focused green
 - exact 1×1 + `0x0500` only owns six paragraphs; shared IR preserves all six blocks.
 - count7/wrong width-ref/geometry/extension hostile axes fail closed; HWP5 70, fmt/clippy/wasm32 green.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,11 @@
 
 ---
 
+## 2026-08-24 (Codex sol) · #190 focused green
+- exact 1×1 + `0x0500` only owns six paragraphs; shared IR preserves all six blocks.
+- count7/wrong width-ref/geometry/extension hostile axes fail closed; HWP5 70, fmt/clippy/wasm32 green.
+- public boundary advanced to common-object `0x47/47738`; next quick/full→audit→PR/CI/merge.
+
 ## 2026-08-24 (Codex sol) · #190 classified
 - two content-free runs exact: owned 1×1 table, `0x0500`, exact geometry/extension, 6 cell paragraphs.
 - shared `Cell.blocks` is lossless; global span/row equations already prove geometry; classifier removed.


### PR DESCRIPTION
## Summary
- own the exact 1x1 HWP5 cell variant with six declared paragraphs and width reference 0x0500
- preserve all six paragraphs in shared IR while retaining existing global geometry equations
- fail closed on count 7, wrong width-reference pairing, geometry drift, and extension drift
- advance the content-free public parser boundary to the next common-object record

## Verification
- scripts/verify-local.sh
- scripts/verify-local.sh --full (local sandbox port bind separated)
- Chromium: 85 passed, 3 intentional skips, 0 failed
- HWP5: 70 tests; PDF visual: 51; public corpus: 84; oracle: 82
- canonical layout: 8/18/24 and 98.9%+
- Vitest: 1,007; optimized wasm: 7,810,657 bytes

## Boundaries
- production route unchanged
- external/rhwp unchanged and remains a pinned read-only oracle
- HWPX, shared typesetter, and generated assets unchanged
- no source content, local path, hash, raw payload, or credential is published

Closes #190