### PR TITLE
test(hwp5): add fail-closed own-parser eligibility matrix

### DIFF
--- a/corpus/PUBLIC-CORPUS.md
+++ b/corpus/PUBLIC-CORPUS.md
@@ -9,6 +9,15 @@
 40/40이 정상 종료했다. 이 확인은 문서가 안전하게 열리고 조판 feature를 계측할 수 있다는 증거이지,
 한/글과의 시각 동일성 점수는 아니다.
 
+first-party HWP5 전환 적격성은 별도 fail-closed 계약이다. 저장소에 직접 커밋된 공개 HWP5 12건과
+bounded benchmark 1건은 `hwp5_eligibility_matrix`가 파일명·경로·본문·원본 hash 없이 반복 실행한다.
+현재 13건 모두 ineligible이며 사유 집계는 semantic-mismatch 1, unsupported-semantic 7,
+unsupported-section-control 4, invalid-container 1이다. private intake 20건이 로컬에 있으면 매트릭스는
+자동으로 33건으로 확장되며, 현재 추가 거부 사유는 unsupported-style-semantics 15,
+unsupported-border-fill 3, unsupported-table-topology 2다. production parser 40/40 통과와 자체 파서
+eligible은 서로 다른 지표다. 또한 typed semantic 비교가 같더라도 문서별 layout/PDF 근거가 없는
+v2는 `render-parity-unproven`으로 거부한다.
+
 | 형식 | 승격 | 역할 |
 |---|---:|---|
 | HWP5 | 20 | 법령 별지 빈 양식·표·form-control 축 |

--- a/crates/hwp-core/src/lib.rs
+++ b/crates/hwp-core/src/lib.rs
@@ -67,6 +67,29 @@ pub fn hwp5_differential(bytes: &[u8]) -> Result<hwp_hwp5::DifferentialReport> {
     Ok(hwp_hwp5::compare_with_semantic(&native, &semantic))
 }
 
+/// Fail-closed production-cutover diagnostic. An unsupported first-party parse becomes a static,
+/// content-free ineligible result; rhwp is consulted only when the candidate parse succeeds, and
+/// remains the production parser regardless of the result.
+pub fn hwp5_own_parser_eligibility(bytes: &[u8]) -> Result<hwp_hwp5::OwnParserEligibilityReport> {
+    let source = match hwp_hwp5::probe(bytes) {
+        Ok(source) => source,
+        Err(error) => return Ok(hwp_hwp5::rejected_eligibility(error.eligibility_code())),
+    };
+    let candidate = match hwp_hwp5::OwnHwp5Parser::new().parse(bytes) {
+        Ok(candidate) => candidate,
+        Err(error) => {
+            return Ok(hwp_hwp5::rejected_eligibility_with_source(
+                &source,
+                error.eligibility_code(),
+            ));
+        }
+    };
+    let oracle = RhwpEngine::new().parse(bytes, SourceFormat::Hwp5)?;
+    Ok(hwp_hwp5::compare_semantic_candidates_with_source(
+        &source, &candidate, &oracle,
+    ))
+}
+
 #[cfg(all(test, feature = "rhwp"))]
 mod hwp5_candidate_tests {
     use super::*;
@@ -99,6 +122,69 @@ mod hwp5_candidate_tests {
         assert!(!json.contains("benchmark.hwp"));
         assert!(!json.contains("BodyText"));
         assert!(json.contains("topo-fnv1a64:"));
+    }
+
+    #[test]
+    fn eligibility_uses_semantic_coordinates_and_is_content_free() {
+        let legacy = hwp5_differential(&benchmark()).unwrap();
+        let first = hwp5_own_parser_eligibility(&benchmark()).unwrap();
+        let second = hwp5_own_parser_eligibility(&benchmark()).unwrap();
+        assert_eq!(first, second);
+        assert_eq!(first.schema, "auto-hwp.hwp5-own-parser-eligibility.v2");
+        assert!(!first.eligible);
+        assert_eq!(first.rejection_code, Some("semantic-mismatch"));
+        let source = first.source_records.expect("source record classification");
+        assert_eq!(source.paragraph_headers, 353);
+        assert_eq!(source.run_position_tuples, 389);
+        assert_eq!(source.control_headers.tables, 32);
+        assert_eq!(source.control_headers.section_definitions, 1);
+        assert_eq!(source.control_headers.column_definitions, 1);
+        assert_eq!(source.control_headers.page_number_positions, 2);
+        assert_eq!(source.control_headers.new_number_controls, 2);
+        assert_eq!(source.control_headers.other, 0);
+        assert_eq!(legacy.delta.paragraphs, 1);
+        assert_eq!(legacy.delta.runs, 7);
+        assert_eq!(legacy.delta.controls, 6);
+        let comparison = first.comparison.as_ref().expect("owned benchmark parses");
+        assert_eq!(comparison.schema, "auto-hwp.hwp5-semantic-differential.v2");
+        assert!(comparison.text_matches);
+        assert!(!comparison.topology_matches);
+        assert_eq!(
+            comparison.candidate.paragraphs,
+            comparison.oracle.paragraphs
+        );
+        assert_eq!(comparison.candidate.controls, comparison.oracle.controls);
+        assert_eq!(
+            comparison.candidate.runs.body,
+            comparison.oracle.runs.body + 2
+        );
+        assert_eq!(
+            comparison.candidate.runs.table_cells,
+            comparison.oracle.runs.table_cells + 4
+        );
+        assert_eq!(
+            comparison.candidate.empty_text_runs.body,
+            comparison.oracle.empty_text_runs.body + 2
+        );
+        assert_eq!(
+            comparison.candidate.empty_text_runs.table_cells,
+            comparison.oracle.empty_text_runs.table_cells + 4
+        );
+        let json = serde_json::to_string(&first).unwrap();
+        assert!(!json.contains("benchmark.hwp"));
+        assert!(!json.contains("BodyText"));
+        assert!(json.contains("topo-fnv1a64:"));
+    }
+
+    #[test]
+    fn unsupported_input_is_ineligible_without_dynamic_error_details() {
+        let report = hwp5_own_parser_eligibility(b"fixture-input-marker").unwrap();
+        assert!(!report.eligible);
+        assert_eq!(report.rejection_code, Some("invalid-container"));
+        assert!(report.source_records.is_none());
+        assert!(report.comparison.is_none());
+        let json = serde_json::to_string(&report).unwrap();
+        assert!(!json.contains("fixture-input-marker"));
     }
 }
 

