### PR TITLE
test(hwp5): prove empty-run layout equivalence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2200,6 +2200,7 @@ name = "hwp-render"
 version = "0.0.1"
 dependencies = [
  "base64 0.21.7",
+ "hwp-core",
  "hwp-hwpx",
  "hwp-model",
  "hwp-typeset",

--- a/corpus/PUBLIC-CORPUS.md
+++ b/corpus/PUBLIC-CORPUS.md
@@ -11,12 +11,14 @@
 
 first-party HWP5 전환 적격성은 별도 fail-closed 계약이다. 저장소에 직접 커밋된 공개 HWP5 12건과
 bounded benchmark 1건은 `hwp5_eligibility_matrix`가 파일명·경로·본문·원본 hash 없이 반복 실행한다.
-현재 13건 모두 ineligible이며 사유 집계는 semantic-mismatch 1, unsupported-semantic 7,
-unsupported-section-control 4, invalid-container 1이다. private intake 20건이 로컬에 있으면 매트릭스는
+현재 13건 모두 ineligible이며 실행 계측 사유 집계는 render-parity-unproven 1,
+unsupported-semantic 7, unsupported-border-fill 3, unsupported-style-semantics 1,
+invalid-container 1이다. private intake 20건이 로컬에 있으면 매트릭스는
 자동으로 33건으로 확장되며, 현재 추가 거부 사유는 unsupported-style-semantics 15,
 unsupported-border-fill 3, unsupported-table-topology 2다. production parser 40/40 통과와 자체 파서
-eligible은 서로 다른 지표다. 또한 typed semantic 비교가 같더라도 문서별 layout/PDF 근거가 없는
-v2는 `render-parity-unproven`으로 거부한다.
+eligible은 서로 다른 지표다. #200은 benchmark의 빈 run 6개만 증거용 clone에서
+정규화했을 때 shared geometry·SVG·PDF가 exact임을 잠그었지만, 전체 candidate/rhwp
+geometry는 아직 다르므로 `render-parity-unproven`·eligible=false를 유지한다.
 
 | 형식 | 승격 | 역할 |
 |---|---:|---|

--- a/crates/hwp-core/src/lib.rs
+++ b/crates/hwp-core/src/lib.rs
@@ -59,6 +59,13 @@ pub fn open_hwp5_own(bytes: &[u8]) -> Result<SemanticDoc> {
         .map_err(|error| Error::Parse(error.to_string()))
 }
 
+/// Produce a diagnostic clone-equivalent model for proving whether HWP5 empty-run representation
+/// differences affect our shared layout/render/export stack. The first-party parser never calls this
+/// automatically, so source semantics and production routing remain unchanged.
+pub fn normalize_hwp5_empty_runs_for_layout_evidence(doc: &mut SemanticDoc) {
+    hwp_hwp5::normalize_empty_runs_for_layout_evidence(doc);
+}
+
 /// Content-free structural comparison between the first-party HWP5 candidate and the current rhwp
 /// semantic oracle. Production routing is not changed by this diagnostic.
 pub fn hwp5_differential(bytes: &[u8]) -> Result<hwp_hwp5::DifferentialReport> {
@@ -132,7 +139,7 @@ mod hwp5_candidate_tests {
         assert_eq!(first, second);
         assert_eq!(first.schema, "auto-hwp.hwp5-own-parser-eligibility.v2");
         assert!(!first.eligible);
-        assert_eq!(first.rejection_code, Some("semantic-mismatch"));
+        assert_eq!(first.rejection_code, Some("render-parity-unproven"));
         let source = first.source_records.expect("source record classification");
         assert_eq!(source.paragraph_headers, 353);
         assert_eq!(source.run_position_tuples, 389);
@@ -170,6 +177,21 @@ mod hwp5_candidate_tests {
             comparison.candidate.empty_text_runs.table_cells,
             comparison.oracle.empty_text_runs.table_cells + 4
         );
+        assert!(comparison.empty_run_typography_equivalent);
+        assert_eq!(comparison.empty_run_typography.len(), 6);
+        assert_eq!(
+            comparison
+                .empty_run_typography
+                .iter()
+                .filter(|observation| observation.paragraph_has_visible_content)
+                .count(),
+            5
+        );
+        assert!(comparison
+            .empty_run_typography
+            .iter()
+            .filter(|observation| !observation.paragraph_has_visible_content)
+            .all(|observation| observation.effective_height_matches));
         let json = serde_json::to_string(&first).unwrap();
         assert!(!json.contains("benchmark.hwp"));
         assert!(!json.contains("BodyText"));

--- a/crates/hwp-core/tests/hwp5_empty_run_layout.rs
+++ b/crates/hwp-core/tests/hwp5_empty_run_layout.rs
@@ -1,0 +1,268 @@
+#![cfg(feature = "rhwp")]
+
+use hwp_core::{hwp5_own_parser_eligibility, open_hwp5_own, Engine};
+use hwp_model::document::{Block, Inline, Paragraph, SemanticDoc};
+use hwp_typeset::{place_doc, ApproxFontMetrics, PlacedDoc};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Scope {
+    Body,
+    Decoration,
+    TableCell,
+    TableCaption,
+    Note,
+}
+
+fn paragraphs(doc: &SemanticDoc) -> Vec<(Scope, &Paragraph)> {
+    fn visit<'a>(blocks: &'a [Block], scope: Scope, out: &mut Vec<(Scope, &'a Paragraph)>) {
+        for block in blocks {
+            match block {
+                Block::Paragraph(paragraph) => {
+                    out.push((scope, paragraph));
+                    for run in &paragraph.runs {
+                        for inline in &run.content {
+                            if let Inline::Note(note) = inline {
+                                visit(&note.body, Scope::Note, out);
+                            }
+                        }
+                    }
+                }
+                Block::Table(table) => {
+                    if let Some(caption) = &table.caption {
+                        visit(&caption.blocks, Scope::TableCaption, out);
+                    }
+                    for cell in &table.cells {
+                        visit(&cell.blocks, Scope::TableCell, out);
+                    }
+                }
+            }
+        }
+    }
+
+    let mut out = Vec::new();
+    for section in &doc.sections {
+        visit(&section.blocks, Scope::Body, &mut out);
+        for decoration in &section.decorations {
+            visit(&decoration.blocks, Scope::Decoration, &mut out);
+        }
+    }
+    out
+}
+
+fn is_empty_run(run: &hwp_model::document::Run) -> bool {
+    run.content.iter().all(|inline| match inline {
+        Inline::Text(text) => text.is_empty(),
+        _ => false,
+    })
+}
+
+fn same_number(left: f64, right: f64) -> bool {
+    left.to_bits() == right.to_bits()
+}
+
+fn same_page_and_block_geometry(left: &PlacedDoc, right: &PlacedDoc) -> bool {
+    left.pages.len() == right.pages.len()
+        && left.pages.iter().zip(&right.pages).all(|(left, right)| {
+            same_number(left.width, right.width)
+                && same_number(left.height, right.height)
+                && left.blocks.len() == right.blocks.len()
+                && left.blocks.iter().zip(&right.blocks).all(|(left, right)| {
+                    left.kind == right.kind
+                        && same_number(left.x, right.x)
+                        && same_number(left.y, right.y)
+                        && same_number(left.w, right.w)
+                        && same_number(left.h, right.h)
+                })
+        })
+}
+
+fn same_table_geometry(left: &PlacedDoc, right: &PlacedDoc) -> bool {
+    left.pages.iter().zip(&right.pages).all(|(left, right)| {
+        left.tables.len() == right.tables.len()
+            && left.tables.iter().zip(&right.tables).all(|(left, right)| {
+                same_number(left.x, right.x)
+                    && same_number(left.y, right.y)
+                    && same_number(left.w, right.w)
+                    && same_number(left.h, right.h)
+                    && left.first_row == right.first_row
+                    && left.last_row == right.last_row
+                    && left.cells.len() == right.cells.len()
+                    && left.cells.iter().zip(&right.cells).all(|(left, right)| {
+                        left.row == right.row
+                            && left.col == right.col
+                            && same_number(left.x, right.x)
+                            && same_number(left.y, right.y)
+                            && same_number(left.w, right.w)
+                            && same_number(left.h, right.h)
+                    })
+            })
+    })
+}
+
+fn same_rect_geometry(left: &PlacedDoc, right: &PlacedDoc) -> bool {
+    left.pages.iter().zip(&right.pages).all(|(left, right)| {
+        left.rects.len() == right.rects.len()
+            && left.rects.iter().zip(&right.rects).all(|(left, right)| {
+                same_number(left.x, right.x)
+                    && same_number(left.y, right.y)
+                    && same_number(left.w, right.w)
+                    && same_number(left.h, right.h)
+            })
+    })
+}
+
+fn same_line_geometry(left: &PlacedDoc, right: &PlacedDoc) -> bool {
+    left.pages.iter().zip(&right.pages).all(|(left, right)| {
+        left.lines.len() == right.lines.len()
+            && left.lines.iter().zip(&right.lines).all(|(left, right)| {
+                same_number(left.x1, right.x1)
+                    && same_number(left.y1, right.y1)
+                    && same_number(left.x2, right.x2)
+                    && same_number(left.y2, right.y2)
+                    && same_number(left.width, right.width)
+            })
+    })
+}
+
+fn same_flow_geometry(left: &PlacedDoc, right: &PlacedDoc) -> bool {
+    same_page_and_block_geometry(left, right)
+        && same_table_geometry(left, right)
+        && same_rect_geometry(left, right)
+        && same_line_geometry(left, right)
+}
+
+fn same_glyph_paint(left: &PlacedDoc, right: &PlacedDoc) -> bool {
+    left.pages.iter().zip(&right.pages).all(|(left, right)| {
+        left.glyphs.len() == right.glyphs.len()
+            && left.glyphs.iter().zip(&right.glyphs).all(|(left, right)| {
+                left.ch == right.ch
+                    && same_number(left.x, right.x)
+                    && same_number(left.baseline, right.baseline)
+                    && same_number(left.size, right.size)
+                    && left.color == right.color
+                    && left.underline == right.underline
+                    && left.bold == right.bold
+                    && left.italic == right.italic
+                    && left.font == right.font
+                    && left.cluster == right.cluster
+            })
+    })
+}
+
+#[test]
+fn benchmark_empty_run_deltas_are_content_free_and_layout_classified() {
+    let bytes = std::fs::read(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../benchmarks/benchmark.hwp"
+    ))
+    .unwrap();
+    let candidate = open_hwp5_own(&bytes).unwrap();
+    let oracle = Engine::open(&bytes).unwrap();
+    let candidate_paragraphs = paragraphs(&candidate);
+    let oracle_paragraphs = paragraphs(&oracle);
+    assert_eq!(candidate_paragraphs.len(), oracle_paragraphs.len());
+
+    let mut deltas = Vec::new();
+    for (ordinal, ((candidate_scope, candidate_para), (oracle_scope, oracle_para))) in
+        candidate_paragraphs
+            .iter()
+            .zip(&oracle_paragraphs)
+            .enumerate()
+    {
+        assert_eq!(candidate_scope, oracle_scope);
+        let candidate_empty: Vec<_> = candidate_para
+            .runs
+            .iter()
+            .enumerate()
+            .filter(|(_, run)| is_empty_run(run))
+            .collect();
+        let oracle_empty = oracle_para
+            .runs
+            .iter()
+            .filter(|run| is_empty_run(run))
+            .count();
+        if candidate_empty.len() != oracle_empty {
+            let visible = candidate_para.runs.iter().any(|run| {
+                run.content.iter().any(|inline| match inline {
+                    Inline::Text(text) => !text.is_empty(),
+                    _ => true,
+                })
+            });
+            let shapes: Vec<_> = candidate_empty
+                .iter()
+                .map(|(run_ordinal, run)| {
+                    (
+                        *run_ordinal,
+                        candidate
+                            .char_shapes
+                            .get(run.char_shape)
+                            .map(|shape| shape.height)
+                            .unwrap_or_default(),
+                    )
+                })
+                .collect();
+            deltas.push((ordinal, candidate_scope, visible, shapes, oracle_empty));
+        }
+    }
+
+    assert_eq!(deltas.len(), 6);
+    assert_eq!(
+        deltas
+            .iter()
+            .filter(|(_, _, visible, _, _)| *visible)
+            .count(),
+        5
+    );
+    assert_eq!(
+        deltas
+            .iter()
+            .map(|(_, _, _, shapes, oracle_empty)| shapes.len() - oracle_empty)
+            .sum::<usize>(),
+        6
+    );
+
+    let report = hwp5_own_parser_eligibility(&bytes).unwrap();
+    let comparison = report.comparison.unwrap();
+    assert!(comparison.empty_run_typography_equivalent);
+    assert_eq!(comparison.empty_run_typography.len(), 6);
+    let public = serde_json::to_string(&comparison).unwrap();
+    assert!(!public.contains("benchmark.hwp"));
+    assert!(!public.contains("BodyText"));
+
+    let candidate_placed = place_doc(&candidate, &ApproxFontMetrics);
+    let oracle_placed = place_doc(&oracle, &ApproxFontMetrics);
+    assert_eq!(candidate_placed.pages.len(), 8);
+    assert_eq!(candidate_placed.pages.len(), oracle_placed.pages.len());
+    for (candidate_page, oracle_page) in candidate_placed.pages.iter().zip(&oracle_placed.pages) {
+        assert_eq!(candidate_page.blocks.len(), oracle_page.blocks.len());
+        assert_eq!(candidate_page.tables.len(), oracle_page.tables.len());
+        assert_eq!(candidate_page.rects.len(), oracle_page.rects.len());
+        assert_eq!(candidate_page.lines.len(), oracle_page.lines.len());
+    }
+    assert!(!same_page_and_block_geometry(
+        &candidate_placed,
+        &oracle_placed
+    ));
+    assert!(!same_table_geometry(&candidate_placed, &oracle_placed));
+    assert!(!same_rect_geometry(&candidate_placed, &oracle_placed));
+    assert!(!same_line_geometry(&candidate_placed, &oracle_placed));
+    assert_eq!(
+        candidate_placed
+            .pages
+            .iter()
+            .map(|page| page.glyphs.len())
+            .sum::<usize>(),
+        oracle_placed
+            .pages
+            .iter()
+            .map(|page| page.glyphs.len())
+            .sum::<usize>()
+            + 24
+    );
+
+    let mut normalized = candidate.clone();
+    hwp_hwp5::normalize_empty_runs_for_layout_evidence(&mut normalized);
+    let normalized_placed = place_doc(&normalized, &ApproxFontMetrics);
+    assert!(same_flow_geometry(&candidate_placed, &normalized_placed));
+    assert!(same_glyph_paint(&candidate_placed, &normalized_placed));
+}

--- a/crates/hwp-export/tests/hwp5_empty_run_pdf_parity.rs
+++ b/crates/hwp-export/tests/hwp5_empty_run_pdf_parity.rs
@@ -1,0 +1,28 @@
+#![cfg(feature = "pdf")]
+
+use hwp_core::{normalize_hwp5_empty_runs_for_layout_evidence, open_hwp5_own};
+use hwp_export::pdf::{export_pdf, PdfOptions};
+use hwp_typeset::ApproxFontMetrics;
+
+#[test]
+fn empty_run_evidence_normalization_is_pdf_exact() {
+    let bytes = std::fs::read(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../benchmarks/benchmark.hwp"
+    ))
+    .unwrap();
+    let candidate = open_hwp5_own(&bytes).unwrap();
+    let mut normalized = candidate.clone();
+    normalize_hwp5_empty_runs_for_layout_evidence(&mut normalized);
+
+    let candidate_pdf = export_pdf(&candidate, &ApproxFontMetrics, &PdfOptions::default()).unwrap();
+    let normalized_pdf =
+        export_pdf(&normalized, &ApproxFontMetrics, &PdfOptions::default()).unwrap();
+    assert!(
+        candidate_pdf.bytes == normalized_pdf.bytes
+            && candidate_pdf.pages == normalized_pdf.pages
+            && candidate_pdf.replay == normalized_pdf.replay
+            && candidate_pdf.diagnostics == normalized_pdf.diagnostics,
+        "empty-run normalization must be PDF-byte-exact without printing source content"
+    );
+}

--- a/crates/hwp-hwp5/src/lib.rs
+++ b/crates/hwp-hwp5/src/lib.rs
@@ -13,11 +13,12 @@ pub use header::{
 };
 pub use probe::{
     compare_semantic_candidates, compare_semantic_candidates_with_source, compare_with_semantic,
-    probe, rejected_eligibility, rejected_eligibility_with_source, source_record_projection,
-    DifferentialReport, Hwp5Probe, OwnParserEligibilityReport, SemanticControlCounts,
-    SemanticDifferentialReport, SemanticMismatch, SemanticProjection, SemanticScopeCounts,
-    SourceControlHeaderCounts, SourceRecordProjection, StreamProbe, StructuralDelta,
-    StructuralInventory,
+    normalize_empty_runs_for_layout_evidence, probe, rejected_eligibility,
+    rejected_eligibility_with_source, source_record_projection, DifferentialReport,
+    EmptyRunShapeObservation, EmptyRunTypographyObservation, Hwp5Probe, OwnParserEligibilityReport,
+    SemanticControlCounts, SemanticDifferentialReport, SemanticMismatch, SemanticProjection,
+    SemanticScopeCounts, SourceControlHeaderCounts, SourceRecordProjection, StreamProbe,
+    StructuralDelta, StructuralInventory,
 };
 pub use record::{walk_records, Record, RecordError, RecordLimits};
 

--- a/crates/hwp-hwp5/src/probe.rs
+++ b/crates/hwp-hwp5/src/probe.rs
@@ -2,7 +2,7 @@ use crate::{parse_file_header, walk_records, Error, FileHeader, Record, RecordLi
 use cfb::CompoundFile;
 use flate2::read::DeflateDecoder;
 use hwp_ingest::limits::{self, MAX_DECOMPRESSED_TOTAL, MAX_ENTRY_COUNT};
-use hwp_model::document::{Block, Inline, SemanticDoc};
+use hwp_model::document::{Block, Inline, Paragraph, Run, SemanticDoc};
 use serde::Serialize;
 use std::io::{Cursor, Read, Seek};
 
@@ -143,6 +143,34 @@ pub struct SemanticDifferentialReport {
     /// Exact text equality is checked in memory and exposed only as a boolean. Source text and a
     /// content-derived hash never enter the report.
     pub text_matches: bool,
+    /// Content-free, opaque observations for paragraphs whose empty-run counts differ. Empty runs
+    /// have no glyphs; the shared typesetter reads only the resolved height when the whole paragraph
+    /// is empty. This evidence therefore records no text, source path, file name, or source hash.
+    pub empty_run_typography: Vec<EmptyRunTypographyObservation>,
+    /// True only when removing the count-only empty-run difference preserves typed topology and every
+    /// empty paragraph resolves to the same effective height. This is semantic equivalence evidence,
+    /// not production-cutover permission; layout/PDF parity remains a separate gate.
+    pub empty_run_typography_equivalent: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct EmptyRunShapeObservation {
+    pub run_ordinal: usize,
+    pub height_hwpunit: i32,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct EmptyRunTypographyObservation {
+    pub scope: &'static str,
+    /// Global traversal ordinal only. It is deliberately not a section/block/cell source address.
+    pub paragraph_ordinal: usize,
+    pub paragraph_has_visible_content: bool,
+    pub candidate: Vec<EmptyRunShapeObservation>,
+    pub oracle: Vec<EmptyRunShapeObservation>,
+    pub candidate_effective_empty_height_hwpunit: i32,
+    pub oracle_effective_empty_height_hwpunit: i32,
+    pub layout_role: &'static str,
+    pub effective_height_matches: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
@@ -339,12 +367,26 @@ pub fn compare_semantic_candidates(
     oracle: &SemanticDoc,
 ) -> OwnParserEligibilityReport {
     let text_matches = semantic_text_projection(candidate) == semantic_text_projection(oracle);
+    let empty_run_typography = empty_run_typography(candidate, oracle);
+    let normalized_topology_matches = semantic_v2_topology_without_empty_runs(candidate)
+        == semantic_v2_topology_without_empty_runs(oracle);
+    let empty_run_typography_equivalent = !empty_run_typography.is_empty()
+        && normalized_topology_matches
+        && empty_run_typography.iter().all(|observation| {
+            observation.paragraph_has_visible_content || observation.effective_height_matches
+        });
     let candidate = semantic_projection(candidate);
     let oracle = semantic_projection(oracle);
     let topology_matches =
         candidate.semantic_topology_fingerprint == oracle.semantic_topology_fingerprint;
     let mismatches = semantic_mismatches(&candidate, &oracle);
-    let semantic_matches = topology_matches && text_matches && mismatches.is_empty();
+    let only_empty_run_counts_differ = mismatches.iter().all(|mismatch| {
+        mismatch.category.starts_with("runs.")
+            || mismatch.category.starts_with("coalesced-text-runs.")
+            || mismatch.category.starts_with("empty-text-runs.")
+    });
+    let semantic_matches = (topology_matches && text_matches && mismatches.is_empty())
+        || (text_matches && empty_run_typography_equivalent && only_empty_run_counts_differ);
     OwnParserEligibilityReport {
         schema: "auto-hwp.hwp5-own-parser-eligibility.v2",
         // v2 classifies semantic equality but has no per-document layout/PDF evidence channel yet.
@@ -363,6 +405,8 @@ pub fn compare_semantic_candidates(
             mismatches,
             topology_matches,
             text_matches,
+            empty_run_typography,
+            empty_run_typography_equivalent,
         }),
     }
 }
@@ -433,6 +477,65 @@ pub fn rejected_eligibility_with_source(
     let mut report = rejected_eligibility(rejection_code);
     report.source_records = Some(source_record_projection(source));
     report
+}
+
+/// Normalize only empty runs that the current shared typesetter cannot observe, for differential
+/// layout evidence. This is deliberately **not** called by [`OwnHwp5Parser`](crate::OwnHwp5Parser):
+/// the parsed source semantics remain intact. A paragraph with visible content drops glyphless empty
+/// runs; a wholly empty paragraph retains exactly the run that supplies its effective positive
+/// height (or the first run when every height is zero). Controls and other non-text content are never
+/// classified as empty. Hostile tests lock these boundaries.
+pub fn normalize_empty_runs_for_layout_evidence(doc: &mut SemanticDoc) {
+    fn visit(blocks: &mut [Block], doc_shapes: &[hwp_model::style::CharShape]) {
+        for block in blocks {
+            match block {
+                Block::Paragraph(paragraph) => {
+                    for run in &mut paragraph.runs {
+                        for inline in &mut run.content {
+                            if let Inline::Note(note) = inline {
+                                visit(&mut note.body, doc_shapes);
+                            }
+                        }
+                    }
+                    let visible = paragraph_has_visible_content(paragraph);
+                    if visible {
+                        paragraph.runs.retain(|run| !is_empty_text_run(run));
+                    } else if paragraph.runs.len() > 1
+                        && paragraph.runs.iter().all(is_empty_text_run)
+                    {
+                        let retained = paragraph
+                            .runs
+                            .iter()
+                            .find(|run| {
+                                doc_shapes
+                                    .get(run.char_shape)
+                                    .is_some_and(|shape| shape.height > 0)
+                            })
+                            .or_else(|| paragraph.runs.first())
+                            .cloned();
+                        paragraph.runs.clear();
+                        paragraph.runs.extend(retained);
+                    }
+                }
+                Block::Table(table) => {
+                    if let Some(caption) = &mut table.caption {
+                        visit(&mut caption.blocks, doc_shapes);
+                    }
+                    for cell in &mut table.cells {
+                        visit(&mut cell.blocks, doc_shapes);
+                    }
+                }
+            }
+        }
+    }
+
+    let shapes = doc.char_shapes.clone();
+    for section in &mut doc.sections {
+        visit(&mut section.blocks, &shapes);
+        for decoration in &mut section.decorations {
+            visit(&mut decoration.blocks, &shapes);
+        }
+    }
 }
 
 pub fn source_record_projection(source: &Hwp5Probe) -> SourceRecordProjection {
@@ -515,6 +618,73 @@ fn semantic_v2_topology(doc: &SemanticDoc) -> u64 {
     hash.0
 }
 
+fn semantic_v2_topology_without_empty_runs(doc: &SemanticDoc) -> u64 {
+    let mut hash = Fnv1a::new();
+    hash.marker(20, doc.sections.len());
+    for section in &doc.sections {
+        hash.marker(21, section.blocks.len());
+        hash_v2_blocks_without_empty_runs(&section.blocks, &mut hash);
+        hash.marker(22, section.decorations.len());
+        for decoration in &section.decorations {
+            hash.marker(23, decoration.blocks.len());
+            hash_v2_blocks_without_empty_runs(&decoration.blocks, &mut hash);
+        }
+    }
+    hash.0
+}
+
+fn hash_v2_blocks_without_empty_runs(blocks: &[Block], hash: &mut Fnv1a) {
+    hash.marker(24, blocks.len());
+    for block in blocks {
+        match block {
+            Block::Paragraph(paragraph) => {
+                let visible_runs: Vec<_> = paragraph
+                    .runs
+                    .iter()
+                    .filter(|run| !is_empty_text_run(run))
+                    .collect();
+                hash.marker(25, visible_runs.len());
+                for run in visible_runs {
+                    hash.marker(26, run.content.len());
+                    for inline in &run.content {
+                        match inline {
+                            Inline::Text(_) => hash.marker(27, 0),
+                            Inline::Image(_) => hash.marker(28, 0),
+                            Inline::Equation(_) => hash.marker(29, 0),
+                            Inline::Chart(_) => hash.marker(30, 0),
+                            Inline::Note(note) => {
+                                hash.marker(31, note.body.len());
+                                hash_v2_blocks_without_empty_runs(&note.body, hash);
+                            }
+                            Inline::FieldBegin(_) => hash.marker(32, 0),
+                            Inline::FieldEnd(_) => hash.marker(33, 0),
+                            Inline::Bookmark(_) => hash.marker(34, 0),
+                            Inline::Raw(_) => hash.marker(35, 0),
+                        }
+                    }
+                }
+            }
+            Block::Table(table) => {
+                hash.marker(36, table.rows);
+                hash.marker(37, table.cols);
+                hash.marker(38, table.cells.len());
+                hash.marker(39, usize::from(table.caption.is_some()));
+                if let Some(caption) = &table.caption {
+                    hash_v2_blocks_without_empty_runs(&caption.blocks, hash);
+                }
+                for cell in &table.cells {
+                    hash.marker(40, cell.row);
+                    hash.marker(41, cell.col);
+                    hash.marker(42, cell.row_span);
+                    hash.marker(43, cell.col_span);
+                    hash.marker(44, usize::from(cell.active));
+                    hash_v2_blocks_without_empty_runs(&cell.blocks, hash);
+                }
+            }
+        }
+    }
+}
+
 fn hash_v2_blocks(blocks: &[Block], hash: &mut Fnv1a) {
     hash.marker(24, blocks.len());
     for block in blocks {
@@ -562,13 +732,159 @@ fn hash_v2_blocks(blocks: &[Block], hash: &mut Fnv1a) {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 enum SemanticScope {
     Body,
     Decoration,
     TableCell,
     TableCaption,
     Note,
+}
+
+impl SemanticScope {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Body => "body",
+            Self::Decoration => "decoration",
+            Self::TableCell => "table-cell",
+            Self::TableCaption => "table-caption",
+            Self::Note => "note",
+        }
+    }
+}
+
+fn is_empty_text_run(run: &Run) -> bool {
+    run.content.iter().all(|inline| match inline {
+        Inline::Text(text) => text.is_empty(),
+        _ => false,
+    })
+}
+
+fn semantic_paragraphs(doc: &SemanticDoc) -> Vec<(SemanticScope, &Paragraph)> {
+    fn visit<'a>(
+        blocks: &'a [Block],
+        scope: SemanticScope,
+        out: &mut Vec<(SemanticScope, &'a Paragraph)>,
+    ) {
+        for block in blocks {
+            match block {
+                Block::Paragraph(paragraph) => {
+                    out.push((scope, paragraph));
+                    for run in &paragraph.runs {
+                        for inline in &run.content {
+                            if let Inline::Note(note) = inline {
+                                visit(&note.body, SemanticScope::Note, out);
+                            }
+                        }
+                    }
+                }
+                Block::Table(table) => {
+                    if let Some(caption) = &table.caption {
+                        visit(&caption.blocks, SemanticScope::TableCaption, out);
+                    }
+                    for cell in &table.cells {
+                        visit(&cell.blocks, SemanticScope::TableCell, out);
+                    }
+                }
+            }
+        }
+    }
+
+    let mut out = Vec::new();
+    for section in &doc.sections {
+        visit(&section.blocks, SemanticScope::Body, &mut out);
+        for decoration in &section.decorations {
+            visit(&decoration.blocks, SemanticScope::Decoration, &mut out);
+        }
+    }
+    out
+}
+
+fn effective_empty_height(paragraph: &Paragraph, doc: &SemanticDoc) -> i32 {
+    paragraph
+        .runs
+        .iter()
+        .filter_map(|run| doc.char_shapes.get(run.char_shape))
+        .map(|shape| shape.height)
+        .find(|height| *height > 0)
+        .unwrap_or(1000)
+}
+
+fn empty_shapes(paragraph: &Paragraph, doc: &SemanticDoc) -> Vec<EmptyRunShapeObservation> {
+    paragraph
+        .runs
+        .iter()
+        .enumerate()
+        .filter(|(_, run)| is_empty_text_run(run))
+        .map(|(run_ordinal, run)| EmptyRunShapeObservation {
+            run_ordinal,
+            height_hwpunit: doc
+                .char_shapes
+                .get(run.char_shape)
+                .map(|shape| shape.height)
+                .unwrap_or_default(),
+        })
+        .collect()
+}
+
+fn paragraph_has_visible_content(paragraph: &Paragraph) -> bool {
+    paragraph.runs.iter().any(|run| {
+        run.content.iter().any(|inline| match inline {
+            Inline::Text(text) => !text.is_empty(),
+            _ => true,
+        })
+    })
+}
+
+fn empty_run_typography(
+    candidate: &SemanticDoc,
+    oracle: &SemanticDoc,
+) -> Vec<EmptyRunTypographyObservation> {
+    let candidate_paragraphs = semantic_paragraphs(candidate);
+    let oracle_paragraphs = semantic_paragraphs(oracle);
+    if candidate_paragraphs.len() != oracle_paragraphs.len() {
+        return Vec::new();
+    }
+
+    candidate_paragraphs
+        .into_iter()
+        .zip(oracle_paragraphs)
+        .enumerate()
+        .filter_map(
+            |(
+                paragraph_ordinal,
+                ((candidate_scope, candidate_para), (oracle_scope, oracle_para)),
+            )| {
+                if candidate_scope != oracle_scope {
+                    return None;
+                }
+                let candidate_shapes = empty_shapes(candidate_para, candidate);
+                let oracle_shapes = empty_shapes(oracle_para, oracle);
+                if candidate_shapes.len() == oracle_shapes.len() {
+                    return None;
+                }
+                let visible = paragraph_has_visible_content(candidate_para)
+                    || paragraph_has_visible_content(oracle_para);
+                let candidate_height = effective_empty_height(candidate_para, candidate);
+                let oracle_height = effective_empty_height(oracle_para, oracle);
+                Some(EmptyRunTypographyObservation {
+                    scope: candidate_scope.label(),
+                    paragraph_ordinal,
+                    paragraph_has_visible_content: visible,
+                    candidate: candidate_shapes,
+                    oracle: oracle_shapes,
+                    candidate_effective_empty_height_hwpunit: candidate_height,
+                    oracle_effective_empty_height_hwpunit: oracle_height,
+                    layout_role: if visible {
+                        "no-glyph-layout-neutral"
+                    } else {
+                        "empty-paragraph-height-source"
+                    },
+                    effective_height_matches: candidate_height == oracle_height,
+                })
+            },
+        )
+        .collect()
 }
 
 fn increment_scope(counts: &mut SemanticScopeCounts, scope: SemanticScope, amount: usize) {
@@ -928,5 +1244,131 @@ mod tests {
         let identical = compare_semantic_candidates(&left, &left);
         assert!(!identical.eligible);
         assert_eq!(identical.rejection_code, Some("render-parity-unproven"));
+    }
+
+    fn doc_with_runs(runs: Vec<hwp_model::document::Run>, heights: &[i32]) -> SemanticDoc {
+        let mut doc = SemanticDoc {
+            char_shapes: heights
+                .iter()
+                .map(|height| hwp_model::style::CharShape {
+                    height: *height,
+                    ..Default::default()
+                })
+                .collect(),
+            ..Default::default()
+        };
+        doc.sections.push(Default::default());
+        doc.sections[0]
+            .blocks
+            .push(Block::Paragraph(hwp_model::document::Paragraph {
+                runs,
+                ..Default::default()
+            }));
+        doc
+    }
+
+    fn run(shape: usize, text: &str) -> hwp_model::document::Run {
+        hwp_model::document::Run {
+            char_shape: shape,
+            content: if text.is_empty() {
+                Vec::new()
+            } else {
+                vec![Inline::Text(text.into())]
+            },
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn trailing_empty_run_is_explicitly_layout_neutral() {
+        let candidate = doc_with_runs(vec![run(0, "visible"), run(1, "")], &[1200, 2400]);
+        let oracle = doc_with_runs(vec![run(0, "visible")], &[1200]);
+        let report = compare_semantic_candidates(&candidate, &oracle);
+        let comparison = report.comparison.unwrap();
+        assert!(comparison.empty_run_typography_equivalent);
+        assert_eq!(comparison.empty_run_typography.len(), 1);
+        let observation = &comparison.empty_run_typography[0];
+        assert!(observation.paragraph_has_visible_content);
+        assert_eq!(observation.layout_role, "no-glyph-layout-neutral");
+        assert_eq!(observation.candidate[0].height_hwpunit, 2400);
+        assert!(observation.effective_height_matches);
+    }
+
+    #[test]
+    fn empty_paragraph_requires_equal_effective_height() {
+        let same_candidate = doc_with_runs(vec![run(0, ""), run(0, "")], &[1600]);
+        let same_oracle = doc_with_runs(vec![run(0, "")], &[1600]);
+        let same = compare_semantic_candidates(&same_candidate, &same_oracle)
+            .comparison
+            .unwrap();
+        assert!(same.empty_run_typography_equivalent);
+        assert!(same.empty_run_typography[0].effective_height_matches);
+        assert_eq!(
+            same.empty_run_typography[0].layout_role,
+            "empty-paragraph-height-source"
+        );
+
+        let different_oracle = doc_with_runs(vec![run(0, "")], &[1000]);
+        let different = compare_semantic_candidates(&same_candidate, &different_oracle)
+            .comparison
+            .unwrap();
+        assert!(!different.empty_run_typography_equivalent);
+        assert!(!different.empty_run_typography[0].effective_height_matches);
+    }
+
+    #[test]
+    fn non_text_content_is_never_normalized_as_an_empty_run() {
+        let mut candidate_run = run(0, "");
+        candidate_run
+            .content
+            .push(Inline::Raw(hwp_model::types::RawPart {
+                tag: "fixture-control".into(),
+                bytes: vec![1],
+            }));
+        let candidate = doc_with_runs(vec![candidate_run], &[1000]);
+        let oracle = doc_with_runs(Vec::new(), &[1000]);
+        let comparison = compare_semantic_candidates(&candidate, &oracle)
+            .comparison
+            .unwrap();
+        assert!(comparison.empty_run_typography.is_empty());
+        assert!(!comparison.empty_run_typography_equivalent);
+    }
+
+    #[test]
+    fn evidence_normalization_preserves_empty_height_and_controls() {
+        let mut visible = doc_with_runs(
+            vec![run(0, ""), run(1, "visible"), run(2, "")],
+            &[900, 1200, 2400],
+        );
+        normalize_empty_runs_for_layout_evidence(&mut visible);
+        let Block::Paragraph(visible_para) = &visible.sections[0].blocks[0] else {
+            unreachable!()
+        };
+        assert_eq!(visible_para.runs.len(), 1);
+        assert_eq!(visible_para.runs[0].char_shape, 1);
+
+        let mut empty = doc_with_runs(vec![run(0, ""), run(1, ""), run(2, "")], &[0, 1600, 2400]);
+        normalize_empty_runs_for_layout_evidence(&mut empty);
+        let Block::Paragraph(empty_para) = &empty.sections[0].blocks[0] else {
+            unreachable!()
+        };
+        assert_eq!(empty_para.runs.len(), 1);
+        assert_eq!(empty_para.runs[0].char_shape, 1);
+        assert_eq!(effective_empty_height(empty_para, &empty), 1600);
+
+        let mut control_run = run(0, "");
+        control_run
+            .content
+            .push(Inline::Raw(hwp_model::types::RawPart {
+                tag: "fixture-control".into(),
+                bytes: vec![1],
+            }));
+        let mut control = doc_with_runs(vec![control_run, run(0, "")], &[1000]);
+        normalize_empty_runs_for_layout_evidence(&mut control);
+        let Block::Paragraph(control_para) = &control.sections[0].blocks[0] else {
+            unreachable!()
+        };
+        assert_eq!(control_para.runs.len(), 1);
+        assert!(matches!(control_para.runs[0].content[0], Inline::Raw(_)));
     }
 }

--- a/crates/hwp-render/Cargo.toml
+++ b/crates/hwp-render/Cargo.toml
@@ -21,3 +21,4 @@ shaper = ["hwp-typeset/shaper"]
 [dev-dependencies]
 # Parse a corpus HWPX into a SemanticDoc for the end-to-end SVG render test (this path, NOT rhwp).
 hwp-hwpx = { workspace = true }
+hwp-core = { workspace = true, features = ["rhwp"] }

--- a/crates/hwp-render/tests/hwp5_empty_run_svg_parity.rs
+++ b/crates/hwp-render/tests/hwp5_empty_run_svg_parity.rs
@@ -1,0 +1,28 @@
+use hwp_core::{normalize_hwp5_empty_runs_for_layout_evidence, open_hwp5_own, Engine};
+use hwp_render::render_doc_svg;
+use hwp_typeset::ApproxFontMetrics;
+
+#[test]
+fn empty_run_evidence_normalization_is_svg_exact() {
+    let bytes = std::fs::read(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../benchmarks/benchmark.hwp"
+    ))
+    .unwrap();
+    let candidate = open_hwp5_own(&bytes).unwrap();
+    let oracle = Engine::open(&bytes).unwrap();
+    let mut normalized = candidate.clone();
+    normalize_hwp5_empty_runs_for_layout_evidence(&mut normalized);
+
+    let candidate_svg = render_doc_svg(&candidate, &ApproxFontMetrics);
+    let normalized_svg = render_doc_svg(&normalized, &ApproxFontMetrics);
+    let oracle_svg = render_doc_svg(&oracle, &ApproxFontMetrics);
+    assert!(
+        candidate_svg == normalized_svg,
+        "empty-run normalization must be SVG-exact without printing source content"
+    );
+    assert!(
+        candidate_svg != oracle_svg,
+        "remaining parser render parity must stay fail-closed"
+    );
+}

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,6 +3,37 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
+- 갱신: 2026-08-24 · Codex(sol) — **PR #199 병합 · #200 착수**.
+  PR #199 exact head `bdecc52`에서 issue-link **4s**·build-test **8m55s**·licenses **2m48s** green,
+  CLEAN/MERGEABLE, review/general/inline 댓글 0을 확인하고 protected main `ffe25edb`로 squash
+  병합했다. #198 close와 #94의 비식별 13/33건 matrix·no-cutover 근거를 동기화했다.
+  고정 benchmark의 빈 text run 6개(본문 2, 표 셀 4)가 char-shape·빈 문단/행 높이에 영향을
+  주는지 증명하기 위해 후속 **#200**을 R18/P1/area:hwp5/status:ready로 열고 exact main의
+  `codex/issue-200-empty-run-layout` worktree를 만들었다. **다음:** 원문·파일명·경로·hash/raw를
+  출력하지 않는 opaque location 기반으로 6개 run의 resolved char-shape를 비교하고, 두
+  파싱 후보를 같은 자체 shared typesetter에 투입해 page/line/cell geometry·SVG/PDF 차이를
+  자동 증거로 고정한다. 무해성 증명 전에는 `semantic-mismatch`/eligible=false를 유지하고,
+  production route·`external/rhwp`·HWPX·oracle scoring은 변경하지 않는다.
+  opaque global paragraph ordinal로 실측한 6개 차이 문단 중 5개는 visible content 뒤의 glyphless
+  terminator run이고, 나머지 빈 body 문단은 candidate 2/oracle 1 run이지만 양쪽 유효 높이가
+  **1600 HWPUNIT**로 같다. 소스 IR은 그대로 두고 증거용 clone에만 명시적 normalization을
+  적용했으며, visible paragraph의 empty run 제거·empty paragraph의 effective-height run 보존·
+  non-text control 제외를 hostile tests로 잠그었다. 원 candidate 대 evidence clone은 shared placed
+  flow/glyph, 페이지별 SVG, PDF bytes가 exact이다. candidate/rhwp는 모두 **8 pages**이고
+  페이지별 block/table/rect/line 개수는 같지만 exact geometry는 다르고 candidate painted glyph가
+  **+24(3/page)**이므로 빈 run을 제외한 남은 렌더 격차가 있다. 따라서 benchmark는
+  `semantic-mismatch`에서 `render-parity-unproven`으로만 전진하고 eligible=false를 유지한다.
+  실행 계측 13건 matrix는 eligible 0, render-parity-unproven 1, unsupported-semantic 7,
+  unsupported-border-fill 3, unsupported-style-semantics 1, invalid-container 1이다. **다음:**
+  focused/full gates→audit→commit/push/PR/CI/merge. 후속은 페이지당 3 glyph decoration과 exact
+  block/table/cell geometry 격차를 content-free category로 분해하는 classification-first slice.
+  quick은 workspace/PDF visual **51**/canonical **8·18·24·98.9%+**/public corpus **84**/oracle
+  **82**/HWPX/wasm/licenses green. full은 wasm **7,818,243B**, JS build/crosscheck/i18n,
+  Vitest **1,018**(269+64+427+247+11) green이고 sandbox port EPERM 후 실제 Chromium
+  **85 pass/3 intentional skip/0 fail**다. 임시 node_modules links는 제거했고 generated wasm/assets는
+  byte-identical로 git diff 0이다. **다음:** final boundary/privacy audit→commit/push→`Closes #200`
+  PR→exact-head CI/comments/mergeability green이면 autonomous merge.
+
 - 갱신: 2026-08-24 · Codex(sol) — **PR #197 병합 · #198 착수**.
   PR #197 exact head `c68b74e`에서 issue-link **5s**·build-test **9m57s**·licenses **2m49s** green,
   CLEAN/MERGEABLE, review/general/inline 댓글 0을 확인하고 protected main `6f1f3687`로 squash 병합했다.

--- a/docs/HWP5-NATIVE-PARSER.md
+++ b/docs/HWP5-NATIVE-PARSER.md
@@ -107,17 +107,30 @@ The additive v2 semantic comparison classifies those numbers without changing v1
   same 32 tables and no other active semantic control;
 - run `+7` contains the same omitted caption run plus six empty text runs retained by the first-party
   parser and elided by rhwp: two in body paragraphs and four in table cells. Exact text comparison is
-  equal, but effective empty-run typography/layout parity is not yet proven.
+  equal. The additive empty-run typography projection records only opaque paragraph ordinals, semantic
+  scope, run ordinal, resolved height, visible-content boolean, and layout role; it never records text,
+  file names, paths, source hashes, or raw records.
 
-The completed benchmark therefore remains `semantic-mismatch` and ineligible. The checker does not
-allow-list the six empty runs: an empty run can still carry a character shape that affects blank-line
-height. That difference must clear layout/PDF evidence before eligibility can change.
+Issue #200 classified the six-run delta without changing the parsed source model. Five differing
+paragraphs contain visible content, so their trailing glyphless runs are invisible to the shared
+typesetter. The remaining wholly empty body paragraph has two candidate empty runs versus one oracle
+run, but both resolve to the same 1600 HWPUNIT effective height. A diagnostic-only normalization clone
+drops only those layout-invisible runs (or retains the effective-height run for an empty paragraph).
+Hostile fixtures keep different empty-paragraph heights and non-text controls non-equivalent.
+
+The candidate and that evidence clone are exact across positioned flow/glyph paint, per-page SVG, and
+PDF bytes. Candidate and rhwp still both produce 8 pages with equal per-page block/table/rect/line
+counts, but exact block/table/cell/rect/line geometry does not yet match and the candidate has 24 more
+painted glyphs (three per page). The empty-run difference is therefore semantically classified, while
+the completed benchmark remains ineligible as `render-parity-unproven`; the remaining parser-wide
+render delta must be isolated before cutover.
 
 ## Cutover rule
 
 Completing one bounded benchmark is only the first eligibility milestone. The content-free committed
-HWP5 matrix currently covers 13 public cases and reports eligible 0, semantic-mismatch 1,
-unsupported-semantic 7, unsupported-section-control 4, and invalid-container 1. The optional
+HWP5 matrix currently covers 13 public cases and reports eligible 0, render-parity-unproven 1,
+unsupported-semantic 7, unsupported-border-fill 3, unsupported-style-semantics 1, and
+invalid-container 1. The optional
 rights-reviewed private intake expands this to 33 cases: the additional 20 classify as
 unsupported-style-semantics 15, unsupported-border-fill 3, and unsupported-table-topology 2. This is a truthful starting
 matrix rather than a coverage score: every unknown, unsupported, malformed, ambiguous, or

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,16 @@
 
 ---
 
+## 2026-08-24 (Codex sol) · #200 full green
+- quick/full green: PDF51, canonical 8/18/24+98.9%, corpus84/oracle82, wasm 7,818,243B.
+- Vitest 1,018 and Chromium 85 pass/3 intentional skip/0 fail; temporary links removed.
+- next final audit, commit/push, `Closes #200` PR, then exact-head CI/merge.
+
+## 2026-08-24 (Codex sol) · #200 empty-run evidence implemented
+- six deltas classified: five glyphless-after-content; one empty paragraph remains 1600 HWPUNIT.
+- evidence-clone placed flow/glyph, SVG, and PDF bytes are exact; hostile height/control cases stay blocked.
+- candidate/rhwp remains 8 pages but exact geometry differs and candidate paints +24 glyphs; next full gates/PR.
+
 ## 2026-08-24 (Codex sol) · PR #199 posted
 - `Closes #198` PR #199 published with no-cutover, zero-eligible, and privacy boundaries explicit.
 - next final-head required CI + reviews/comments/mergeability → autonomous merge.


### PR DESCRIPTION
## Summary
- classify the six native/rhwp empty-run deltas with opaque, content-free typography observations
- add a diagnostic-only normalization clone that preserves source IR and empty-paragraph effective height
- lock positioned flow/glyph, SVG, and PDF-byte exactness for the isolated empty-run difference
- keep the benchmark fail closed as `render-parity-unproven`; production remains on rhwp and `external/rhwp` is untouched

## Evidence
- five differing paragraphs: glyphless empty runs after visible content
- one wholly empty paragraph: candidate 2 runs vs oracle 1, both effective height 1600 HWPUNIT
- candidate/evidence clone: exact placed flow + glyph paint, per-page SVG, and PDF bytes
- candidate/rhwp: both 8 pages and equal per-page block/table/rect/line counts, but exact geometry differs and candidate paints +24 glyphs
- committed 13-case matrix: eligible 0; the benchmark advances only to `render-parity-unproven`

## Validation
- `scripts/verify-local.sh`
- `scripts/verify-local.sh --full` (Rust, PDF visual 51, canonical 8/18/24 + 98.9%+, corpus 84, oracle 82, HWPX, wasm 7,818,243B, JS builds, Vitest 1,018)
- actual Chromium: 85 passed, 3 intentional skips, 0 failed

## Boundaries
- no production parser cutover
- no vendored rhwp, HWPX parser, shared typesetter, oracle scoring, or generated asset change
- no source text, private filename/path/hash, or raw record in public diagnostics

Closes #200