### PR TITLE
feat(hwp5): own exact captioned table boundary

### DIFF
--- a/crates/hwp-hwp5/src/semantic.rs
+++ b/crates/hwp-hwp5/src/semantic.rs
@@ -1598,7 +1598,7 @@ fn parse_inline_table(
     // 1×2 form stores column-relative placement. The table tuple below binds each flag word to only
     // its observed topology so a floating or unrelated object cannot be flattened.
     let common_attr = read_u32(common, 4).expect("exact length checked");
-    if !matches!(common_attr, 0x082a_2311 | 0x082a_2211) {
+    if !matches!(common_attr, 0x082a_2311 | 0x082a_2211 | 0x282a_2311) {
         return Err(malformed(
             control,
             Some(section),
@@ -1639,7 +1639,92 @@ fn parse_inline_table(
         ));
     }
     let child_level = control.level + 1;
-    if children.len() < 3 || children[0].tag != TAG_TABLE || children[0].level != child_level {
+    let (table_index, caption) = if common_attr == 0x282a_2311 {
+        let Some(list_record) = children.first().copied() else {
+            return Err(malformed(
+                control,
+                Some(section),
+                "captioned TABLE is missing its caption LIST_HEADER",
+            ));
+        };
+        let list_bytes = data(stream, &list_record);
+        if list_record.tag != TAG_LIST_HEADER
+            || list_record.level != child_level
+            || list_bytes.len() != 30
+            || read_u16(list_bytes, 0) != Some(1)
+            || read_u32(list_bytes, 2) != Some(0)
+            || read_u16(list_bytes, 6) != Some(0)
+            || read_u32(list_bytes, 8) != Some(2)
+            || read_u32(list_bytes, 12) != Some(8_504)
+            || read_u16(list_bytes, 16) != Some(850)
+            || read_u32(list_bytes, 18) != Some(48_047)
+            || list_bytes[22..].iter().any(|byte| *byte != 0)
+        {
+            return Err(malformed(
+                &list_record,
+                Some(section),
+                "caption LIST_HEADER differs from the exact owned top-caption tuple",
+            ));
+        }
+        let Some(header) = children.get(1).copied() else {
+            return Err(malformed(
+                &list_record,
+                Some(section),
+                "caption LIST_HEADER declares a missing paragraph",
+            ));
+        };
+        if header.tag != TAG_PARA_HEADER || header.level != child_level {
+            return Err(malformed(
+                &header,
+                Some(section),
+                "caption LIST_HEADER is not followed by its paragraph header",
+            ));
+        }
+        let mut next = 2usize;
+        while next < children.len() && children[next].level > child_level {
+            next += 1;
+        }
+        let parsed = parse_paragraph(
+            stream,
+            &children[1..next],
+            doc,
+            para_usage,
+            styles,
+            section,
+            None,
+            table_depth + 1,
+        )?;
+        if parsed.page.is_some()
+            || parsed.page_number.is_some()
+            || parsed.paragraph.page_break_before
+            || parsed.paragraph.column_break_before
+            || parsed.paragraph.column_layout_before.is_some()
+            || !parsed.tables.is_empty()
+        {
+            return Err(malformed(
+                &header,
+                Some(section),
+                "owned table caption contains nested layout controls",
+            ));
+        }
+        (
+            next,
+            Some(TableCaption {
+                position: TableCaptionPosition::Top,
+                blocks: vec![Block::Paragraph(parsed.paragraph)],
+                spacing: 850,
+                width: 8_504,
+                max_width: 48_047,
+                include_margin: false,
+            }),
+        )
+    } else {
+        (0, None)
+    };
+    if children.len() < table_index + 3
+        || children[table_index].tag != TAG_TABLE
+        || children[table_index].level != child_level
+    {
         return Err(malformed(
             control,
             Some(section),
@@ -1647,7 +1732,7 @@ fn parse_inline_table(
         ));
     }
 
-    let table_record = children[0];
+    let table_record = children[table_index];
     let table_bytes = data(stream, &table_record);
     if table_bytes.len() < 24 {
         return Err(malformed(
@@ -1754,6 +1839,9 @@ fn parse_inline_table(
             (7, 1, 2, 1),
             (7, 3, 2, 1),
         ],
+        (0x282a_2311, 0x0600_0006, 4, 5) => (0..4)
+            .flat_map(|row| (0..5).map(move |col| (row, col, 1, 1)))
+            .collect(),
         _ => {
             return Err(malformed(
                 &table_record,
@@ -1836,11 +1924,25 @@ fn parse_inline_table(
         (common_attr, table_attr, rows, cols) == (0x082a_2311, 0x0600_000c, 7, 3);
     let exact_one_by_one =
         (common_attr, table_attr, rows, cols) == (0x082a_2311, 0x0400_0006, 1, 1);
+    let exact_captioned = (common_attr, table_attr, rows, cols) == (0x282a_2311, 0x0600_0006, 4, 5);
+    if exact_captioned
+        && (width != 48_047
+            || height != 7_492
+            || margins != [141, 141, 141, 141]
+            || table_padding != [141, 141, 141, 141]
+            || table_border_id != 4)
+    {
+        return Err(malformed(
+            &table_record,
+            Some(section),
+            "captioned TABLE common or table geometry differs from its exact owned tuple",
+        ));
+    }
     let mut cells = Vec::with_capacity(expected_cells);
     let mut cell_heights = Vec::with_capacity(expected_cells);
     let mut cell_width_refs = Vec::with_capacity(expected_cells);
     let mut nested_table_count = 0usize;
-    let mut cursor = 1usize;
+    let mut cursor = table_index + 1;
     while cursor < children.len() {
         if cells.len() == expected_cells {
             return Err(malformed(
@@ -1913,9 +2015,11 @@ fn parse_inline_table(
             };
         let expected_seven_by_three_width_ref =
             exact_seven_by_three.then_some(if col == 2 { 0x0100 } else { 0x0500 });
+        let expected_captioned_width_ref = exact_captioned.then_some(0x0400);
         let expected_exact_width_ref = expected_one_by_two_width_ref
             .or(expected_eight_by_five_width_ref)
-            .or(expected_seven_by_three_width_ref);
+            .or(expected_seven_by_three_width_ref)
+            .or(expected_captioned_width_ref);
         let owned_width_ref = expected_exact_width_ref.map_or_else(
             || {
                 matches!(width_ref, 0x0000 | 0x0100 | 0x0500)
@@ -1998,6 +2102,18 @@ fn parse_inline_table(
         // core width; the global span equations below prove that override instead of trusting it alone.
         debug_assert_eq!(list_extra.len(), 13);
         let cell_border_id = read_u16(list_bytes, 32).expect("exact length checked");
+        if exact_captioned
+            && (paragraph_count != 1
+                || cell_padding != [141, 141, 141, 141]
+                || !width_extension
+                || extension_width != cell_width)
+        {
+            return Err(malformed(
+                &list_record,
+                Some(section),
+                "captioned TABLE cell framing differs from its exact owned tuple",
+            ));
+        }
         let cell_fill = table_border(doc, cell_border_id, &list_record, section, "table cell")?;
 
         cursor += 1;
@@ -2263,6 +2379,16 @@ fn parse_inline_table(
     let stored_height = derived_rows
         .iter()
         .try_fold(0i64, |sum, value| sum.checked_add(i64::from(*value)));
+    if exact_captioned
+        && (col_widths != [3_221, 6_593, 8_956, 21_855, 7_422]
+            || derived_rows != [1_948, 1_848, 1_848, 1_848])
+    {
+        return Err(malformed(
+            &table_record,
+            Some(section),
+            "captioned TABLE column or row geometry differs from its exact owned grid",
+        ));
+    }
     let owned_nested_stale_common_height = table_depth == 1
         && (table_attr, rows, cols, height, stored_height)
             == (0x0400_0006, 1, 1, 3_882, Some(1_848));
@@ -2275,6 +2401,7 @@ fn parse_inline_table(
     }
 
     Ok(Table {
+        caption,
         rows,
         cols,
         cells,
@@ -2284,9 +2411,9 @@ fn parse_inline_table(
         keep_together: table_attr != 0x0600_000e,
         col_widths,
         row_heights: derived_rows,
-        // Both exact large-table attributes carry HWP's no-adjust bit. Their stored row heights are
+        // The exact no-adjust table attributes carry HWP's no-adjust bit. Their stored row heights are
         // exact clipping geometry, not merely content-size floors.
-        fixed_row_heights: matches!(table_attr, 0x0600_000c | 0x0600_000e),
+        fixed_row_heights: matches!(table_attr, 0x0600_0006 | 0x0600_000c | 0x0600_000e),
         outer_margin_left: margins[0] as HwpUnit,
         outer_margin_right: margins[1] as HwpUnit,
         outer_margin_top: margins[2] as HwpUnit,

--- a/crates/hwp-hwp5/tests/layout_semantic.rs
+++ b/crates/hwp-hwp5/tests/layout_semantic.rs
@@ -149,6 +149,22 @@ enum SixByFourMutation {
 }
 
 #[derive(Clone, Copy)]
+enum CaptionedTableMutation {
+    None,
+    BadCaptionDirection,
+    BadCaptionGap,
+    BadCaptionReserved,
+    MissingCaptionParagraph,
+    ExtraCaptionParagraph,
+    BadTableAttribute,
+    BadRowCellCount,
+    BadWidthReference,
+    BadListExtension,
+    BadGridGeometry,
+    BadCellBorder,
+}
+
+#[derive(Clone, Copy)]
 enum SevenByThreeMutation {
     None,
     BadCommonAttribute,
@@ -1066,6 +1082,72 @@ fn strict_six_by_four_slice_rejects_hostile_pairing_topology_geometry_and_extens
                 .parse(&six_by_four_fixture(mutation))
                 .is_err(),
             "hostile 6x4 mutation must fail closed"
+        );
+    }
+}
+
+#[test]
+fn owns_exact_top_captioned_four_by_five_full_grid_table() {
+    let doc = OwnHwp5Parser::new()
+        .parse(&captioned_table_fixture(CaptionedTableMutation::None))
+        .expect("strict captioned 4x5 full-grid table fixture parses");
+    let [Block::Paragraph(anchor), Block::Table(table)] = doc.sections[0].blocks.as_slice() else {
+        panic!("table host must lower to one anchor and one table")
+    };
+    assert!(anchor.is_table_anchor);
+    assert_eq!((table.rows, table.cols, table.cells.len()), (4, 5, 20));
+    assert!(table.keep_together);
+    assert!(table.fixed_row_heights);
+    assert_eq!(table.col_widths, vec![3_221, 6_593, 8_956, 21_855, 7_422]);
+    assert_eq!(table.row_heights, vec![1_948, 1_848, 1_848, 1_848]);
+    let caption = table
+        .caption
+        .as_ref()
+        .expect("top caption reaches shared IR");
+    assert_eq!(
+        caption.position,
+        hwp_model::document::TableCaptionPosition::Top
+    );
+    assert_eq!(
+        (caption.width, caption.spacing, caption.max_width),
+        (8_504, 850, 48_047)
+    );
+    assert!(!caption.include_margin);
+    assert_eq!(caption.blocks.len(), 1);
+    assert!(matches!(caption.blocks[0], Block::Paragraph(_)));
+    assert!(table.cells.iter().enumerate().all(|(index, cell)| {
+        (cell.row, cell.col, cell.row_span, cell.col_span, cell.width)
+            == (
+                index / 5,
+                index % 5,
+                1,
+                1,
+                Some(table.col_widths[index % 5]),
+            )
+            && cell.blocks.len() == 1
+    }));
+}
+
+#[test]
+fn strict_captioned_table_rejects_hostile_caption_topology_geometry_and_refs() {
+    for mutation in [
+        CaptionedTableMutation::BadCaptionDirection,
+        CaptionedTableMutation::BadCaptionGap,
+        CaptionedTableMutation::BadCaptionReserved,
+        CaptionedTableMutation::MissingCaptionParagraph,
+        CaptionedTableMutation::ExtraCaptionParagraph,
+        CaptionedTableMutation::BadTableAttribute,
+        CaptionedTableMutation::BadRowCellCount,
+        CaptionedTableMutation::BadWidthReference,
+        CaptionedTableMutation::BadListExtension,
+        CaptionedTableMutation::BadGridGeometry,
+        CaptionedTableMutation::BadCellBorder,
+    ] {
+        assert!(
+            OwnHwp5Parser::new()
+                .parse(&captioned_table_fixture(mutation))
+                .is_err(),
+            "hostile captioned-table mutation must fail closed"
         );
     }
 }
@@ -2183,6 +2265,201 @@ fn six_by_four_fixture(mutation: SixByFourMutation) -> Vec<u8> {
         cell.extend_from_slice(&width.to_le_bytes());
         cell.extend([0; 9]);
         if index == 0 && matches!(mutation, SixByFourMutation::BadListExtension) {
+            cell[38] = 1;
+        }
+        push_record(&mut body, TAG_LIST_HEADER, 2, &cell);
+        push_para_header_at_level(&mut body, 2, 2, 0, 1, 0, 0);
+        push_record(
+            &mut body,
+            TAG_PARA_TEXT,
+            3,
+            &utf16_bytes(&[u16::from(b'A') + index as u16, 0x000d]),
+        );
+        push_record(&mut body, TAG_PARA_CHAR_SHAPE, 3, &shape_refs(&[(0, 0)]));
+    }
+
+    let mut compound = CompoundFile::create(Cursor::new(Vec::new())).unwrap();
+    {
+        let mut stream = compound.create_stream("/FileHeader").unwrap();
+        stream.write_all(&header).unwrap();
+    }
+    {
+        let mut stream = compound.create_stream("/DocInfo").unwrap();
+        stream.write_all(&doc_info).unwrap();
+    }
+    compound.create_storage("/BodyText").unwrap();
+    {
+        let mut stream = compound.create_stream("/BodyText/Section0").unwrap();
+        stream.write_all(&body).unwrap();
+    }
+    compound.into_inner().into_inner()
+}
+
+fn captioned_table_fixture(mutation: CaptionedTableMutation) -> Vec<u8> {
+    const COL_WIDTHS: [u32; 5] = [3_221, 6_593, 8_956, 21_855, 7_422];
+    const ROW_HEIGHTS: [u32; 4] = [1_948, 1_848, 1_848, 1_848];
+
+    let mut header = vec![0; 256];
+    header[..HWP_SIGNATURE.len()].copy_from_slice(HWP_SIGNATURE);
+    header[32..36].copy_from_slice(&[0, 0, 0, 5]);
+
+    let mut doc_info = Vec::new();
+    let mut properties = vec![0; 26];
+    properties[..2].copy_from_slice(&1u16.to_le_bytes());
+    push_record(&mut doc_info, TAG_DOCUMENT_PROPERTIES, 0, &properties);
+    let mut mappings = Vec::new();
+    for count in [0, 1, 1, 1, 1, 1, 1, 1, 35, 1, 0, 0, 0, 1, 0] {
+        mappings.extend_from_slice(&(count as u32).to_le_bytes());
+    }
+    push_record(&mut doc_info, TAG_ID_MAPPINGS, 0, &mappings);
+    for _ in 0..7 {
+        push_record(&mut doc_info, TAG_FACE_NAME, 0, &face_name("Test Sans"));
+    }
+    for _ in 0..35 {
+        push_record(&mut doc_info, TAG_BORDER_FILL, 0, &solid_border_fill());
+    }
+    push_record(&mut doc_info, TAG_CHAR_SHAPE, 0, &char_shape());
+    push_record(&mut doc_info, TAG_PARA_SHAPE, 0, &para_shape());
+
+    let mut body = Vec::new();
+    let mut host_text = extended_control(0x0002, CTRL_SECTION_DEF);
+    host_text.extend(extended_control(0x000b, CTRL_TABLE));
+    host_text.push(0x000d);
+    push_para_header_with_break(
+        &mut body,
+        host_text.len() as u32,
+        (1 << 2) | (1 << 0x000b),
+        1,
+        0,
+        0x01,
+    );
+    push_record(&mut body, TAG_PARA_TEXT, 1, &utf16_bytes(&host_text));
+    push_record(&mut body, TAG_PARA_CHAR_SHAPE, 1, &shape_refs(&[(0, 0)]));
+
+    let mut section_control = Vec::with_capacity(28);
+    section_control.extend_from_slice(&CTRL_SECTION_DEF.to_le_bytes());
+    section_control.extend([0; 24]);
+    push_record(&mut body, TAG_CTRL_HEADER, 1, &section_control);
+    push_record(&mut body, TAG_PAGE_DEF, 2, &page_def(Mutation::None));
+
+    let mut common = Vec::with_capacity(46);
+    common.extend_from_slice(&CTRL_TABLE.to_le_bytes());
+    common.extend_from_slice(&0x282a_2311u32.to_le_bytes());
+    common.extend_from_slice(&0u32.to_le_bytes());
+    common.extend_from_slice(&0u32.to_le_bytes());
+    common.extend_from_slice(&48_047u32.to_le_bytes());
+    common.extend_from_slice(&7_492u32.to_le_bytes());
+    common.extend_from_slice(&0i32.to_le_bytes());
+    for margin in [141i16, 141, 141, 141] {
+        common.extend_from_slice(&margin.to_le_bytes());
+    }
+    common.extend_from_slice(&1u32.to_le_bytes());
+    common.extend_from_slice(&0i32.to_le_bytes());
+    common.extend_from_slice(&0u16.to_le_bytes());
+    push_record(&mut body, TAG_CTRL_HEADER, 1, &common);
+
+    let mut caption = Vec::with_capacity(30);
+    caption.extend_from_slice(&1u16.to_le_bytes());
+    caption.extend_from_slice(&0u32.to_le_bytes());
+    caption.extend_from_slice(&0u16.to_le_bytes());
+    caption.extend_from_slice(
+        &if matches!(mutation, CaptionedTableMutation::BadCaptionDirection) {
+            3u32
+        } else {
+            2
+        }
+        .to_le_bytes(),
+    );
+    caption.extend_from_slice(&8_504u32.to_le_bytes());
+    caption.extend_from_slice(
+        &if matches!(mutation, CaptionedTableMutation::BadCaptionGap) {
+            851i16
+        } else {
+            850
+        }
+        .to_le_bytes(),
+    );
+    caption.extend_from_slice(&48_047u32.to_le_bytes());
+    caption.extend([0; 8]);
+    if matches!(mutation, CaptionedTableMutation::BadCaptionReserved) {
+        caption[22] = 1;
+    }
+    push_record(&mut body, TAG_LIST_HEADER, 2, &caption);
+
+    let mut push_caption_paragraph = |text: u16| {
+        push_para_header_at_level(&mut body, 2, 2, 0, 1, 0, 0);
+        push_record(&mut body, TAG_PARA_TEXT, 3, &utf16_bytes(&[text, 0x000d]));
+        push_record(&mut body, TAG_PARA_CHAR_SHAPE, 3, &shape_refs(&[(0, 0)]));
+    };
+    if !matches!(mutation, CaptionedTableMutation::MissingCaptionParagraph) {
+        push_caption_paragraph(u16::from(b'C'));
+    }
+    if matches!(mutation, CaptionedTableMutation::ExtraCaptionParagraph) {
+        push_caption_paragraph(u16::from(b'D'));
+    }
+
+    let mut table = Vec::with_capacity(30);
+    table.extend_from_slice(
+        &if matches!(mutation, CaptionedTableMutation::BadTableAttribute) {
+            0x0400_0006u32
+        } else {
+            0x0600_0006
+        }
+        .to_le_bytes(),
+    );
+    table.extend_from_slice(&4u16.to_le_bytes());
+    table.extend_from_slice(&5u16.to_le_bytes());
+    table.extend_from_slice(&0u16.to_le_bytes());
+    for padding in [141i16, 141, 141, 141] {
+        table.extend_from_slice(&padding.to_le_bytes());
+    }
+    let mut row_counts = [5u16; 4];
+    if matches!(mutation, CaptionedTableMutation::BadRowCellCount) {
+        row_counts[0] = 4;
+    }
+    for count in row_counts {
+        table.extend_from_slice(&count.to_le_bytes());
+    }
+    table.extend_from_slice(&4u16.to_le_bytes());
+    table.extend_from_slice(&0u16.to_le_bytes());
+    push_record(&mut body, TAG_TABLE, 2, &table);
+
+    for index in 0usize..20 {
+        let row = index / 5;
+        let col = index % 5;
+        let mut width = COL_WIDTHS[col];
+        if index == 0 && matches!(mutation, CaptionedTableMutation::BadGridGeometry) {
+            width -= 1;
+        }
+        let width_ref =
+            if index == 0 && matches!(mutation, CaptionedTableMutation::BadWidthReference) {
+                0x0500u16
+            } else {
+                0x0400
+            };
+        let mut cell = Vec::with_capacity(47);
+        cell.extend_from_slice(&1u16.to_le_bytes());
+        cell.extend_from_slice(&0x0020_0000u32.to_le_bytes());
+        cell.extend_from_slice(&width_ref.to_le_bytes());
+        for value in [col as u16, row as u16, 1, 1] {
+            cell.extend_from_slice(&value.to_le_bytes());
+        }
+        cell.extend_from_slice(&width.to_le_bytes());
+        cell.extend_from_slice(&ROW_HEIGHTS[row].to_le_bytes());
+        for padding in [141i16, 141, 141, 141] {
+            cell.extend_from_slice(&padding.to_le_bytes());
+        }
+        cell.extend_from_slice(
+            &if index == 0 && matches!(mutation, CaptionedTableMutation::BadCellBorder) {
+                0u16
+            } else {
+                35
+            }
+            .to_le_bytes(),
+        );
+        cell.extend_from_slice(&width.to_le_bytes());
+        cell.extend([0; 9]);
+        if index == 0 && matches!(mutation, CaptionedTableMutation::BadListExtension) {
             cell[38] = 1;
         }
         push_record(&mut body, TAG_LIST_HEADER, 2, &cell);

--- a/crates/hwp-hwp5/tests/public_probe.rs
+++ b/crates/hwp-hwp5/tests/public_probe.rs
@@ -28,27 +28,16 @@ fn public_hwp5_has_bounded_content_free_record_provenance() {
 }
 
 #[test]
-fn explicit_own_parser_owns_six_paragraph_cell_then_stops_content_free() {
-    let probed = probe(&benchmark()).unwrap();
-    let next = probed
-        .streams
-        .iter()
-        .flat_map(|stream| &stream.records)
-        .find(|record| record.head == 47_738)
-        .unwrap();
-    assert_eq!(
-        (next.tag, next.level, next.head, next.data, next.end, next.size),
-        (0x47, 1, 47_738, 47_742, 47_788, 46)
-    );
+fn explicit_own_parser_owns_captioned_table_then_stops_content_free() {
     let error = OwnHwp5Parser::new().parse(&benchmark()).unwrap_err();
     eprintln!("{error:?}");
     assert!(matches!(
         error,
         Error::MalformedRecord {
-            tag: 0x47,
+            tag: 0x4d,
             section: Some(0),
-            offset: 47738,
-            reason: "inline table common-object attributes are not owned",
+            offset: 51364,
+            reason: "TABLE attributes or row/column topology are not owned",
             ..
         }
     ));

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,6 +3,35 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
+- 갱신: 2026-08-24 · Codex(sol) — **PR #194 병합 · #192 latest main 재개**.
+  PR #194 exact head `89c3ea4`에서 issue-link **3s**·build-test **9m24s**·licenses **2m58s** green,
+  MERGEABLE/CLEAN, review/general/inline 외부 댓글 0을 확인하고 protected main `f2306d17`로 squash
+  병합했다. #193 close와 원격 branch 정리 후 `codex/issue-192-hwp5-common-object`의 과거 문서-only
+  커밋을 latest main에 rebase했고, 정본에 이미 흡수된 중복이라 branch는 exact main과 clean하다.
+  #192의 두 content-free 분류 run은 exact 동일: common attr `0x282a2311`, TABLE 앞 30B caption
+  LIST_HEADER+strict 1 paragraph, top/width **8504**/gap **850**/max-width **48047**/include-margin false,
+  list attr·width-ref·reserved tail zero. 본체는 attr `0x06000006`, 4×5 full grid/20 cells, column widths
+  `3221/6593/8956/21855/7422`, row heights `1948/1848/1848/1848`, 각 cell 1 paragraph·width-ref
+  `0x0400`·mirrored extension이다. **다음:** 이 exact tuple만 parser에 additive로 소유하고 caption
+  paragraph를 ordinary shared Block으로 내려 synthetic positive+hostile discriminator를 잠근다.
+  route·`external/rhwp`·HWPX·shared layout·generated assets·oracle scoring은 불변.
+  구현은 caption LIST_HEADER와 정확히 한 ordinary paragraph를 TABLE 전용 prefix로 소비하고,
+  top/width/gap/max-width/include-margin을 shared `TableCaption`으로 내린다. 4×5 full-grid tuple만
+  additive로 열어 common/table geometry, row counts, cell order/span, paragraph count, padding,
+  width-ref `0x0400`, mirrored extension, nonzero/range-checked border refs와 exact row/column geometry를
+  검증한다. synthetic positive와 direction/gap/reserved/missing·extra paragraph/table attr/row count/
+  width-ref/extension/geometry/border hostile **11축**이 green이다. 실제 public benchmark own-parser는
+  이 table을 통과해 다음 unowned TABLE `0x4d/51364`까지 전진했다. HWP5 **72 tests**(15+47+2+8),
+  focused clippy `-D warnings`, wasm32 green. quick은 workspace/PDF visual **51**/canonical
+  **8·18·24·98.9%+**/public corpus **84**/oracle **82**/HWPX/wasm/licenses 전체 green이다. full도 새
+  wasm **7,818,243B**, JS builds/crosscheck/i18n와 Vitest **1,007** green. Chromium 전체 run은
+  **82 pass/3 intentional skip/2 retry-pass/1 timeout**이었고, 유일한 HWPX secPr-host timeout은
+  깨끗한 서버의 단독 재검증에서 **1 pass/0 fail (26.9s)**로 통과해 장시간 직렬 실행 누적 지연으로
+  분류했다. 임시 dependency links는 제거했고 final diff audit에서 production route·`external/rhwp`·
+  HWPX·shared layout·generated assets·oracle scoring diff 0, private text/path/hash/raw/credential diff 0을
+  확인했다. **다음:** commit/push/PR→required CI·comments·mergeability green이면 autonomous merge;
+  이후 #94 근거 동기화와 다음 boundary `TABLE 0x4d/51364` issue.
+
 - 갱신: 2026-08-24 · Codex(sol) — **#193 shared table-caption foundation 구현 중**.
   `TableCaption`을 source-neutral shared IR에 추가하고 rhwp HWP5 lift가 방향 4종·문단 blocks·gap·
   width/max-width·include-margin을 손실 없이 내리도록 했다. top/bottom은 기존 paragraph placer와

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -29,8 +29,10 @@
   깨끗한 서버의 단독 재검증에서 **1 pass/0 fail (26.9s)**로 통과해 장시간 직렬 실행 누적 지연으로
   분류했다. 임시 dependency links는 제거했고 final diff audit에서 production route·`external/rhwp`·
   HWPX·shared layout·generated assets·oracle scoring diff 0, private text/path/hash/raw/credential diff 0을
-  확인했다. **다음:** commit/push/PR→required CI·comments·mergeability green이면 autonomous merge;
-  이후 #94 근거 동기화와 다음 boundary `TABLE 0x4d/51364` issue.
+  확인했다. 구현·검증·continuity를 commit `8453f30`으로 원격
+  `codex/issue-192-hwp5-common-object`에 push했다. **다음:** `Closes #192` PR 게시→required CI·
+  comments·mergeability green이면 autonomous merge; 이후 #94 근거 동기화와 다음 boundary
+  `TABLE 0x4d/51364` issue.
 
 - 갱신: 2026-08-24 · Codex(sol) — **#193 shared table-caption foundation 구현 중**.
   `TableCaption`을 source-neutral shared IR에 추가하고 rhwp HWP5 lift가 방향 4종·문단 blocks·gap·

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -30,9 +30,9 @@
   분류했다. 임시 dependency links는 제거했고 final diff audit에서 production route·`external/rhwp`·
   HWPX·shared layout·generated assets·oracle scoring diff 0, private text/path/hash/raw/credential diff 0을
   확인했다. 구현·검증·continuity를 commit `8453f30`으로 원격
-  `codex/issue-192-hwp5-common-object`에 push했다. **다음:** `Closes #192` PR 게시→required CI·
-  comments·mergeability green이면 autonomous merge; 이후 #94 근거 동기화와 다음 boundary
-  `TABLE 0x4d/51364` issue.
+  `codex/issue-192-hwp5-common-object`에 push하고 PR **#195**를 `Closes #192`로 게시했다.
+  **다음:** final head required CI·comments·mergeability green이면 autonomous merge; 이후 #94 근거
+  동기화와 다음 boundary `TABLE 0x4d/51364` issue.
 
 - 갱신: 2026-08-24 · Codex(sol) — **#193 shared table-caption foundation 구현 중**.
   `TableCaption`을 source-neutral shared IR에 추가하고 rhwp HWP5 lift가 방향 4종·문단 blocks·gap·

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,21 @@
 
 ---
 
+## 2026-08-24 (Codex sol) · #192 full/audit green
+- quick all green; full Rust/gates/WASM/JS + Vitest 1,007 green.
+- Chromium full 82 pass/3 skip/2 retry-pass; lone timeout passes alone in 26.9s.
+- rhwp/generated/HWPX/layout/scoring/private-content diffs 0; next PR/CI/merge.
+
+## 2026-08-24 (Codex sol) · #192 captioned HWP5 table owned
+- exact top-caption prefix + 4×5 full grid now lower to shared IR; hostile 11-axis fail-closed.
+- public own-parser boundary advanced to TABLE `0x4d/51364`; HWP5 72/clippy/wasm32 green.
+- next quick/full→audit→PR/CI/merge, then #94+next boundary.
+
+## 2026-08-24 (Codex sol) · #194 merged / #192 rebased
+- #194 exact-head required CI green, CLEAN/MERGEABLE, external comments 0; main `f2306d17`.
+- #193 closed/remote branch removed; #192 docs-only history was already absorbed and rebased cleanly.
+- next strict top-captioned 4×5 HWP5 parser + hostile fixtures; production/rhwp/HWPX/layout unchanged.
+
 ## 2026-08-24 (Codex sol) · #193 canonical caption loss seams closed
 - JSX/equality now round-trip caption semantics strictly; duplicate captions fail closed.
 - semantic HTML keeps caption content/position; equation enrichment reaches caption blocks.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,10 @@
 
 ---
 
+## 2026-08-24 (Codex sol) · PR #195 posted
+- `Closes #192` PR #195 published with exact validation and privacy/rhwp boundaries.
+- next final-head required CI + reviews/comments/mergeability → autonomous merge.
+
 ## 2026-08-24 (Codex sol) · #192 implementation pushed
 - exact captioned-table parser/tests/continuity committed as `8453f30` and pushed.
 - next `Closes #192` PR → required CI/comments/mergeability → autonomous merge.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,10 @@
 
 ---
 
+## 2026-08-24 (Codex sol) · #192 implementation pushed
+- exact captioned-table parser/tests/continuity committed as `8453f30` and pushed.
+- next `Closes #192` PR → required CI/comments/mergeability → autonomous merge.
+
 ## 2026-08-24 (Codex sol) · #192 full/audit green
 - quick all green; full Rust/gates/WASM/JS + Vitest 1,007 green.
 - Chromium full 82 pass/3 skip/2 retry-pass; lone timeout passes alone in 26.9s.


### PR DESCRIPTION
Closes #192

## What changed
- Own the exact captioned HWP5 4x5 full-grid table tuple and lower its top caption into shared IR.
- Validate caption framing, common/table geometry, cell topology, width references, mirrored extensions, border references, and exact grid dimensions fail-closed.
- Add a positive synthetic fixture, 11 hostile discriminator mutations, and advance the content-free public boundary regression to the next unowned TABLE.

## Validation
- HWP5: 72 tests; focused clippy -D warnings; wasm32: green
- quick: workspace, PDF visual 51, canonical 8/18/24 at >=98.9%, public corpus 84, oracle 82, HWPX, wasm/licenses: green
- full: WASM 7,818,243 B; JS builds/crosscheck/i18n; Vitest 1,007: green
- Chromium full run: 82 passed, 3 intentional skips, 2 retry-passed, 1 accumulated timeout; the sole timeout passed alone in 26.9s

`external/rhwp`, HWPX, shared layout, generated assets, and oracle scoring are unchanged. No private source content, path, hash, raw payload, or credential is included.