--- a/crates/hwp-core/tests/hwp5_eligibility_matrix.rs
+++ b/crates/hwp-core/tests/hwp5_eligibility_matrix.rs
@@ -1,0 +1,72 @@
+#![cfg(feature = "rhwp")]
+
+use hwp_core::hwp5_own_parser_eligibility;
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+fn public_hwp5_cases() -> Vec<PathBuf> {
+    let repo = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let mut paths: Vec<PathBuf> = std::fs::read_dir(repo.join("corpus/hwp"))
+        .expect("committed public HWP5 corpus exists")
+        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+        .filter(|path| path.extension().is_some_and(|extension| extension == "hwp"))
+        .collect();
+    paths.push(repo.join("benchmarks/benchmark.hwp"));
+    let private_intake = repo.join("corpus/private/public-intake/files");
+    if let Ok(entries) = std::fs::read_dir(private_intake) {
+        paths.extend(
+            entries
+                .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+                .filter(|path| path.extension().is_some_and(|extension| extension == "hwp")),
+        );
+    }
+    paths.sort();
+    paths
+}
+
+#[test]
+fn public_hwp5_matrix_is_reproducible_content_free_and_fail_closed() {
+    let cases = public_hwp5_cases();
+    assert!(
+        cases.len() >= 13,
+        "public HWP5 coverage unexpectedly shrank"
+    );
+
+    let mut eligible = 0usize;
+    let mut rejected = BTreeMap::<&'static str, usize>::new();
+    for path in &cases {
+        let bytes = std::fs::read(path).expect("committed public case remains readable");
+        let first = hwp5_own_parser_eligibility(&bytes).expect("bounded diagnostic completes");
+        let second = hwp5_own_parser_eligibility(&bytes).expect("bounded diagnostic repeats");
+        assert_eq!(first, second, "eligibility must be deterministic");
+
+        if first.eligible {
+            eligible += 1;
+            let comparison = first
+                .comparison
+                .as_ref()
+                .expect("eligible case has comparison");
+            assert!(comparison.mismatches.is_empty());
+            assert!(comparison.topology_matches);
+            assert!(comparison.text_matches);
+        } else {
+            let code = first
+                .rejection_code
+                .expect("every ineligible case has a static reason");
+            *rejected.entry(code).or_default() += 1;
+        }
+
+        let public = serde_json::to_string(&first).unwrap();
+        assert!(!public.contains(&path.to_string_lossy().to_string()));
+        if let Some(name) = path.file_name().and_then(|name| name.to_str()) {
+            assert!(!public.contains(name));
+        }
+    }
+
+    println!(
+        "hwp5-eligibility-matrix.v2 cases={} eligible={} ineligible={} reasons={rejected:?}",
+        cases.len(),
+        eligible,
+        cases.len() - eligible,
+    );
+}

--- a/crates/hwp-hwp5/src/lib.rs
+++ b/crates/hwp-hwp5/src/lib.rs
@@ -12,7 +12,11 @@ pub use header::{
     HWP_SIGNATURE,
 };
 pub use probe::{
-    compare_with_semantic, probe, DifferentialReport, Hwp5Probe, StreamProbe, StructuralDelta,
+    compare_semantic_candidates, compare_semantic_candidates_with_source, compare_with_semantic,
+    probe, rejected_eligibility, rejected_eligibility_with_source, source_record_projection,
+    DifferentialReport, Hwp5Probe, OwnParserEligibilityReport, SemanticControlCounts,
+    SemanticDifferentialReport, SemanticMismatch, SemanticProjection, SemanticScopeCounts,
+    SourceControlHeaderCounts, SourceRecordProjection, StreamProbe, StructuralDelta,
     StructuralInventory,
 };
 pub use record::{walk_records, Record, RecordError, RecordLimits};
@@ -76,6 +80,38 @@ pub enum Error {
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
+
+impl Error {
+    /// Stable content-free classifier for corpus eligibility reports. The detailed error remains
+    /// available to local diagnostics, while public matrices never expose paths, offsets, or input.
+    pub fn eligibility_code(&self) -> &'static str {
+        match self {
+            Self::Limit(_) | Self::DecompressedLimit { .. } => "resource-limit",
+            Self::Cfb(_) => "invalid-container",
+            Self::MissingStream(_) => "missing-required-stream",
+            Self::NonContiguousSections { .. } => "noncontiguous-sections",
+            Self::Header(_) => "invalid-header",
+            Self::OpaqueBody(_) => "opaque-body",
+            Self::Record(_) => "malformed-record",
+            Self::MalformedRecord { reason, .. } => match *reason {
+                "BORDER_FILL image, gradient, or mixed fill is not supported" => {
+                    "unsupported-border-fill"
+                }
+                "STYLE has an unknown kind or attributes" => "unsupported-style-semantics",
+                "TABLE attributes or row/column topology are not owned" => {
+                    "unsupported-table-topology"
+                }
+                "section CTRL_HEADER extension semantics are not owned" => {
+                    "unsupported-section-control"
+                }
+                _ => "malformed-record",
+            },
+            Self::PoolCountMismatch { .. } => "pool-count-mismatch",
+            Self::InvalidReference { .. } => "invalid-reference",
+            Self::UnsupportedBodyRecord { .. } => "unsupported-semantic",
+        }
+    }
+}
 
 /// Explicit own-parser entry point. This type has no rhwp dependency and cannot silently fall back.
 #[derive(Default)]

--- a/crates/hwp-hwp5/src/probe.rs
+++ b/crates/hwp-hwp5/src/probe.rs
@@ -13,6 +13,11 @@ const TAG_TABLE: u16 = 0x4d;
 const TAG_PICTURE: u16 = 0x55;
 const TAG_EQUATION: u16 = 0x58;
 const TAG_CHART: u16 = 0x5f;
