### PR TITLE
feat(hwp5): complete bounded public benchmark parse

### DIFF
--- a/crates/hwp-core/src/lib.rs
+++ b/crates/hwp-core/src/lib.rs
@@ -51,8 +51,8 @@ impl Engine {
 }
 
 /// Run only the first-party HWP5 parser lane. This entry point is intentionally separate from
-/// [`Engine::open`]: it accepts the strict text-only subset and returns a parse error for every
-/// unsupported construct. It never calls or falls back to rhwp.
+/// [`Engine::open`]: it accepts only explicitly owned strict subsets and returns a parse error for
+/// every unsupported construct. It never calls or falls back to rhwp.
 pub fn open_hwp5_own(bytes: &[u8]) -> Result<SemanticDoc> {
     hwp_hwp5::OwnHwp5Parser::new()
         .parse(bytes)
@@ -80,11 +80,11 @@ mod hwp5_candidate_tests {
     }
 
     #[test]
-    fn own_only_fails_closed_even_when_rhwp_is_available() {
-        let error = open_hwp5_own(&benchmark()).unwrap_err().to_string();
-        assert!(error.contains("HWP5"));
-        assert!(error.contains("tag"));
-        assert!(!error.contains("benchmark.hwp"));
+    fn own_only_completes_benchmark_without_consulting_rhwp() {
+        let doc = open_hwp5_own(&benchmark()).expect("strict first-party benchmark parse succeeds");
+        assert_eq!(doc.origin, Some(SourceFormat::Hwp5));
+        assert_eq!(doc.sections.len(), 1);
+        assert!(!doc.sections[0].blocks.is_empty());
     }
 
     #[test]

--- a/crates/hwp-hwp5/src/semantic.rs
+++ b/crates/hwp-hwp5/src/semantic.rs
@@ -1559,11 +1559,11 @@ fn parse_new_number_control(
 }
 
 /// Own the bounded binary-table slices seen at the public first-party boundary: strict inline 1×1,
-/// 10×2, 9×8, 8×5, 6×4, and 7×3 tables. The 9×8 slice has 34 active cells and one nested 1×1 table;
-/// the 8×5 slice has 19 active cells, one bounded vertical merge, and nine nested 1×1 tables. The
-/// 6×4 slice is a complete 24-cell grid. The 7×3 slice has 19 active cells and one vertical plus one
-/// horizontal merge. Both have one paragraph per cell. A 1×1 cell may use the exact observed
-/// cell-own inner-margin bit;
+/// 10×2, 9×8, 8×5, 6×4, 7×3, and two exact 4×5 full-grid tables (one top-captioned). The 9×8 slice
+/// has 34 active cells and one nested 1×1 table; the 8×5 slice has 19 active cells, one bounded
+/// vertical merge, and nine nested 1×1 tables. The 6×4 slice is a complete 24-cell grid. The 7×3
+/// slice has 19 active cells and one vertical plus one horizontal merge. Both have one paragraph per
+/// cell. A 1×1 cell may use the exact observed cell-own inner-margin bit;
 /// protection/header/form bits remain unsupported. Multiple controls in one text-empty host are
 /// emitted in marker/header order by `parse_paragraph`. Anything outside these exact source-neutral
 /// shapes, including deeper nesting, remains fail-closed rather than being approximated.
@@ -1842,6 +1842,9 @@ fn parse_inline_table(
         (0x282a_2311, 0x0600_0006, 4, 5) => (0..4)
             .flat_map(|row| (0..5).map(move |col| (row, col, 1, 1)))
             .collect(),
+        (0x082a_2311, 0x0600_0006, 4, 5) => (0..4)
+            .flat_map(|row| (0..5).map(move |col| (row, col, 1, 1)))
+            .collect(),
         _ => {
             return Err(malformed(
                 &table_record,
@@ -1925,6 +1928,8 @@ fn parse_inline_table(
     let exact_one_by_one =
         (common_attr, table_attr, rows, cols) == (0x082a_2311, 0x0400_0006, 1, 1);
     let exact_captioned = (common_attr, table_attr, rows, cols) == (0x282a_2311, 0x0600_0006, 4, 5);
+    let exact_plain_four_by_five =
+        (common_attr, table_attr, rows, cols) == (0x082a_2311, 0x0600_0006, 4, 5);
     if exact_captioned
         && (width != 48_047
             || height != 7_492
@@ -1936,6 +1941,19 @@ fn parse_inline_table(
             &table_record,
             Some(section),
             "captioned TABLE common or table geometry differs from its exact owned tuple",
+        ));
+    }
+    if exact_plain_four_by_five
+        && (width != 48_046
+            || height != 7_492
+            || margins != [141, 141, 141, 141]
+            || table_padding != [141, 141, 141, 141]
+            || table_border_id != 4)
+    {
+        return Err(malformed(
+            &table_record,
+            Some(section),
+            "plain 4x5 TABLE common or table geometry differs from its exact owned tuple",
         ));
     }
     let mut cells = Vec::with_capacity(expected_cells);
@@ -2016,10 +2034,12 @@ fn parse_inline_table(
         let expected_seven_by_three_width_ref =
             exact_seven_by_three.then_some(if col == 2 { 0x0100 } else { 0x0500 });
         let expected_captioned_width_ref = exact_captioned.then_some(0x0400);
+        let expected_plain_four_by_five_width_ref = exact_plain_four_by_five.then_some(0x0500);
         let expected_exact_width_ref = expected_one_by_two_width_ref
             .or(expected_eight_by_five_width_ref)
             .or(expected_seven_by_three_width_ref)
-            .or(expected_captioned_width_ref);
+            .or(expected_captioned_width_ref)
+            .or(expected_plain_four_by_five_width_ref);
         let owned_width_ref = expected_exact_width_ref.map_or_else(
             || {
                 matches!(width_ref, 0x0000 | 0x0100 | 0x0500)
@@ -2112,6 +2132,24 @@ fn parse_inline_table(
                 &list_record,
                 Some(section),
                 "captioned TABLE cell framing differs from its exact owned tuple",
+            ));
+        }
+        let expected_plain_border_id = match row {
+            0 => 35,
+            1 => 36,
+            _ => 4,
+        };
+        if exact_plain_four_by_five
+            && (paragraph_count != 1
+                || cell_padding != [141, 141, 141, 141]
+                || !width_extension
+                || extension_width != cell_width
+                || cell_border_id != expected_plain_border_id)
+        {
+            return Err(malformed(
+                &list_record,
+                Some(section),
+                "plain 4x5 TABLE cell framing differs from its exact owned tuple",
             ));
         }
         let cell_fill = table_border(doc, cell_border_id, &list_record, section, "table cell")?;
@@ -2387,6 +2425,16 @@ fn parse_inline_table(
             &table_record,
             Some(section),
             "captioned TABLE column or row geometry differs from its exact owned grid",
+        ));
+    }
+    if exact_plain_four_by_five
+        && (col_widths != [3_221, 9_238, 14_770, 12_223, 8_594]
+            || derived_rows != [1_948, 1_848, 1_848, 1_848])
+    {
+        return Err(malformed(
+            &table_record,
+            Some(section),
+            "plain 4x5 TABLE column or row geometry differs from its exact owned grid",
         ));
     }
     let owned_nested_stale_common_height = table_depth == 1

--- a/crates/hwp-hwp5/tests/layout_semantic.rs
+++ b/crates/hwp-hwp5/tests/layout_semantic.rs
@@ -165,6 +165,22 @@ enum CaptionedTableMutation {
 }
 
 #[derive(Clone, Copy)]
+enum PlainFourByFiveMutation {
+    None,
+    BadCommonWidth,
+    BadTableAttribute,
+    BadTableBorder,
+    BadRowCellCount,
+    BadCellSpan,
+    BadWidthReference,
+    BadListExtension,
+    BadGridGeometry,
+    BadParagraphCount,
+    BadCellPadding,
+    BadCellBorder,
+}
+
+#[derive(Clone, Copy)]
 enum SevenByThreeMutation {
     None,
     BadCommonAttribute,
@@ -1148,6 +1164,59 @@ fn strict_captioned_table_rejects_hostile_caption_topology_geometry_and_refs() {
                 .parse(&captioned_table_fixture(mutation))
                 .is_err(),
             "hostile captioned-table mutation must fail closed"
+        );
+    }
+}
+
+#[test]
+fn owns_exact_plain_four_by_five_full_grid_table() {
+    let doc = OwnHwp5Parser::new()
+        .parse(&plain_four_by_five_fixture(PlainFourByFiveMutation::None))
+        .expect("strict plain 4x5 full-grid table fixture parses");
+    let [Block::Paragraph(anchor), Block::Table(table)] = doc.sections[0].blocks.as_slice() else {
+        panic!("table host must lower to one anchor and one table")
+    };
+    assert!(anchor.is_table_anchor);
+    assert_eq!((table.rows, table.cols, table.cells.len()), (4, 5, 20));
+    assert!(table.caption.is_none());
+    assert!(table.keep_together);
+    assert!(table.fixed_row_heights);
+    assert_eq!(table.col_widths, vec![3_221, 9_238, 14_770, 12_223, 8_594]);
+    assert_eq!(table.row_heights, vec![1_948, 1_848, 1_848, 1_848]);
+    assert!(table.cells.iter().enumerate().all(|(index, cell)| {
+        (cell.row, cell.col, cell.row_span, cell.col_span, cell.width)
+            == (
+                index / 5,
+                index % 5,
+                1,
+                1,
+                Some(table.col_widths[index % 5]),
+            )
+            && cell.blocks.len() == 1
+            && matches!(cell.blocks[0], Block::Paragraph(_))
+    }));
+}
+
+#[test]
+fn strict_plain_four_by_five_rejects_hostile_pairing_topology_geometry_and_refs() {
+    for mutation in [
+        PlainFourByFiveMutation::BadCommonWidth,
+        PlainFourByFiveMutation::BadTableAttribute,
+        PlainFourByFiveMutation::BadTableBorder,
+        PlainFourByFiveMutation::BadRowCellCount,
+        PlainFourByFiveMutation::BadCellSpan,
+        PlainFourByFiveMutation::BadWidthReference,
+        PlainFourByFiveMutation::BadListExtension,
+        PlainFourByFiveMutation::BadGridGeometry,
+        PlainFourByFiveMutation::BadParagraphCount,
+        PlainFourByFiveMutation::BadCellPadding,
+        PlainFourByFiveMutation::BadCellBorder,
+    ] {
+        assert!(
+            OwnHwp5Parser::new()
+                .parse(&plain_four_by_five_fixture(mutation))
+                .is_err(),
+            "hostile plain 4x5 mutation must fail closed"
         );
     }
 }
@@ -2471,6 +2540,202 @@ fn captioned_table_fixture(mutation: CaptionedTableMutation) -> Vec<u8> {
             &utf16_bytes(&[u16::from(b'A') + index as u16, 0x000d]),
         );
         push_record(&mut body, TAG_PARA_CHAR_SHAPE, 3, &shape_refs(&[(0, 0)]));
+    }
+
+    let mut compound = CompoundFile::create(Cursor::new(Vec::new())).unwrap();
+    {
+        let mut stream = compound.create_stream("/FileHeader").unwrap();
+        stream.write_all(&header).unwrap();
+    }
+    {
+        let mut stream = compound.create_stream("/DocInfo").unwrap();
+        stream.write_all(&doc_info).unwrap();
+    }
+    compound.create_storage("/BodyText").unwrap();
+    {
+        let mut stream = compound.create_stream("/BodyText/Section0").unwrap();
+        stream.write_all(&body).unwrap();
+    }
+    compound.into_inner().into_inner()
+}
+
+fn plain_four_by_five_fixture(mutation: PlainFourByFiveMutation) -> Vec<u8> {
+    const COL_WIDTHS: [u32; 5] = [3_221, 9_238, 14_770, 12_223, 8_594];
+    const ROW_HEIGHTS: [u32; 4] = [1_948, 1_848, 1_848, 1_848];
+
+    let mut header = vec![0; 256];
+    header[..HWP_SIGNATURE.len()].copy_from_slice(HWP_SIGNATURE);
+    header[32..36].copy_from_slice(&[0, 0, 0, 5]);
+
+    let mut doc_info = Vec::new();
+    let mut properties = vec![0; 26];
+    properties[..2].copy_from_slice(&1u16.to_le_bytes());
+    push_record(&mut doc_info, TAG_DOCUMENT_PROPERTIES, 0, &properties);
+    let mut mappings = Vec::new();
+    for count in [0, 1, 1, 1, 1, 1, 1, 1, 36, 1, 0, 0, 0, 1, 0] {
+        mappings.extend_from_slice(&(count as u32).to_le_bytes());
+    }
+    push_record(&mut doc_info, TAG_ID_MAPPINGS, 0, &mappings);
+    for _ in 0..7 {
+        push_record(&mut doc_info, TAG_FACE_NAME, 0, &face_name("Test Sans"));
+    }
+    for _ in 0..36 {
+        push_record(&mut doc_info, TAG_BORDER_FILL, 0, &solid_border_fill());
+    }
+    push_record(&mut doc_info, TAG_CHAR_SHAPE, 0, &char_shape());
+    push_record(&mut doc_info, TAG_PARA_SHAPE, 0, &para_shape());
+
+    let mut body = Vec::new();
+    let mut host_text = extended_control(0x0002, CTRL_SECTION_DEF);
+    host_text.extend(extended_control(0x000b, CTRL_TABLE));
+    host_text.push(0x000d);
+    push_para_header_with_break(
+        &mut body,
+        host_text.len() as u32,
+        (1 << 2) | (1 << 0x000b),
+        1,
+        0,
+        0x01,
+    );
+    push_record(&mut body, TAG_PARA_TEXT, 1, &utf16_bytes(&host_text));
+    push_record(&mut body, TAG_PARA_CHAR_SHAPE, 1, &shape_refs(&[(0, 0)]));
+
+    let mut section_control = Vec::with_capacity(28);
+    section_control.extend_from_slice(&CTRL_SECTION_DEF.to_le_bytes());
+    section_control.extend([0; 24]);
+    push_record(&mut body, TAG_CTRL_HEADER, 1, &section_control);
+    push_record(&mut body, TAG_PAGE_DEF, 2, &page_def(Mutation::None));
+
+    let mut common = Vec::with_capacity(46);
+    common.extend_from_slice(&CTRL_TABLE.to_le_bytes());
+    common.extend_from_slice(&0x082a_2311u32.to_le_bytes());
+    common.extend_from_slice(&0u32.to_le_bytes());
+    common.extend_from_slice(&0u32.to_le_bytes());
+    common.extend_from_slice(
+        &if matches!(mutation, PlainFourByFiveMutation::BadCommonWidth) {
+            48_045u32
+        } else {
+            48_046
+        }
+        .to_le_bytes(),
+    );
+    common.extend_from_slice(&7_492u32.to_le_bytes());
+    common.extend_from_slice(&0i32.to_le_bytes());
+    for margin in [141i16, 141, 141, 141] {
+        common.extend_from_slice(&margin.to_le_bytes());
+    }
+    common.extend_from_slice(&1u32.to_le_bytes());
+    common.extend_from_slice(&0i32.to_le_bytes());
+    common.extend_from_slice(&0u16.to_le_bytes());
+    push_record(&mut body, TAG_CTRL_HEADER, 1, &common);
+
+    let mut table = Vec::with_capacity(30);
+    table.extend_from_slice(
+        &if matches!(mutation, PlainFourByFiveMutation::BadTableAttribute) {
+            0x0400_0006u32
+        } else {
+            0x0600_0006
+        }
+        .to_le_bytes(),
+    );
+    table.extend_from_slice(&4u16.to_le_bytes());
+    table.extend_from_slice(&5u16.to_le_bytes());
+    table.extend_from_slice(&0u16.to_le_bytes());
+    for padding in [141i16, 141, 141, 141] {
+        table.extend_from_slice(&padding.to_le_bytes());
+    }
+    let mut row_counts = [5u16; 4];
+    if matches!(mutation, PlainFourByFiveMutation::BadRowCellCount) {
+        row_counts[0] = 4;
+    }
+    for count in row_counts {
+        table.extend_from_slice(&count.to_le_bytes());
+    }
+    table.extend_from_slice(
+        &if matches!(mutation, PlainFourByFiveMutation::BadTableBorder) {
+            5u16
+        } else {
+            4
+        }
+        .to_le_bytes(),
+    );
+    table.extend_from_slice(&0u16.to_le_bytes());
+    push_record(&mut body, TAG_TABLE, 2, &table);
+
+    for index in 0usize..20 {
+        let row = index / 5;
+        let col = index % 5;
+        let paragraph_count =
+            if index == 0 && matches!(mutation, PlainFourByFiveMutation::BadParagraphCount) {
+                2u16
+            } else {
+                1
+            };
+        let mut width = COL_WIDTHS[col];
+        if index == 0 && matches!(mutation, PlainFourByFiveMutation::BadGridGeometry) {
+            width -= 1;
+        }
+        let width_ref =
+            if index == 0 && matches!(mutation, PlainFourByFiveMutation::BadWidthReference) {
+                0x0100u16
+            } else {
+                0x0500
+            };
+        let col_span = if index == 0 && matches!(mutation, PlainFourByFiveMutation::BadCellSpan) {
+            2u16
+        } else {
+            1
+        };
+        let mut cell = Vec::with_capacity(47);
+        cell.extend_from_slice(&paragraph_count.to_le_bytes());
+        cell.extend_from_slice(&0x0020_0000u32.to_le_bytes());
+        cell.extend_from_slice(&width_ref.to_le_bytes());
+        for value in [col as u16, row as u16, col_span, 1] {
+            cell.extend_from_slice(&value.to_le_bytes());
+        }
+        cell.extend_from_slice(&width.to_le_bytes());
+        cell.extend_from_slice(&ROW_HEIGHTS[row].to_le_bytes());
+        for (padding_index, padding) in [141i16, 141, 141, 141].into_iter().enumerate() {
+            let value = if index == 0
+                && padding_index == 0
+                && matches!(mutation, PlainFourByFiveMutation::BadCellPadding)
+            {
+                142
+            } else {
+                padding
+            };
+            cell.extend_from_slice(&value.to_le_bytes());
+        }
+        let border = if index == 0 && matches!(mutation, PlainFourByFiveMutation::BadCellBorder) {
+            34u16
+        } else {
+            match row {
+                0 => 35,
+                1 => 36,
+                _ => 4,
+            }
+        };
+        cell.extend_from_slice(&border.to_le_bytes());
+        cell.extend_from_slice(&width.to_le_bytes());
+        cell.extend([0; 9]);
+        if index == 0 && matches!(mutation, PlainFourByFiveMutation::BadListExtension) {
+            cell[38] = 1;
+        }
+        push_record(&mut body, TAG_LIST_HEADER, 2, &cell);
+
+        for paragraph_index in 0..paragraph_count {
+            let empty = row == 3 && col > 0 && paragraph_index == 0;
+            push_para_header_at_level(&mut body, 2, if empty { 1 } else { 2 }, 0, 1, 0, 0);
+            if !empty {
+                push_record(
+                    &mut body,
+                    TAG_PARA_TEXT,
+                    3,
+                    &utf16_bytes(&[u16::from(b'A') + index as u16, 0x000d]),
+                );
+            }
+            push_record(&mut body, TAG_PARA_CHAR_SHAPE, 3, &shape_refs(&[(0, 0)]));
+        }
     }
 
     let mut compound = CompoundFile::create(Cursor::new(Vec::new())).unwrap();

--- a/crates/hwp-hwp5/tests/public_probe.rs
+++ b/crates/hwp-hwp5/tests/public_probe.rs
@@ -1,4 +1,4 @@
-use hwp_hwp5::{probe, Error, OwnHwp5Parser};
+use hwp_hwp5::{probe, OwnHwp5Parser};
 
 fn benchmark() -> Vec<u8> {
     std::fs::read(concat!(
@@ -28,17 +28,10 @@ fn public_hwp5_has_bounded_content_free_record_provenance() {
 }
 
 #[test]
-fn explicit_own_parser_owns_captioned_table_then_stops_content_free() {
-    let error = OwnHwp5Parser::new().parse(&benchmark()).unwrap_err();
-    eprintln!("{error:?}");
-    assert!(matches!(
-        error,
-        Error::MalformedRecord {
-            tag: 0x4d,
-            section: Some(0),
-            offset: 51364,
-            reason: "TABLE attributes or row/column topology are not owned",
-            ..
-        }
-    ));
+fn explicit_own_parser_reaches_public_benchmark_end_content_free() {
+    let doc = OwnHwp5Parser::new()
+        .parse(&benchmark())
+        .expect("first-party parser owns the complete bounded public benchmark");
+    assert_eq!(doc.sections.len(), 1);
+    assert!(!doc.sections[0].blocks.is_empty());
 }

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -49,7 +49,8 @@
   continuity 문서뿐이다. `external/rhwp`·HWPX·shared typesetter·generated wasm/assets·oracle scoring diff 0,
   임시 instrumentation 및 private text/path/hash/raw/credential diff 0을 확인했다. 구현·검증·continuity를
   commits `7663aa7`·`50ca455`로 원격 `codex/issue-196-hwp5-next-table`에 push했다. **다음:**
-  `Closes #196` PR→required CI·comments·mergeability green이면 autonomous merge; 후속 delta/eligibility issue.
+  PR **#197**을 `Closes #196`으로 게시했다. **다음:** final head required CI·comments·mergeability
+  green이면 autonomous merge; 후속 content-free semantic-delta/84-doc eligibility issue.
 
 - 갱신: 2026-08-24 · Codex(sol) — **PR #194 병합 · #192 latest main 재개**.
   PR #194 exact head `89c3ea4`에서 issue-link **3s**·build-test **9m24s**·licenses **2m58s** green,

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -14,6 +14,41 @@
   flags, full cell topology/order/span, geometry, references, paragraph/nesting/extension framing을 분류한다.
   모든 active semantics가 shared IR로 faithful할 때만 exact discriminator+positive/hostile fixture를
   구현한다. production route·`external/rhwp`·HWPX·shared layout·generated assets·scoring은 불변.
+  pinned oracle submodule 초기화 중 병합 완료 #192의 재생성 가능한 target cache가 디스크를 채워,
+  해당 target만 `cargo clean`해 **14.2GiB**를 회수한 뒤 pinned `f137b4c`를 정상 초기화했다. 임시
+  numeric-only instrumentation으로 독립 2회 분류한 결과는 exact 동일했고 계측은 제거했다. boundary는
+  common attr `0x082a2311`/width **48046**/height **7492**/margins `[141;4]`, table attr
+  `0x06000006`/4×5 full grid/20 cells/row counts `[5;4]`/padding `[141;4]`/border 4/zone 0이다.
+  cells는 row-major 1×1 spans, 각 1 ordinary paragraph(일부 empty)/nested controls 0, width-ref
+  `0x0500`, mirrored 13B extension, padding `[141;4]`, exact columns
+  `3221/9238/14770/12223/8594`, rows `1948/1848/1848/1848`; border refs는 range-valid row variants다.
+  모든 active semantics가 현 shared Table/Cell/Paragraph IR로 손실 없이 표현 가능하다. **다음:** 이
+  exact tuple만 additive로 소유하고 positive + attr/count/span/width-ref/extension/geometry/paragraph/
+  padding/border hostile discriminators를 잠근 뒤 public boundary를 다음 unsupported record로 전진.
+  구현은 이 exact uncaptioned tuple만 match에 추가하고 common/table geometry, full-grid positions,
+  width-ref sequence, mirrored extensions, paragraph/padding, row-specific range-valid border refs와 exact
+  row/column geometry를 묶어 검증한다. synthetic positive는 실제와 같이 마지막 행의 ordinary empty
+  paragraphs도 포함하며 common width/table attr/table border/row count/span/width-ref/extension/grid/
+  paragraph count/padding/cell border **11축** hostile fixture가 모두 fail-closed한다. 이 slice 뒤에는
+  다음 unsupported record가 없었고 own parser가 public benchmark 전체를 끝까지 성공해, 공개 경계
+  회귀를 원문을 출력하지 않는 full-parse success 계약으로 바꿨다. HWP5 **74 tests**(15+49+2+8)와
+  focused clippy `-D warnings` green. **다음:** wasm32→quick/full gates와 final diff/security audit;
+  #196 PR/CI/merge 뒤 #94의 benchmark-complete와 production cutover 전 corpus differential gap을 분리.
+  quick 첫 run은 과거 hwp-core 계약이 own-only benchmark 실패를 기대해 새 성공을 회귀로 잡았고,
+  이를 production route 변경 없이 “rhwp fallback 없이 benchmark 완주” 계약으로 갱신했다. focused
+  hwp-core 2 tests green이며 content-free deterministic differential은 native/oracle
+  sections **1/1**, tables **32/32**, images **0/0**, equations/charts **0/0**이지만 paragraphs
+  **353/352**, runs **389/382**, controls **38/32** delta를 드러냈다. 이는 cutover 전 별도 분류 대상이다.
+  rerun quick은 workspace 전체, canonical **8/18/24·98.9%+**, public corpus **84**, oracle **82**,
+  HWPX, wasm/licenses 모두 green. **다음:** full gate→final audit→commit/push/PR/CI/merge; 후속은
+  content-free semantic delta를 원인별로 분해한 뒤 84-document own-parser eligibility matrix로 확장.
+  full도 Rust/gates, PDF visual **51**, 새 wasm **7,818,243B**, JS builds/crosscheck/i18n, Vitest
+  **1,007** green이다. sandbox bind EPERM 뒤 허용된 실제 서버에서 Chromium **85 pass/3 intentional
+  skip/0 fail**로 재시도 없이 통과했다. 임시 dependency links는 제거했고 final audit에서 변경은
+  HWP5 exact parser/fixtures, hwp-core own-only success contract, content-free public completion regression,
+  continuity 문서뿐이다. `external/rhwp`·HWPX·shared typesetter·generated wasm/assets·oracle scoring diff 0,
+  임시 instrumentation 및 private text/path/hash/raw/credential diff 0을 확인했다. **다음:** commit/push/
+  `Closes #196` PR→required CI·comments·mergeability green이면 autonomous merge; 후속 delta/eligibility issue.
 
 - 갱신: 2026-08-24 · Codex(sol) — **PR #194 병합 · #192 latest main 재개**.
   PR #194 exact head `89c3ea4`에서 issue-link **3s**·build-test **9m24s**·licenses **2m58s** green,

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -47,7 +47,8 @@
   skip/0 fail**로 재시도 없이 통과했다. 임시 dependency links는 제거했고 final audit에서 변경은
   HWP5 exact parser/fixtures, hwp-core own-only success contract, content-free public completion regression,
   continuity 문서뿐이다. `external/rhwp`·HWPX·shared typesetter·generated wasm/assets·oracle scoring diff 0,
-  임시 instrumentation 및 private text/path/hash/raw/credential diff 0을 확인했다. **다음:** commit/push/
+  임시 instrumentation 및 private text/path/hash/raw/credential diff 0을 확인했다. 구현·검증·continuity를
+  commits `7663aa7`·`50ca455`로 원격 `codex/issue-196-hwp5-next-table`에 push했다. **다음:**
   `Closes #196` PR→required CI·comments·mergeability green이면 autonomous merge; 후속 delta/eligibility issue.
 
 - 갱신: 2026-08-24 · Codex(sol) — **PR #194 병합 · #192 latest main 재개**.

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,6 +3,18 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
+- 갱신: 2026-08-24 · Codex(sol) — **PR #195 병합 · #196 착수**.
+  PR #195 exact head `cecbfdc`에서 issue-link **5s**·build-test **9m31s**·licenses **2m54s** green,
+  CLEAN/MERGEABLE, review/general/inline 댓글 0을 확인하고 protected main `dee2996f`로 squash 병합했다.
+  #192 close와 원격 branch 삭제를 확인하고 #94에 content-free 근거를 동기화했다. 최근 GitHub 활동은
+  owner 작업뿐이며 신규 외부 제보·PR·댓글, 스팸·악성·보안/개인정보 신호는 0이다. 다음 unowned
+  boundary `TABLE 0x4d/51364`는 중복 이슈가 없어 classification-first 자식 **#196**을 R18/P1/
+  area:hwp5/status:ready로 열고 exact main의 `codex/issue-196-hwp5-next-table` worktree를 만들었다.
+  **다음:** source text/path/hash/raw를 출력하지 않는 content-free probe를 독립 2회 수행해 common/table
+  flags, full cell topology/order/span, geometry, references, paragraph/nesting/extension framing을 분류한다.
+  모든 active semantics가 shared IR로 faithful할 때만 exact discriminator+positive/hostile fixture를
+  구현한다. production route·`external/rhwp`·HWPX·shared layout·generated assets·scoring은 불변.
+
 - 갱신: 2026-08-24 · Codex(sol) — **PR #194 병합 · #192 latest main 재개**.
   PR #194 exact head `89c3ea4`에서 issue-link **3s**·build-test **9m24s**·licenses **2m58s** green,
   MERGEABLE/CLEAN, review/general/inline 외부 댓글 0을 확인하고 protected main `f2306d17`로 squash

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -46,11 +46,15 @@
   **1,007** green이다. sandbox bind EPERM 뒤 허용된 실제 서버에서 Chromium **85 pass/3 intentional
   skip/0 fail**로 재시도 없이 통과했다. 임시 dependency links는 제거했고 final audit에서 변경은
   HWP5 exact parser/fixtures, hwp-core own-only success contract, content-free public completion regression,
-  continuity 문서뿐이다. `external/rhwp`·HWPX·shared typesetter·generated wasm/assets·oracle scoring diff 0,
+  native-parser boundary 문서와 continuity뿐이다. `external/rhwp`·HWPX·shared typesetter·generated
+  wasm/assets·oracle scoring diff 0,
   임시 instrumentation 및 private text/path/hash/raw/credential diff 0을 확인했다. 구현·검증·continuity를
   commits `7663aa7`·`50ca455`로 원격 `codex/issue-196-hwp5-next-table`에 push했다. **다음:**
   PR **#197**을 `Closes #196`으로 게시했다. **다음:** final head required CI·comments·mergeability
   green이면 autonomous merge; 후속 content-free semantic-delta/84-doc eligibility issue.
+  후속 설계 audit에서 `docs/HWP5-NATIVE-PARSER.md`가 여전히 첫 1×1 뒤 offset 936 중단을 주장하는
+  stale 계약임을 발견해, benchmark-end exact-subset 사실·paragraph/run/control delta·corpus cutover
+  gates로 정정했다. **다음:** docs fix commit/push로 #197 final CI 재기동→green이면 merge.
 
 - 갱신: 2026-08-24 · Codex(sol) — **PR #194 병합 · #192 latest main 재개**.
   PR #194 exact head `89c3ea4`에서 issue-link **3s**·build-test **9m24s**·licenses **2m58s** green,

--- a/docs/HWP5-NATIVE-PARSER.md
+++ b/docs/HWP5-NATIVE-PARSER.md
@@ -4,8 +4,9 @@ Issue #107 introduced the first owned binary-HWP layer; issue #154 added its fir
 issue #156 added the minimum source-layout facts needed by the shared typesetter, issue #158 owns
 the paragraph support-pool boundary, and issue #160 owns DocInfo styles plus content-free paragraph
 header refusal reasons; issue #161 adds strict column definitions and the shared multi-column layout
-contract; issue #168 adds the first strict inline 1×1 table slice. None of these slices changes
-production parsing.
+contract. Issues #168–#196 then advanced one content-free control/table boundary at a time through
+strict exact subsets. The bounded public benchmark now parses to the end in the first-party-only lane.
+None of these slices changes production parsing.
 
 ## What is owned now
 
@@ -64,19 +65,19 @@ rejected instead of being interpreted as records.
 
 - `Engine::open`: unchanged production route. Binary HWP still uses the governed rhwp bootstrap.
 - `open_hwp5_own`: explicit first-party-only route. It returns a `SemanticDoc` only for the owned
-  text, single-sided page setup, strict column subset, and strict inline 1×1 table subset. Larger,
-  floating, merged, captioned, or nested tables, images, fields, notes, equations, charts,
+  text, single-sided page setup, strict column subset, page numbering, and explicitly enumerated
+  table subsets. These include exact merged/full-grid forms, bounded depth-1 nested tables, multiple
+  ordered table controls, fixed row geometry, and top captions represented by shared source-neutral
+  IR. Unenumerated table attributes/topologies, floating objects, images, fields, notes, equations, charts,
   decorations, page border/fill, duplex binding, active custom tabs/lists/paragraph borders,
   unknown body controls, and unsupported pool values fail closed with a static reason plus tag,
-  section, and byte span only. It cannot call rhwp. The public benchmark now passes its first
-  multi-column paragraph header and `cold` definition plus its first inline table, then stops at the
-  next larger TABLE record (`0x4d`, section 0, bytes 936..982) without exposing content. The owned prefix includes strict
+  section, and byte span only. It cannot call rhwp. The bounded public benchmark now reaches the end
+  without exposing content or using a fallback. This proves that document's exact subsets, not generic
+  HWP5 coverage or production readiness. The owned lane includes strict
   single-section `pgnp` positioning and `nwno` page-counter restarts; other counters, zero starts,
   conflicting duplicates, missing positions, and multi-section inheritance fail closed. Exact duplicate
-  `pgnp`/`nwno` records are idempotently collapsed by typed equality. The first public `tbl ` control is
-  owned only as a treat-as-character 1×1 table with one centered cell paragraph, inherited table
-  padding, consistent object/cell geometry, and resolved border fills. It lowers to the shared
-  `Table`/`Cell` IR, so SVG and PDF consume the same `place_doc` geometry.
+  `pgnp`/`nwno` records are idempotently collapsed by typed equality. Every owned `tbl ` control lowers
+  to shared `Table`/`Cell`/`TableCaption` IR, so SVG and PDF consume the same `place_doc` geometry.
 - `hwp5_differential`: explicitly runs the owned probe and current rhwp semantic oracle, then reports
   section/paragraph/run/table/image/control/equation/chart counts and their deltas.
 
@@ -88,11 +89,16 @@ Raw-record counts and semantic counts are not treated as equivalent truth. In pa
 `runs` currently counts `PARA_CHAR_SHAPE` position tuples and native `controls` counts
 `CTRL_HEADER` records. Semantic `controls` counts typed table/image/equation/chart and remaining
 field/note/raw control nodes. The differential makes these gaps measurable; it does not relax a gate
-or claim semantic parity.
+or claim semantic parity. On the completed bounded benchmark, sections/tables/images/equations/charts
+currently agree while native-minus-oracle is paragraphs `+1`, runs `+7`, and controls `+6`. Those
+content-free deltas must be classified before any production cutover claim.
 
 ## Cutover rule
 
-The next #94 slices promote tables, BinData/images, decorations, and remaining controls into
-this crate. The production route may change only when public-corpus differential gates, native/wasm
-parity, hostile input tests, and the canonical 8/18/24-page + 98.9% line gate remain green. Explicit
-own-parser mode must continue to fail closed for every unsupported semantic construct.
+Completing one bounded benchmark is only the first eligibility milestone. The next #94 slices must
+classify the remaining semantic-count deltas, run fail-closed own-parser eligibility across the
+privacy-safe public corpus, and promote BinData/images, decorations, and other controls only when
+encountered semantics have faithful shared-IR representations. The production route may change only
+when corpus differential gates, native/wasm parity, hostile input tests, and the canonical
+8/18/24-page + 98.9% line gate remain green. Explicit own-parser mode must continue to fail closed for
+every unsupported semantic construct.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,10 @@
 
 ---
 
+## 2026-08-24 (Codex sol) · PR #197 posted
+- `Closes #196` PR #197 published with explicit no-cutover/delta/privacy boundaries.
+- next final-head required CI + reviews/comments/mergeability → autonomous merge.
+
 ## 2026-08-24 (Codex sol) · #196 pushed
 - benchmark-complete parser/tests/continuity committed through `50ca455` and pushed.
 - next `Closes #196` PR → required CI/comments/mergeability → autonomous merge.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,11 @@
 
 ---
 
+## 2026-08-24 (Codex sol) · #195 merged / #196 started
+- #195 exact-head CI green, CLEAN/MERGEABLE, comments 0; main `dee2996f`, #192 closed.
+- #94 synced; no new external/community/security signal; remote branch removed.
+- #196 opened for TABLE `0x4d/51364`; exact-main worktree ready for content-free classification.
+
 ## 2026-08-24 (Codex sol) · PR #195 posted
 - `Closes #192` PR #195 published with exact validation and privacy/rhwp boundaries.
 - next final-head required CI + reviews/comments/mergeability → autonomous merge.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,10 @@
 
 ---
 
+## 2026-08-24 (Codex sol) · #196 stale boundary docs fixed
+- HWP5 native-parser doc no longer claims offset 936 stop; records benchmark-end exact-subset truth.
+- semantic delta and corpus/wasm/hostile/layout cutover gates stay explicit; next push/restarted CI.
+
 ## 2026-08-24 (Codex sol) · PR #197 posted
 - `Closes #196` PR #197 published with explicit no-cutover/delta/privacy boundaries.
 - next final-head required CI + reviews/comments/mergeability → autonomous merge.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,10 @@
 
 ---
 
+## 2026-08-24 (Codex sol) · #196 pushed
+- benchmark-complete parser/tests/continuity committed through `50ca455` and pushed.
+- next `Closes #196` PR → required CI/comments/mergeability → autonomous merge.
+
 ## 2026-08-24 (Codex sol) · #196 full/audit green
 - full green: PDF51, wasm 7,818,243B, Vitest 1,007, Chromium 85 pass/3 skip/0 fail.
 - rhwp/HWPX/layout/generated/scoring/private-content diffs 0; temp links/instrumentation removed.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,26 @@
 
 ---
 
+## 2026-08-24 (Codex sol) · #196 full/audit green
+- full green: PDF51, wasm 7,818,243B, Vitest 1,007, Chromium 85 pass/3 skip/0 fail.
+- rhwp/HWPX/layout/generated/scoring/private-content diffs 0; temp links/instrumentation removed.
+- next commit/push/PR/CI/merge, then semantic-delta + eligibility child.
+
+## 2026-08-24 (Codex sol) · #196 quick green
+- stale own-only failure contract updated to fallback-free benchmark success; quick all green.
+- deterministic delta: paragraphs +1, runs +7, controls +6; tables/sections/images/equations/charts equal.
+- next full/audit→PR/merge, then semantic-delta + 84-doc eligibility issue.
+
+## 2026-08-24 (Codex sol) · #196 reaches benchmark end
+- exact plain 4×5 parser + positive/11 hostile axes implemented; empty paragraphs preserved.
+- no next unsupported record: first-party parser completes the public benchmark content-free.
+- HWP5 74 + focused clippy green; next wasm32→quick/full/audit→PR/merge.
+
+## 2026-08-24 (Codex sol) · #196 classification deterministic
+- numeric-only probe runs agree: exact uncaptioned 4×5 full grid, 20 cells, no nesting.
+- geometry/refs/extensions/paragraphs fit shared IR without loss; temporary instrumentation removed.
+- reclaimed 14.2GiB merged #192 target cache; next exact parser + hostile fixtures.
+
 ## 2026-08-24 (Codex sol) · #195 merged / #196 started
 - #195 exact-head CI green, CLEAN/MERGEABLE, comments 0; main `dee2996f`, #192 closed.
 - #94 synced; no new external/community/security signal; remote branch removed.


### PR DESCRIPTION
Closes #196

## What changed
- Own the exact uncaptioned HWP5 4x5 full-grid table tuple at the final unsupported public benchmark boundary.
- Bind common/table geometry, row-major topology, paragraph and padding framing, width-reference sequence, mirrored extensions, row-specific border references, and exact row/column dimensions fail-closed.
- Add a positive fixture with ordinary empty cell paragraphs plus 11 hostile discriminator axes.
- Replace the former expected-error boundary with a content-free full first-party parse success contract. Production HWP5 routing remains unchanged and own-only never falls back to rhwp.

## Validation
- HWP5: 74 tests; focused clippy -D warnings; wasm32: green
- quick: workspace, PDF visual 51, canonical 8/18/24 at >=98.9%, public corpus 84, oracle 82, HWPX, wasm/licenses: green
- full: WASM 7,818,243 B; JS builds/crosscheck/i18n; Vitest 1,007: green
- Chromium: 85 passed, 3 intentional skips, 0 failed

## Honest cutover boundary
The deterministic content-free benchmark differential now has equal sections/tables/images/equations/charts, but still reports native-vs-oracle deltas of paragraphs +1, runs +7, and controls +6. This PR does not flip production routing; those semantic deltas and 84-document own-parser eligibility remain follow-up gates.

`external/rhwp`, HWPX, shared typesetting, generated assets, and oracle scoring are unchanged. No source content, filename/path, digest, raw payload, private fixture, or credential is included.