+const CTRL_SECTION_DEF: u32 = u32::from_be_bytes(*b"secd");
+const CTRL_COLUMN_DEF: u32 = u32::from_be_bytes(*b"cold");
+const CTRL_PAGE_NUM_POS: u32 = u32::from_be_bytes(*b"pgnp");
+const CTRL_NEW_NUMBER: u32 = u32::from_be_bytes(*b"nwno");
+const CTRL_TABLE: u32 = u32::from_be_bytes(*b"tbl ");
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct StreamProbe {
@@ -64,6 +69,91 @@ pub struct DifferentialReport {
     pub delta: StructuralDelta,
     /// FNV-1a over typed AST topology markers only. It is not a source/content hash.
     pub semantic_topology_fingerprint: String,
+}
+
+/// Paragraph/run counts split by their semantic location. Unlike [`StructuralInventory`], every
+/// field here is measured from a `SemanticDoc` on both sides of the comparison.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize)]
+pub struct SemanticScopeCounts {
+    pub body: usize,
+    pub decorations: usize,
+    pub table_cells: usize,
+    pub table_captions: usize,
+    pub notes: usize,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize)]
+pub struct SemanticControlCounts {
+    pub tables: usize,
+    pub images: usize,
+    pub equations: usize,
+    pub charts: usize,
+    pub notes: usize,
+    pub field_boundaries: usize,
+    pub bookmarks: usize,
+    pub raw: usize,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct SemanticProjection {
+    pub sections: usize,
+    pub paragraphs: SemanticScopeCounts,
+    pub runs: SemanticScopeCounts,
+    /// Adjacent text-only runs with the same in-document character-shape reference count as one.
+    /// This distinguishes harmless record segmentation from an effective style boundary.
+    pub coalesced_text_runs: SemanticScopeCounts,
+    pub empty_text_runs: SemanticScopeCounts,
+    pub controls: SemanticControlCounts,
+    /// FNV-1a over typed AST topology markers only. It is not a source/content hash.
+    pub semantic_topology_fingerprint: String,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize)]
+pub struct SourceControlHeaderCounts {
+    pub tables: usize,
+    pub section_definitions: usize,
+    pub column_definitions: usize,
+    pub page_number_positions: usize,
+    pub new_number_controls: usize,
+    pub other: usize,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize)]
+pub struct SourceRecordProjection {
+    pub paragraph_headers: usize,
+    pub run_position_tuples: usize,
+    pub control_headers: SourceControlHeaderCounts,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct SemanticMismatch {
+    pub category: &'static str,
+    pub candidate: usize,
+    pub oracle: usize,
+    pub delta: i64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct SemanticDifferentialReport {
+    pub schema: &'static str,
+    pub candidate: SemanticProjection,
+    pub oracle: SemanticProjection,
+    pub mismatches: Vec<SemanticMismatch>,
+    pub topology_matches: bool,
+    /// Exact text equality is checked in memory and exposed only as a boolean. Source text and a
+    /// content-derived hash never enter the report.
+    pub text_matches: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct OwnParserEligibilityReport {
+    pub schema: &'static str,
+    pub eligible: bool,
+    /// Static, content-free reason. Dynamic parse errors, offsets, paths, and source identifiers are
+    /// intentionally excluded from this report.
+    pub rejection_code: Option<&'static str>,
+    pub source_records: Option<SourceRecordProjection>,
+    pub comparison: Option<SemanticDifferentialReport>,
 }
 
 pub fn probe(bytes: &[u8]) -> Result<Hwp5Probe> {
@@ -242,6 +332,459 @@ pub fn compare_with_semantic(native: &Hwp5Probe, oracle: &SemanticDoc) -> Differ
     }
 }
 
+/// Compare the first-party parser and the rhwp oracle in the same semantic coordinate system.
+/// This additive v2 contract leaves the raw-record-to-semantic v1 report unchanged.
+pub fn compare_semantic_candidates(
+    candidate: &SemanticDoc,
+    oracle: &SemanticDoc,
+) -> OwnParserEligibilityReport {
+    let text_matches = semantic_text_projection(candidate) == semantic_text_projection(oracle);
+    let candidate = semantic_projection(candidate);
+    let oracle = semantic_projection(oracle);
+    let topology_matches =
+        candidate.semantic_topology_fingerprint == oracle.semantic_topology_fingerprint;
+    let mismatches = semantic_mismatches(&candidate, &oracle);
+    let semantic_matches = topology_matches && text_matches && mismatches.is_empty();
+    OwnParserEligibilityReport {
+        schema: "auto-hwp.hwp5-own-parser-eligibility.v2",
+        // v2 classifies semantic equality but has no per-document layout/PDF evidence channel yet.
+        // A semantic match is therefore still not sufficient to declare cutover eligibility.
+        eligible: false,
+        rejection_code: Some(if semantic_matches {
+            "render-parity-unproven"
+        } else {
+            "semantic-mismatch"
+        }),
+        source_records: None,
+        comparison: Some(SemanticDifferentialReport {
+            schema: "auto-hwp.hwp5-semantic-differential.v2",
+            candidate,
+            oracle,
+            mismatches,
+            topology_matches,
+            text_matches,
+        }),
+    }
+}
+
+fn semantic_text_projection(doc: &SemanticDoc) -> Vec<String> {
+    let mut out = Vec::new();
+    for section in &doc.sections {
+        collect_block_text(&section.blocks, &mut out);
+        for decoration in &section.decorations {
+            collect_block_text(&decoration.blocks, &mut out);
+        }
+    }
+    out
+}
+
+fn collect_block_text(blocks: &[Block], out: &mut Vec<String>) {
+    for block in blocks {
+        match block {
+            Block::Paragraph(paragraph) => {
+                let mut text = String::new();
+                for run in &paragraph.runs {
+                    for inline in &run.content {
+                        match inline {
+                            Inline::Text(value) => text.push_str(value),
+                            Inline::Note(note) => collect_block_text(&note.body, out),
+                            _ => {}
+                        }
+                    }
+                }
+                out.push(text);
+            }
+            Block::Table(table) => {
+                if let Some(caption) = &table.caption {
+                    collect_block_text(&caption.blocks, out);
+                }
+                for cell in &table.cells {
+                    collect_block_text(&cell.blocks, out);
+                }
+            }
+        }
+    }
+}
+
+pub fn compare_semantic_candidates_with_source(
+    source: &Hwp5Probe,
+    candidate: &SemanticDoc,
+    oracle: &SemanticDoc,
+) -> OwnParserEligibilityReport {
+    let mut report = compare_semantic_candidates(candidate, oracle);
+    report.source_records = Some(source_record_projection(source));
+    report
+}
+
+pub fn rejected_eligibility(rejection_code: &'static str) -> OwnParserEligibilityReport {
+    OwnParserEligibilityReport {
+        schema: "auto-hwp.hwp5-own-parser-eligibility.v2",
+        eligible: false,
+        rejection_code: Some(rejection_code),
+        source_records: None,
+        comparison: None,
+    }
+}
+
+pub fn rejected_eligibility_with_source(
+    source: &Hwp5Probe,
+    rejection_code: &'static str,
+) -> OwnParserEligibilityReport {
+    let mut report = rejected_eligibility(rejection_code);
+    report.source_records = Some(source_record_projection(source));
+    report
+}
+
+pub fn source_record_projection(source: &Hwp5Probe) -> SourceRecordProjection {
+    let mut projection = SourceRecordProjection::default();
+    for stream in source
+        .streams
+        .iter()
+        .filter(|stream| stream.section.is_some())
+    {
+        for record in &stream.records {
+            match record.tag {
+                TAG_PARA_HEADER => projection.paragraph_headers += 1,
+                TAG_PARA_CHAR_SHAPE => projection.run_position_tuples += record.size / 8,
+                TAG_CTRL_HEADER => {
+                    let control_id = (record.size >= 4)
+                        .then(|| stream.raw.get(record.data..record.data + 4))
+                        .flatten()
+                        .and_then(|bytes| bytes.try_into().ok())
+                        .map(u32::from_le_bytes);
+                    match control_id {
+                        Some(CTRL_TABLE) => projection.control_headers.tables += 1,
+                        Some(CTRL_SECTION_DEF) => {
+                            projection.control_headers.section_definitions += 1;
+                        }
+                        Some(CTRL_COLUMN_DEF) => {
+                            projection.control_headers.column_definitions += 1;
+                        }
+                        Some(CTRL_PAGE_NUM_POS) => {
+                            projection.control_headers.page_number_positions += 1;
+                        }
+                        Some(CTRL_NEW_NUMBER) => {
+                            projection.control_headers.new_number_controls += 1;
+                        }
+                        _ => projection.control_headers.other += 1,
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    projection
+}
+
+fn semantic_projection(doc: &SemanticDoc) -> SemanticProjection {
+    let fingerprint = semantic_v2_topology(doc);
+    let mut projection = SemanticProjection {
+        sections: doc.sections.len(),
+        paragraphs: SemanticScopeCounts::default(),
+        runs: SemanticScopeCounts::default(),
+        coalesced_text_runs: SemanticScopeCounts::default(),
+        empty_text_runs: SemanticScopeCounts::default(),
+        controls: SemanticControlCounts::default(),
+        semantic_topology_fingerprint: format!("topo-fnv1a64:{fingerprint:016x}"),
+    };
+    for section in &doc.sections {
+        visit_typed_blocks(&section.blocks, SemanticScope::Body, &mut projection);
+        for decoration in &section.decorations {
+            visit_typed_blocks(
+                &decoration.blocks,
+                SemanticScope::Decoration,
+                &mut projection,
+            );
+        }
+    }
+    projection
+}
+
+fn semantic_v2_topology(doc: &SemanticDoc) -> u64 {
+    let mut hash = Fnv1a::new();
+    hash.marker(20, doc.sections.len());
+    for section in &doc.sections {
+        hash.marker(21, section.blocks.len());
+        hash_v2_blocks(&section.blocks, &mut hash);
+        hash.marker(22, section.decorations.len());
+        for decoration in &section.decorations {
+            hash.marker(23, decoration.blocks.len());
+            hash_v2_blocks(&decoration.blocks, &mut hash);
+        }
+    }
+    hash.0
+}
+
+fn hash_v2_blocks(blocks: &[Block], hash: &mut Fnv1a) {
+    hash.marker(24, blocks.len());
+    for block in blocks {
+        match block {
+            Block::Paragraph(paragraph) => {
+                hash.marker(25, paragraph.runs.len());
+                for run in &paragraph.runs {
+                    hash.marker(26, run.content.len());
+                    for inline in &run.content {
+                        match inline {
+                            Inline::Text(_) => hash.marker(27, 0),
+                            Inline::Image(_) => hash.marker(28, 0),
+                            Inline::Equation(_) => hash.marker(29, 0),
+                            Inline::Chart(_) => hash.marker(30, 0),
+                            Inline::Note(note) => {
+                                hash.marker(31, note.body.len());
+                                hash_v2_blocks(&note.body, hash);
+                            }
+                            Inline::FieldBegin(_) => hash.marker(32, 0),
+                            Inline::FieldEnd(_) => hash.marker(33, 0),
+                            Inline::Bookmark(_) => hash.marker(34, 0),
+                            Inline::Raw(_) => hash.marker(35, 0),
+                        }
+                    }
+                }
+            }
+            Block::Table(table) => {
+                hash.marker(36, table.rows);
+                hash.marker(37, table.cols);
+                hash.marker(38, table.cells.len());
+                hash.marker(39, usize::from(table.caption.is_some()));
+                if let Some(caption) = &table.caption {
+                    hash_v2_blocks(&caption.blocks, hash);
+                }
+                for cell in &table.cells {
+                    hash.marker(40, cell.row);
+                    hash.marker(41, cell.col);
+                    hash.marker(42, cell.row_span);
+                    hash.marker(43, cell.col_span);
+                    hash.marker(44, usize::from(cell.active));
+                    hash_v2_blocks(&cell.blocks, hash);
+                }
+            }
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum SemanticScope {
+    Body,
+    Decoration,
+    TableCell,
+    TableCaption,
+    Note,
+}
+
+fn increment_scope(counts: &mut SemanticScopeCounts, scope: SemanticScope, amount: usize) {
+    match scope {
+        SemanticScope::Body => counts.body += amount,
+        SemanticScope::Decoration => counts.decorations += amount,
+        SemanticScope::TableCell => counts.table_cells += amount,
+        SemanticScope::TableCaption => counts.table_captions += amount,
+        SemanticScope::Note => counts.notes += amount,
+    }
+}
+
+fn visit_typed_blocks(blocks: &[Block], scope: SemanticScope, projection: &mut SemanticProjection) {
+    for block in blocks {
+        match block {
+            Block::Paragraph(paragraph) => {
+                increment_scope(&mut projection.paragraphs, scope, 1);
+                increment_scope(&mut projection.runs, scope, paragraph.runs.len());
+                let mut coalesced_runs = 0usize;
+                let mut previous_plain_shape = None;
+                for run in &paragraph.runs {
+                    let plain_text = run
+                        .content
+                        .iter()
+                        .all(|inline| matches!(inline, Inline::Text(_)));
+                    if !plain_text || previous_plain_shape != Some(run.char_shape) {
+                        coalesced_runs += 1;
+                    }
+                    previous_plain_shape = plain_text.then_some(run.char_shape);
+                    let empty_text = run.content.iter().all(|inline| match inline {
+                        Inline::Text(text) => text.is_empty(),
+                        _ => false,
+                    });
+                    if empty_text {
+                        increment_scope(&mut projection.empty_text_runs, scope, 1);
+                    }
+                    for inline in &run.content {
+                        match inline {
+                            Inline::Text(_) => {}
+                            Inline::Image(_) => projection.controls.images += 1,
+                            Inline::Equation(_) => projection.controls.equations += 1,
+                            Inline::Chart(_) => projection.controls.charts += 1,
+                            Inline::Note(note) => {
+                                projection.controls.notes += 1;
+                                visit_typed_blocks(&note.body, SemanticScope::Note, projection);
+                            }
+                            Inline::FieldBegin(_) | Inline::FieldEnd(_) => {
+                                projection.controls.field_boundaries += 1;
+                            }
+                            Inline::Bookmark(_) => projection.controls.bookmarks += 1,
+                            Inline::Raw(_) => projection.controls.raw += 1,
+                        }
+                    }
+                }
+                increment_scope(&mut projection.coalesced_text_runs, scope, coalesced_runs);
+            }
+            Block::Table(table) => {
+                projection.controls.tables += 1;
+                if let Some(caption) = &table.caption {
+                    visit_typed_blocks(&caption.blocks, SemanticScope::TableCaption, projection);
+                }
+                for cell in &table.cells {
+                    visit_typed_blocks(&cell.blocks, SemanticScope::TableCell, projection);
+                }
+            }
+        }
+    }
+}
+
+fn semantic_mismatches(
+    candidate: &SemanticProjection,
+    oracle: &SemanticProjection,
+) -> Vec<SemanticMismatch> {
+    let mut out = Vec::new();
+    let mut push = |category: &'static str, left: usize, right: usize| {
+        if left != right {
+            out.push(SemanticMismatch {
+                category,
+                candidate: left,
+                oracle: right,
+                delta: left as i64 - right as i64,
+            });
+        }
+    };
+    push("sections", candidate.sections, oracle.sections);
+    push(
+        "paragraphs.body",
+        candidate.paragraphs.body,
+        oracle.paragraphs.body,
+    );
+    push(
+        "paragraphs.decorations",
+        candidate.paragraphs.decorations,
+        oracle.paragraphs.decorations,
+    );
+    push(
+        "paragraphs.table-cells",
+        candidate.paragraphs.table_cells,
+        oracle.paragraphs.table_cells,
+    );
+    push(
+        "paragraphs.table-captions",
+        candidate.paragraphs.table_captions,
+        oracle.paragraphs.table_captions,
+    );
+    push(
+        "paragraphs.notes",
+        candidate.paragraphs.notes,
+        oracle.paragraphs.notes,
+    );
+    push("runs.body", candidate.runs.body, oracle.runs.body);
+    push(
+        "runs.decorations",
+        candidate.runs.decorations,
+        oracle.runs.decorations,
+    );
+    push(
+        "runs.table-cells",
+        candidate.runs.table_cells,
+        oracle.runs.table_cells,
+    );
+    push(
+        "runs.table-captions",
+        candidate.runs.table_captions,
+        oracle.runs.table_captions,
+    );
+    push("runs.notes", candidate.runs.notes, oracle.runs.notes);
+    push(
+        "coalesced-text-runs.body",
+        candidate.coalesced_text_runs.body,
+        oracle.coalesced_text_runs.body,
+    );
+    push(
+        "coalesced-text-runs.decorations",
+        candidate.coalesced_text_runs.decorations,
+        oracle.coalesced_text_runs.decorations,
+    );
+    push(
+        "coalesced-text-runs.table-cells",
+        candidate.coalesced_text_runs.table_cells,
+        oracle.coalesced_text_runs.table_cells,
+    );
+    push(
+        "coalesced-text-runs.table-captions",
+        candidate.coalesced_text_runs.table_captions,
+        oracle.coalesced_text_runs.table_captions,
+    );
+    push(
+        "coalesced-text-runs.notes",
+        candidate.coalesced_text_runs.notes,
+        oracle.coalesced_text_runs.notes,
+    );
+    push(
+        "empty-text-runs.body",
+        candidate.empty_text_runs.body,
+        oracle.empty_text_runs.body,
+    );
+    push(
+        "empty-text-runs.decorations",
+        candidate.empty_text_runs.decorations,
+        oracle.empty_text_runs.decorations,
+    );
+    push(
+        "empty-text-runs.table-cells",
+        candidate.empty_text_runs.table_cells,
+        oracle.empty_text_runs.table_cells,
+    );
+    push(
+        "empty-text-runs.table-captions",
+        candidate.empty_text_runs.table_captions,
+        oracle.empty_text_runs.table_captions,
+    );
+    push(
+        "empty-text-runs.notes",
+        candidate.empty_text_runs.notes,
+        oracle.empty_text_runs.notes,
+    );
+    push(
+        "controls.tables",
+        candidate.controls.tables,
+        oracle.controls.tables,
+    );
+    push(
+        "controls.images",
+        candidate.controls.images,
+        oracle.controls.images,
+    );
+    push(
+        "controls.equations",
+        candidate.controls.equations,
+        oracle.controls.equations,
+    );
+    push(
+        "controls.charts",
+        candidate.controls.charts,
+        oracle.controls.charts,
+    );
+    push(
+        "controls.notes",
+        candidate.controls.notes,
+        oracle.controls.notes,
+    );
+    push(
+        "controls.field-boundaries",
+        candidate.controls.field_boundaries,
+        oracle.controls.field_boundaries,
+    );
+    push(
+        "controls.bookmarks",
+        candidate.controls.bookmarks,
+        oracle.controls.bookmarks,
+    );
+    push("controls.raw", candidate.controls.raw, oracle.controls.raw);
+    out
+}
+
 fn delta(a: StructuralInventory, b: StructuralInventory) -> StructuralDelta {
     let d = |left: usize, right: usize| left as i64 - right as i64;
     StructuralDelta {
@@ -359,7 +902,7 @@ mod tests {
             runs: vec![hwp_model::document::Run {
                 char_shape: 0,
                 char_ref: None,
-                content: vec![Inline::Text("private-a".into())],
+                content: vec![Inline::Text("fixture-a".into())],
             }],
             ..Default::default()
         });
@@ -367,9 +910,23 @@ mod tests {
         let Block::Paragraph(paragraph) = &mut right.sections[0].blocks[0] else {
             unreachable!()
         };
-        paragraph.runs[0].content[0] = Inline::Text("different-secret".into());
+        paragraph.runs[0].content[0] = Inline::Text("fixture-b".into());
         let (_, a) = semantic_inventory(&left);
         let (_, b) = semantic_inventory(&right);
         assert_eq!(a, b);
+
+        let changed = compare_semantic_candidates(&left, &right);
+        assert!(!changed.eligible);
+        assert_eq!(changed.rejection_code, Some("semantic-mismatch"));
+        let comparison = changed.comparison.unwrap();
+        assert!(comparison.topology_matches);
+        assert!(!comparison.text_matches);
+        let json = serde_json::to_string(&comparison).unwrap();
+        assert!(!json.contains("fixture-a"));
+        assert!(!json.contains("fixture-b"));
+
+        let identical = compare_semantic_candidates(&left, &left);
+        assert!(!identical.eligible);
+        assert_eq!(identical.rejection_code, Some("render-parity-unproven"));
     }
 }

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -15,6 +15,31 @@
   projection을 설계한다. 공개 HWP5 corpus에 fail-closed eligibility matrix를 산출하되 원문·파일명·
   경로·원본 hash/raw는 출력하지 않는다. unknown/unsupported/ambiguous는 ineligible이며 production
   route는 rhwp를 유지한다. `external/rhwp`·HWPX·shared layout·PDF scoring은 불변.
+  v1 `+1/+7/+6`을 typed v2로 재측정했다. paragraph +1은 v1이 caption paragraph/run을 순회하지
+  않은 차이이고 semantic 양쪽은 body **91**/cell **261**/caption **1**로 같다. control +6은 table이
+  아니라 section **1**/column **1**/page-number-position **2**/new-number **2** metadata header이며
+  semantic table **32/32**가 같다. 실 semantic run 차이는 empty text run body **+2**/cell **+4**이고
+  exact text는 같다. 빈 run의 char-shape가 blank-line 조판에 미칠 가능성을 아직 증명하지 않았으므로
+  benchmark는 `semantic-mismatch` ineligible로 유지한다. additive v2는 source header를 typed aggregate로,
+  semantic paragraph/run을 location별로, control을 kind별로 비교하며 text는 메모리에서 exact 비교 후
+  boolean만 노출한다. counts/text가 같아도 per-doc layout/PDF evidence channel이 아직 없으므로
+  `render-parity-unproven`으로 거부해 false-positive eligible을 막는다. unsupported/error는 동적 상세
+  없이 static code로 거부하고 rhwp를 호출하지 않는다.
+  committed public HWP5 **13건** 2회 matrix는 eligible **0**, semantic-mismatch **1**,
+  unsupported-semantic **7**, unsupported-section-control **4**, invalid-container **1**로 deterministic하다.
+  권리/개인정보/컨테이너 검토가 고정된 public intake **50/50**(HWP5 20/HWPX 20/PDF 10)을 private
+  ignored lane에 안전하게 재수집했다. optional HWP5 20건을 포함한 **33건** matrix도 2회 deterministic하며
+  추가 분류는 unsupported-style-semantics **15**, unsupported-border-fill **3**,
+  unsupported-table-topology **2**다. 원문·파일명·경로·원본 hash는 report/log에 없다.
+  hostile/content-free projection tests, focused clippy `-D warnings`, wasm32 green. quick 전체도
+  workspace/PDF visual **51**/canonical **8·18·24·98.9%+**/public corpus **84**/oracle **82**/HWPX/
+  wasm/licenses green이다. full은 새 wasm **7,818,243B**, JS build/crosscheck/i18n, Vitest **1,007**
+  green이고 sandbox port EPERM 뒤 실제 Chromium **85 pass/3 intentional skip/0 fail**이다. 임시
+  node_modules links는 제거했다. final audit에서 변경은 HWP5 typed v2/eligibility/matrix와 문서뿐이며
+  production route·`external/rhwp`·HWPX·shared typesetter·generated wasm/assets·oracle scoring diff 0,
+  private source text/path/hash/raw/credential diff 0이다. **다음:** commit/push→`Closes #198` PR→
+  exact-head CI/comments/mergeability green이면 autonomous merge. 후속은 empty-run 6건의
+  char-shape/layout/PDF 영향 판정과 가장 큰 corpus refusal인 STYLE 15건 classification-first slice.
 
 - 갱신: 2026-08-24 · Codex(sol) — **PR #195 병합 · #196 착수**.
   PR #195 exact head `cecbfdc`에서 issue-link **5s**·build-test **9m31s**·licenses **2m54s** green,

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -40,6 +40,8 @@
   private source text/path/hash/raw/credential diff 0이다. **다음:** commit/push→`Closes #198` PR→
   exact-head CI/comments/mergeability green이면 autonomous merge. 후속은 empty-run 6건의
   char-shape/layout/PDF 영향 판정과 가장 큰 corpus refusal인 STYLE 15건 classification-first slice.
+  continuity start `0e943c9`와 구현/검증 `f8b43e8`을 원격
+  `codex/issue-198-hwp5-eligibility`에 push했다. **다음:** `Closes #198` PR 게시→required CI.
 
 - 갱신: 2026-08-24 · Codex(sol) — **PR #195 병합 · #196 착수**.
   PR #195 exact head `cecbfdc`에서 issue-link **5s**·build-test **9m31s**·licenses **2m54s** green,

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -41,7 +41,8 @@
   exact-head CI/comments/mergeability green이면 autonomous merge. 후속은 empty-run 6건의
   char-shape/layout/PDF 영향 판정과 가장 큰 corpus refusal인 STYLE 15건 classification-first slice.
   continuity start `0e943c9`와 구현/검증 `f8b43e8`을 원격
-  `codex/issue-198-hwp5-eligibility`에 push했다. **다음:** `Closes #198` PR 게시→required CI.
+  `codex/issue-198-hwp5-eligibility`에 push했다. `Closes #198` PR **#199**를 게시했다.
+  **다음:** final head required CI·reviews/comments·mergeability green이면 autonomous merge.
 
 - 갱신: 2026-08-24 · Codex(sol) — **PR #195 병합 · #196 착수**.
   PR #195 exact head `cecbfdc`에서 issue-link **5s**·build-test **9m31s**·licenses **2m54s** green,

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,6 +3,19 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
+- 갱신: 2026-08-24 · Codex(sol) — **PR #197 병합 · #198 착수**.
+  PR #197 exact head `c68b74e`에서 issue-link **5s**·build-test **9m57s**·licenses **2m49s** green,
+  CLEAN/MERGEABLE, review/general/inline 댓글 0을 확인하고 protected main `6f1f3687`로 squash 병합했다.
+  #196 close·원격 branch 정리를 확인하고 #94에 benchmark-complete/no-cutover 근거를 동기화했다.
+  content-free native/rhwp comparison은 sections **1/1**, tables **32/32**, images/equations/charts
+  **0/0**이며 native 쪽 paragraphs **+1**, runs **+7**, controls **+6**이다. raw-record와 semantic IR
+  count를 같은 지표로 취급하지 않고 typed meaning을 분류하기 위해 후속 **#198**을 R18/P1/
+  area:hwp5/status:ready로 열고 exact main의 `codex/issue-198-hwp5-eligibility` worktree를 만들었다.
+  **다음:** 기존 differential schema와 두 projection의 counting semantics를 조사해 additive typed
+  projection을 설계한다. 공개 HWP5 corpus에 fail-closed eligibility matrix를 산출하되 원문·파일명·
+  경로·원본 hash/raw는 출력하지 않는다. unknown/unsupported/ambiguous는 ineligible이며 production
+  route는 rhwp를 유지한다. `external/rhwp`·HWPX·shared layout·PDF scoring은 불변.
+
 - 갱신: 2026-08-24 · Codex(sol) — **PR #195 병합 · #196 착수**.
   PR #195 exact head `cecbfdc`에서 issue-link **5s**·build-test **9m31s**·licenses **2m54s** green,
   CLEAN/MERGEABLE, review/general/inline 댓글 0을 확인하고 protected main `dee2996f`로 squash 병합했다.

--- a/docs/HWP5-NATIVE-PARSER.md
+++ b/docs/HWP5-NATIVE-PARSER.md
@@ -80,6 +80,12 @@ rejected instead of being interpreted as records.
   to shared `Table`/`Cell`/`TableCaption` IR, so SVG and PDF consume the same `place_doc` geometry.
 - `hwp5_differential`: explicitly runs the owned probe and current rhwp semantic oracle, then reports
   section/paragraph/run/table/image/control/equation/chart counts and their deltas.
+- `hwp5_own_parser_eligibility`: runs the first-party parser and rhwp into the same typed semantic
+  projection. Paragraphs and runs are split into body/decoration/table-cell/table-caption/note scopes;
+  controls are split by semantic kind. Exact text is compared only in memory and leaves the report as
+  one boolean. Unsupported input returns a static rejection code without invoking rhwp. Even an exact
+  v2 semantic match remains `render-parity-unproven` until a per-document layout/PDF evidence channel
+  is attached; v2 cannot produce a false-positive eligible result from counts and text alone.
 
 The report's `topo-fnv1a64:*` value hashes only typed `SemanticDoc` topology markers and collection
 cardinalities. It deliberately ignores text, URLs, image bytes, source paths, provenance bytes, and
@@ -90,14 +96,34 @@ Raw-record counts and semantic counts are not treated as equivalent truth. In pa
 `CTRL_HEADER` records. Semantic `controls` counts typed table/image/equation/chart and remaining
 field/note/raw control nodes. The differential makes these gaps measurable; it does not relax a gate
 or claim semantic parity. On the completed bounded benchmark, sections/tables/images/equations/charts
-currently agree while native-minus-oracle is paragraphs `+1`, runs `+7`, and controls `+6`. Those
-content-free deltas must be classified before any production cutover claim.
+currently agree while native-minus-oracle is paragraphs `+1`, runs `+7`, and controls `+6`.
+
+The additive v2 semantic comparison classifies those numbers without changing v1:
+
+- paragraph `+1` is the v1 semantic counter omitting one table-caption paragraph. Both semantic
+  projections contain the same 91 body, 261 table-cell, and 1 table-caption paragraphs;
+- control `+6` is six source metadata headers: one section definition, one column definition, two
+  page-number-position controls, and two new-number controls. Both semantic projections contain the
+  same 32 tables and no other active semantic control;
+- run `+7` contains the same omitted caption run plus six empty text runs retained by the first-party
+  parser and elided by rhwp: two in body paragraphs and four in table cells. Exact text comparison is
+  equal, but effective empty-run typography/layout parity is not yet proven.
+
+The completed benchmark therefore remains `semantic-mismatch` and ineligible. The checker does not
+allow-list the six empty runs: an empty run can still carry a character shape that affects blank-line
+height. That difference must clear layout/PDF evidence before eligibility can change.
 
 ## Cutover rule
 
-Completing one bounded benchmark is only the first eligibility milestone. The next #94 slices must
-classify the remaining semantic-count deltas, run fail-closed own-parser eligibility across the
-privacy-safe public corpus, and promote BinData/images, decorations, and other controls only when
+Completing one bounded benchmark is only the first eligibility milestone. The content-free committed
+HWP5 matrix currently covers 13 public cases and reports eligible 0, semantic-mismatch 1,
+unsupported-semantic 7, unsupported-section-control 4, and invalid-container 1. The optional
+rights-reviewed private intake expands this to 33 cases: the additional 20 classify as
+unsupported-style-semantics 15, unsupported-border-fill 3, and unsupported-table-topology 2. This is a truthful starting
+matrix rather than a coverage score: every unknown, unsupported, malformed, ambiguous, or
+unexplained semantic difference is ineligible. The next #94 slices must classify each rejection,
+keep the private 20-file rights-reviewed intake in the same local gate when present, and promote
+BinData/images, decorations, and other controls only when
 encountered semantics have faithful shared-IR representations. The production route may change only
 when corpus differential gates, native/wasm parity, hostile input tests, and the canonical
 8/18/24-page + 98.9% line gate remain green. Explicit own-parser mode must continue to fail closed for

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,11 @@
 
 ---
 
+## 2026-08-24 (Codex sol) · PR #197 merged · #198 started
+- #197 merged as `6f1f3687`; #196 closed and parent #94 received content-free evidence.
+- #198 opened for typed semantic-delta classification and fail-closed own-parser eligibility.
+- next inspect projection/count semantics, then implement without changing production rhwp route.
+
 ## 2026-08-24 (Codex sol) · #196 stale boundary docs fixed
 - HWP5 native-parser doc no longer claims offset 936 stop; records benchmark-end exact-subset truth.
 - semantic delta and corpus/wasm/hostile/layout cutover gates stay explicit; next push/restarted CI.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,17 @@
 
 ---
 
+## 2026-08-24 (Codex sol) · #198 full/audit green
+- quick and full green: PDF51, canonical 8/18/24+98.9%, corpus84/oracle82, wasm 7,818,243B.
+- JS/Vitest 1,007 and Chromium 85 pass/3 intentional skip/0 fail; temporary links removed.
+- final boundary/privacy audit clean; next commit/push and `Closes #198` PR.
+
+## 2026-08-24 (Codex sol) · #198 typed eligibility implemented
+- v1 +1/+7/+6 classified as caption-counter, six metadata headers, and six empty semantic runs.
+- additive v2 compares same-coordinate semantics/text privately and rejects every unexplained delta.
+- public intake fetched 50/50; HWP5 matrix is 13 committed / 33 with private intake, 0 eligible.
+- next focused hostile/privacy tests, clippy/wasm, quick/full gates, then PR.
+
 ## 2026-08-24 (Codex sol) · PR #197 merged · #198 started
 - #197 merged as `6f1f3687`; #196 closed and parent #94 received content-free evidence.
 - #198 opened for typed semantic-delta classification and fail-closed own-parser eligibility.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,10 @@
 
 ---
 
+## 2026-08-24 (Codex sol) · #198 pushed
+- typed eligibility/matrix/docs committed through `f8b43e8` and pushed.
+- next publish `Closes #198` PR, then exact-head required CI/comments/mergeability audit.
+
 ## 2026-08-24 (Codex sol) · #198 full/audit green
 - quick and full green: PDF51, canonical 8/18/24+98.9%, corpus84/oracle82, wasm 7,818,243B.
 - JS/Vitest 1,007 and Chromium 85 pass/3 intentional skip/0 fail; temporary links removed.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,10 @@
 
 ---
 
+## 2026-08-24 (Codex sol) · PR #199 posted
+- `Closes #198` PR #199 published with no-cutover, zero-eligible, and privacy boundaries explicit.
+- next final-head required CI + reviews/comments/mergeability → autonomous merge.
+
 ## 2026-08-24 (Codex sol) · #198 pushed
 - typed eligibility/matrix/docs committed through `f8b43e8` and pushed.
 - next publish `Closes #198` PR, then exact-head required CI/comments/mergeability audit.


### PR DESCRIPTION
## Summary

- preserve the v1 raw-record differential and add a typed v2 candidate-vs-rhwp semantic projection
- classify the bounded benchmark deltas into caption accounting, six metadata control headers, and six retained empty text runs
- compare exact text only in memory and expose only a boolean; never serialize source text or a content hash
- add static privacy-safe rejection codes and a deterministic fail-closed HWP5 matrix
- keep every case ineligible until per-document layout/PDF parity evidence exists; production parsing remains rhwp

## Evidence

- benchmark semantic locations: paragraphs equal; controls equal; exact text equal
- remaining semantic run difference: body +2 and table-cell +4, all empty text runs
- committed public matrix: 13 cases, eligible 0, all static deterministic rejections
- optional rights-reviewed local intake: 20 additional HWP5 cases, total 33, eligible 0
- public intake collection completed 50/50 into the ignored private lane; no binaries are committed

## Validation

- focused HWP5: 74 tests
- focused hwp-core candidate: 4 tests
- clippy `-D warnings` and wasm32: green
- quick/full: workspace, PDF visual 51, canonical 8/18/24 + 98.9%+, public corpus 84, oracle 82, HWPX, wasm/licenses
- rebuilt wasm: 7,818,243 bytes
- Vitest: 1,007 passed
- Chromium: 85 passed, 3 intentional skips, 0 failed

## Boundaries

- no production parser route change
- no changes to `external/rhwp`, HWPX, shared typesetter, generated wasm/assets, or oracle scoring
- no source text, filenames, local paths, original hashes, raw payloads, or credentials in reports

Closes #198