### PR TITLE
test(hwp5): isolate decoration and body deltas

### DIFF
--- a/crates/hwp-core/tests/hwp5_empty_run_layout.rs
+++ b/crates/hwp-core/tests/hwp5_empty_run_layout.rs
@@ -2,7 +2,7 @@
 
 use hwp_core::{hwp5_own_parser_eligibility, open_hwp5_own, Engine};
 use hwp_model::document::{Block, Inline, Paragraph, SemanticDoc};
-use hwp_typeset::{place_doc, ApproxFontMetrics, PlacedDoc};
+use hwp_typeset::{compare_placed_docs, place_doc, ApproxFontMetrics, PlacedDoc};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum Scope {
@@ -231,6 +231,7 @@ fn benchmark_empty_run_deltas_are_content_free_and_layout_classified() {
 
     let candidate_placed = place_doc(&candidate, &ApproxFontMetrics);
     let oracle_placed = place_doc(&oracle, &ApproxFontMetrics);
+    let typed_delta = compare_placed_docs(&candidate_placed, &oracle_placed);
     assert_eq!(candidate_placed.pages.len(), 8);
     assert_eq!(candidate_placed.pages.len(), oracle_placed.pages.len());
     for (candidate_page, oracle_page) in candidate_placed.pages.iter().zip(&oracle_placed.pages) {
@@ -259,6 +260,98 @@ fn benchmark_empty_run_deltas_are_content_free_and_layout_classified() {
             .sum::<usize>()
             + 24
     );
+    assert!(candidate
+        .sections
+        .iter()
+        .any(|section| section.page_number.is_some()));
+    assert!(oracle
+        .sections
+        .iter()
+        .all(|section| section.page_number.is_none()));
+    assert!(typed_delta.pages.iter().all(|page| {
+        page.page_box.is_exact()
+            && page.decoration_glyphs.candidate_count == 3
+            && page.decoration_glyphs.oracle_count == 0
+            && page.decoration_glyphs.candidate_only == 3
+            && page.decoration_glyphs.first_changed_ordinal == Some(0)
+    }));
+    assert_eq!(
+        typed_delta
+            .pages
+            .iter()
+            .filter(|page| !page.body_glyphs.is_exact())
+            .map(|page| page.page_ordinal)
+            .collect::<Vec<_>>(),
+        vec![2, 7]
+    );
+    assert_eq!(
+        typed_delta.pages[2].body_glyphs.max_abs_delta_hwpunit_ceil,
+        148
+    );
+    assert_eq!(
+        typed_delta.pages[7].body_glyphs.max_abs_delta_hwpunit_ceil,
+        72
+    );
+    assert_eq!(
+        typed_delta
+            .pages
+            .iter()
+            .filter(|page| {
+                !page.blocks.is_exact()
+                    || !page.tables.is_exact()
+                    || !page.cells.is_exact()
+                    || !page.rects.is_exact()
+                    || !page.lines.is_exact()
+            })
+            .map(|page| page.page_ordinal)
+            .collect::<Vec<_>>(),
+        vec![2]
+    );
+    assert_eq!(typed_delta.pages[2].cells.max_abs_delta_hwpunit_ceil, 177);
+    assert_eq!(
+        typed_delta.pages[2].body_glyphs.first_changed_ordinal,
+        Some(12)
+    );
+    assert_eq!(
+        typed_delta.pages[2]
+            .body_glyphs
+            .max_delta_coordinate_ordinal,
+        Some(1)
+    );
+    assert_eq!(typed_delta.pages[2].tables.first_changed_ordinal, Some(0));
+    assert_eq!(typed_delta.pages[2].cells.first_changed_ordinal, Some(0));
+    assert_eq!(
+        typed_delta.pages[7].body_glyphs.first_changed_ordinal,
+        Some(324)
+    );
+    assert_eq!(
+        typed_delta.pages[7]
+            .body_glyphs
+            .max_delta_coordinate_ordinal,
+        Some(0)
+    );
+    let typed_public = format!("{typed_delta:?}");
+    assert!(!typed_public.contains("benchmark.hwp"));
+    assert!(!typed_public.contains("BodyText"));
+
+    let mut candidate_without_page_number = candidate.clone();
+    for section in &mut candidate_without_page_number.sections {
+        section.page_number = None;
+    }
+    let candidate_without_page_number_placed =
+        place_doc(&candidate_without_page_number, &ApproxFontMetrics);
+    let page_number_delta =
+        compare_placed_docs(&candidate_placed, &candidate_without_page_number_placed);
+    assert!(page_number_delta.pages.iter().all(|page| {
+        page.decoration_glyphs.candidate_only == 3
+            && page.body_glyphs.is_exact()
+            && page.blocks.is_exact()
+            && page.tables.is_exact()
+            && page.cells.is_exact()
+            && page.rects.is_exact()
+            && page.lines.is_exact()
+            && page.images.is_exact()
+    }));
 
     let mut normalized = candidate.clone();
     hwp_hwp5::normalize_empty_runs_for_layout_evidence(&mut normalized);

--- a/crates/hwp-export/tests/hwp5_empty_run_pdf_parity.rs
+++ b/crates/hwp-export/tests/hwp5_empty_run_pdf_parity.rs
@@ -1,7 +1,8 @@
 #![cfg(feature = "pdf")]
 
-use hwp_core::{normalize_hwp5_empty_runs_for_layout_evidence, open_hwp5_own};
+use hwp_core::{normalize_hwp5_empty_runs_for_layout_evidence, open_hwp5_own, Engine};
 use hwp_export::pdf::{export_pdf, PdfOptions};
+use hwp_render::{render_doc_diagnostic_masks, DiagnosticPaintCategory};
 use hwp_typeset::ApproxFontMetrics;
 
 #[test]
@@ -25,4 +26,48 @@ fn empty_run_evidence_normalization_is_pdf_exact() {
             && candidate_pdf.diagnostics == normalized_pdf.diagnostics,
         "empty-run normalization must be PDF-byte-exact without printing source content"
     );
+}
+
+#[test]
+fn page_decoration_mask_agrees_with_pdf_replay_counts() {
+    let bytes = std::fs::read(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../benchmarks/benchmark.hwp"
+    ))
+    .unwrap();
+    let candidate = open_hwp5_own(&bytes).unwrap();
+    let oracle = Engine::open(&bytes).unwrap();
+    let candidate_masks = render_doc_diagnostic_masks(&candidate, &ApproxFontMetrics);
+    let oracle_masks = render_doc_diagnostic_masks(&oracle, &ApproxFontMetrics);
+    let candidate_pdf = export_pdf(&candidate, &ApproxFontMetrics, &PdfOptions::default()).unwrap();
+    let oracle_pdf = export_pdf(&oracle, &ApproxFontMetrics, &PdfOptions::default()).unwrap();
+
+    assert_eq!(candidate_pdf.pages, 8);
+    assert_eq!(candidate_pdf.pages, oracle_pdf.pages);
+    for (((candidate_page, oracle_page), candidate_mask), oracle_mask) in candidate_pdf
+        .replay
+        .iter()
+        .zip(&oracle_pdf.replay)
+        .zip(&candidate_masks)
+        .zip(&oracle_masks)
+    {
+        let candidate_decoration = candidate_mask
+            .categories
+            .iter()
+            .filter(|category| **category == DiagnosticPaintCategory::PageDecoration)
+            .count();
+        let oracle_decoration = oracle_mask
+            .categories
+            .iter()
+            .filter(|category| **category == DiagnosticPaintCategory::PageDecoration)
+            .count();
+        assert_eq!(candidate_decoration, oracle_decoration + 3);
+        assert_eq!(candidate_page.text.produced, oracle_page.text.produced + 3);
+        assert_eq!(candidate_page.text.replayed, oracle_page.text.replayed + 3);
+        assert_eq!(candidate_page.text.stubbed, oracle_page.text.stubbed);
+        assert_eq!(candidate_page.table_geometry, oracle_page.table_geometry);
+        assert_eq!(candidate_page.image, oracle_page.image);
+        assert_eq!(candidate_page.equation, oracle_page.equation);
+        assert_eq!(candidate_page.chart, oracle_page.chart);
+    }
 }

--- a/crates/hwp-render/src/lib.rs
+++ b/crates/hwp-render/src/lib.rs
@@ -499,6 +499,84 @@ pub fn render_doc_trees(doc: &SemanticDoc, fonts: &dyn FontMetricsProvider) -> V
     place_doc(doc, fonts).pages.iter().map(lower_page).collect()
 }
 
+/// Content-free paint ownership for one operation in the shared page tree. The mask carries no
+/// glyph text, font name, image reference, source provenance, or coordinates.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DiagnosticPaintCategory {
+    Body,
+    PageDecoration,
+    /// An object intersects the body boundary and must not be guessed into either side.
+    BoundaryCrossing,
+}
+
+/// An opaque per-page category mask aligned 1:1 with [`PageLayerTree::ops`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DiagnosticPageMask {
+    pub page_ordinal: usize,
+    pub categories: Vec<DiagnosticPaintCategory>,
+}
+
+fn vertical_category(
+    top: f64,
+    bottom: f64,
+    body_top: f64,
+    body_bottom: f64,
+) -> DiagnosticPaintCategory {
+    if !top.is_finite() || !bottom.is_finite() {
+        return DiagnosticPaintCategory::BoundaryCrossing;
+    }
+    if bottom <= body_top || top >= body_bottom {
+        DiagnosticPaintCategory::PageDecoration
+    } else if top >= body_top && bottom <= body_bottom {
+        DiagnosticPaintCategory::Body
+    } else {
+        DiagnosticPaintCategory::BoundaryCrossing
+    }
+}
+
+fn paint_category(op: &PaintOp, body_top: f64, body_bottom: f64) -> DiagnosticPaintCategory {
+    match op {
+        // Glyph ownership follows its baseline, matching the placed-layout comparator. An ascent may
+        // legitimately cross a margin while the line itself still belongs to the body.
+        PaintOp::Glyph { y, .. } if !y.is_finite() => DiagnosticPaintCategory::BoundaryCrossing,
+        PaintOp::Glyph { y, .. } if *y < body_top || *y > body_bottom => {
+            DiagnosticPaintCategory::PageDecoration
+        }
+        PaintOp::Glyph { .. } => DiagnosticPaintCategory::Body,
+        PaintOp::Rect { y, h, .. } | PaintOp::Image { y, h, .. } => {
+            vertical_category(*y, *y + *h, body_top, body_bottom)
+        }
+        PaintOp::Line { y1, y2, .. } => {
+            vertical_category(y1.min(*y2), y1.max(*y2), body_top, body_bottom)
+        }
+    }
+}
+
+/// Classify the exact paint trees consumed by SVG and PDF into opaque body/decoration masks. This is
+/// diagnostic-only: it neither rewrites the trees nor changes either backend's replay behavior.
+pub fn render_doc_diagnostic_masks(
+    doc: &SemanticDoc,
+    fonts: &dyn FontMetricsProvider,
+) -> Vec<DiagnosticPageMask> {
+    place_doc(doc, fonts)
+        .pages
+        .iter()
+        .enumerate()
+        .map(|(page_ordinal, page)| {
+            let tree = lower_page(page);
+            let body_bottom = page.height - page.margin_bottom;
+            DiagnosticPageMask {
+                page_ordinal,
+                categories: tree
+                    .ops
+                    .iter()
+                    .map(|op| paint_category(op, page.margin_top, body_bottom))
+                    .collect(),
+            }
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -525,6 +603,46 @@ mod tests {
         };
         doc.sections.push(sec);
         doc
+    }
+
+    #[test]
+    fn diagnostic_mask_fails_closed_for_crossing_and_nonfinite_nontext_paint() {
+        let crossing = PaintOp::Line {
+            x1: 0.0,
+            y1: 1_000.0,
+            x2: 1_000.0,
+            y2: 3_000.0,
+            color: Color::default(),
+            style: LineStyle::Solid,
+            width: 1.0,
+        };
+        let non_finite = PaintOp::Image {
+            x: 0.0,
+            y: f64::NAN,
+            w: 10.0,
+            h: 10.0,
+            bin_ref: "not-observed-by-mask".into(),
+            svg: None,
+        };
+        let decoration = PaintOp::Rect {
+            x: 0.0,
+            y: 500.0,
+            w: 10.0,
+            h: 10.0,
+            fill: None,
+        };
+        assert_eq!(
+            paint_category(&crossing, 2_000.0, 18_000.0),
+            DiagnosticPaintCategory::BoundaryCrossing
+        );
+        assert_eq!(
+            paint_category(&non_finite, 2_000.0, 18_000.0),
+            DiagnosticPaintCategory::BoundaryCrossing
+        );
+        assert_eq!(
+            paint_category(&decoration, 2_000.0, 18_000.0),
+            DiagnosticPaintCategory::PageDecoration
+        );
     }
 
     #[test]

--- a/crates/hwp-render/tests/hwp5_geometry_layers.rs
+++ b/crates/hwp-render/tests/hwp5_geometry_layers.rs
@@ -1,0 +1,97 @@
+use hwp_core::{open_hwp5_own, Engine};
+use hwp_model::layout::PageLayerTree;
+use hwp_render::{render_doc_diagnostic_masks, render_doc_trees, DiagnosticPaintCategory, SvgSink};
+use hwp_typeset::ApproxFontMetrics;
+
+fn fixture() -> Vec<u8> {
+    std::fs::read(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../benchmarks/benchmark.hwp"
+    ))
+    .unwrap()
+}
+
+fn masked_svg(tree: &PageLayerTree, categories: &[DiagnosticPaintCategory]) -> String {
+    assert_eq!(tree.ops.len(), categories.len());
+    let body = PageLayerTree {
+        schema_version: tree.schema_version,
+        width: tree.width,
+        height: tree.height,
+        ops: tree
+            .ops
+            .iter()
+            .zip(categories)
+            .filter(|(_, category)| **category == DiagnosticPaintCategory::Body)
+            .map(|(op, _)| op.clone())
+            .collect(),
+    };
+    SvgSink::svg_for(&body)
+}
+
+#[test]
+fn benchmark_masks_prove_page_number_ownership_and_isolate_body_pages() {
+    let bytes = fixture();
+    let candidate = open_hwp5_own(&bytes).unwrap();
+    let oracle = Engine::open(&bytes).unwrap();
+    let candidate_masks = render_doc_diagnostic_masks(&candidate, &ApproxFontMetrics);
+    let oracle_masks = render_doc_diagnostic_masks(&oracle, &ApproxFontMetrics);
+    assert_eq!(candidate_masks.len(), 8);
+    assert_eq!(candidate_masks.len(), oracle_masks.len());
+
+    for (candidate_mask, oracle_mask) in candidate_masks.iter().zip(&oracle_masks) {
+        let candidate_decoration = candidate_mask
+            .categories
+            .iter()
+            .filter(|category| **category == DiagnosticPaintCategory::PageDecoration)
+            .count();
+        let oracle_decoration = oracle_mask
+            .categories
+            .iter()
+            .filter(|category| **category == DiagnosticPaintCategory::PageDecoration)
+            .count();
+        assert_eq!(candidate_decoration, oracle_decoration + 3);
+        assert!(!candidate_mask
+            .categories
+            .contains(&DiagnosticPaintCategory::BoundaryCrossing));
+        assert!(!oracle_mask
+            .categories
+            .contains(&DiagnosticPaintCategory::BoundaryCrossing));
+    }
+
+    let mut without_page_number = candidate.clone();
+    for section in &mut without_page_number.sections {
+        section.page_number = None;
+    }
+    let candidate_trees = render_doc_trees(&candidate, &ApproxFontMetrics);
+    let without_trees = render_doc_trees(&without_page_number, &ApproxFontMetrics);
+    let without_masks = render_doc_diagnostic_masks(&without_page_number, &ApproxFontMetrics);
+    for (((candidate_tree, candidate_mask), without_tree), without_mask) in candidate_trees
+        .iter()
+        .zip(&candidate_masks)
+        .zip(&without_trees)
+        .zip(&without_masks)
+    {
+        assert_eq!(
+            masked_svg(candidate_tree, &candidate_mask.categories),
+            masked_svg(without_tree, &without_mask.categories),
+            "removing page-number decoration must leave the body SVG exact"
+        );
+    }
+
+    let oracle_trees = render_doc_trees(&oracle, &ApproxFontMetrics);
+    let differing_body_pages: Vec<_> = candidate_trees
+        .iter()
+        .zip(&candidate_masks)
+        .zip(&oracle_trees)
+        .zip(&oracle_masks)
+        .enumerate()
+        .filter_map(
+            |(page, (((candidate_tree, candidate_mask), oracle_tree), oracle_mask))| {
+                (masked_svg(candidate_tree, &candidate_mask.categories)
+                    != masked_svg(oracle_tree, &oracle_mask.categories))
+                .then_some(page)
+            },
+        )
+        .collect();
+    assert_eq!(differing_body_pages, vec![2, 7]);
+}

--- a/crates/hwp-typeset/src/diagnostic.rs
+++ b/crates/hwp-typeset/src/diagnostic.rs
@@ -1,0 +1,491 @@
+//! Content-free differential evidence over [`PlacedDoc`](crate::PlacedDoc).
+//!
+//! The comparator deliberately observes only opaque ordinals, counts, payload-equality booleans,
+//! and bounded coordinate buckets. It never records glyph text, font names, image references,
+//! document metadata, or source provenance. Both inputs must already have passed through the same
+//! shared typesetter; this module is diagnostic-only and is not a fallback or an equivalence gate.
+
+use crate::{PlacedDoc, PlacedPage};
+
+/// A bounded summary for one typed placement category on one page.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct GeometryDeltaSummary {
+    pub candidate_count: usize,
+    pub oracle_count: usize,
+    pub paired_count: usize,
+    pub exact_pairs: usize,
+    /// Same coordinates but different non-identifying payload (for example glyph style/content,
+    /// block kind, cell address, or line style). The payload itself is never retained.
+    pub payload_mismatches: usize,
+    pub candidate_only: usize,
+    pub oracle_only: usize,
+    pub non_finite_pairs: usize,
+    pub changed_sub_hwpunit: usize,
+    pub changed_within_one_px: usize,
+    pub changed_within_ten_px: usize,
+    pub changed_over_ten_px: usize,
+    pub max_abs_delta_hwpunit_ceil: u64,
+    /// First opaque ordinal that is not exact, including a one-sided tail.
+    pub first_changed_ordinal: Option<usize>,
+    /// Coordinate slot (not a source field or value) responsible for the maximum absolute delta.
+    pub max_delta_coordinate_ordinal: Option<usize>,
+}
+
+impl GeometryDeltaSummary {
+    pub fn is_exact(&self) -> bool {
+        self.candidate_count == self.oracle_count
+            && self.paired_count == self.exact_pairs
+            && self.payload_mismatches == 0
+            && self.non_finite_pairs == 0
+    }
+}
+
+/// Per-page categories. Decoration glyphs are identified only by their baseline falling outside
+/// the page's body box; no character or semantic source is exposed.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct PagePlacementDelta {
+    pub page_ordinal: usize,
+    pub page_box: GeometryDeltaSummary,
+    pub decoration_glyphs: GeometryDeltaSummary,
+    pub body_glyphs: GeometryDeltaSummary,
+    pub blocks: GeometryDeltaSummary,
+    pub tables: GeometryDeltaSummary,
+    pub cells: GeometryDeltaSummary,
+    pub rects: GeometryDeltaSummary,
+    pub lines: GeometryDeltaSummary,
+    pub images: GeometryDeltaSummary,
+}
+
+/// Document-level result. Page count mismatch is kept separate so missing pages cannot accidentally
+/// disappear into empty per-page categories.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct PlacedDocDeltaReport {
+    pub candidate_pages: usize,
+    pub oracle_pages: usize,
+    pub pages: Vec<PagePlacementDelta>,
+}
+
+impl PlacedDocDeltaReport {
+    pub fn is_exact(&self) -> bool {
+        self.candidate_pages == self.oracle_pages
+            && self.pages.iter().all(|page| {
+                page.page_box.is_exact()
+                    && page.decoration_glyphs.is_exact()
+                    && page.body_glyphs.is_exact()
+                    && page.blocks.is_exact()
+                    && page.tables.is_exact()
+                    && page.cells.is_exact()
+                    && page.rects.is_exact()
+                    && page.lines.is_exact()
+                    && page.images.is_exact()
+            })
+    }
+}
+
+#[derive(Clone)]
+struct Fact {
+    coordinates: Vec<f64>,
+    payload: Vec<u64>,
+}
+
+fn color_key(color: hwp_model::types::Color) -> u64 {
+    u64::from(color.r)
+        | (u64::from(color.g) << 8)
+        | (u64::from(color.b) << 16)
+        | (u64::from(color.a) << 24)
+}
+
+fn extend_optional_text_key(payload: &mut Vec<u64>, value: Option<&str>) {
+    payload.push(u64::from(value.is_some()));
+    if let Some(value) = value {
+        payload.push(value.len() as u64);
+        payload.extend(value.as_bytes().iter().map(|byte| u64::from(*byte) + 1));
+    }
+}
+
+fn summarize(candidate: Vec<Fact>, oracle: Vec<Fact>) -> GeometryDeltaSummary {
+    let mut out = GeometryDeltaSummary {
+        candidate_count: candidate.len(),
+        oracle_count: oracle.len(),
+        paired_count: candidate.len().min(oracle.len()),
+        candidate_only: candidate.len().saturating_sub(oracle.len()),
+        oracle_only: oracle.len().saturating_sub(candidate.len()),
+        ..GeometryDeltaSummary::default()
+    };
+    for (ordinal, (left, right)) in candidate.iter().zip(&oracle).enumerate() {
+        let finite = left
+            .coordinates
+            .iter()
+            .chain(&right.coordinates)
+            .all(|value| value.is_finite());
+        if !finite || left.coordinates.len() != right.coordinates.len() {
+            out.first_changed_ordinal.get_or_insert(ordinal);
+            out.non_finite_pairs += 1;
+            continue;
+        }
+        let coordinates_exact = left
+            .coordinates
+            .iter()
+            .zip(&right.coordinates)
+            .all(|(left, right)| left.to_bits() == right.to_bits());
+        let payload_exact = left.payload == right.payload;
+        if coordinates_exact && payload_exact {
+            out.exact_pairs += 1;
+            continue;
+        }
+        out.first_changed_ordinal.get_or_insert(ordinal);
+        if !payload_exact {
+            out.payload_mismatches += 1;
+        }
+        let (max_slot, max_delta) = left
+            .coordinates
+            .iter()
+            .zip(&right.coordinates)
+            .map(|(left, right)| (left - right).abs())
+            .enumerate()
+            .max_by(|(_, left), (_, right)| left.total_cmp(right))
+            .unwrap_or((0, 0.0));
+        let max_delta_ceil = max_delta.ceil().min(u64::MAX as f64) as u64;
+        if max_delta_ceil > out.max_abs_delta_hwpunit_ceil {
+            out.max_abs_delta_hwpunit_ceil = max_delta_ceil;
+            out.max_delta_coordinate_ordinal = Some(max_slot);
+        }
+        if max_delta < 1.0 {
+            out.changed_sub_hwpunit += 1;
+        } else if max_delta <= 75.0 {
+            out.changed_within_one_px += 1;
+        } else if max_delta <= 750.0 {
+            out.changed_within_ten_px += 1;
+        } else {
+            out.changed_over_ten_px += 1;
+        }
+    }
+    if out.first_changed_ordinal.is_none() && candidate.len() != oracle.len() {
+        out.first_changed_ordinal = Some(out.paired_count);
+    }
+    out
+}
+
+fn glyph_facts(page: &PlacedPage, decoration: bool) -> Vec<Fact> {
+    let body_bottom = page.height - page.margin_bottom;
+    page.glyphs
+        .iter()
+        .filter(|glyph| {
+            let outside_body = glyph.baseline < page.margin_top || glyph.baseline > body_bottom;
+            outside_body == decoration
+        })
+        .map(|glyph| {
+            let mut payload = vec![
+                glyph.ch as u64,
+                color_key(glyph.color),
+                u64::from(glyph.underline),
+                u64::from(glyph.bold),
+                u64::from(glyph.italic),
+            ];
+            extend_optional_text_key(&mut payload, glyph.font.as_deref());
+            extend_optional_text_key(&mut payload, glyph.cluster.as_deref());
+            Fact {
+                coordinates: vec![glyph.x, glyph.baseline, glyph.size],
+                payload,
+            }
+        })
+        .collect()
+}
+
+fn compare_page(ordinal: usize, candidate: &PlacedPage, oracle: &PlacedPage) -> PagePlacementDelta {
+    let page_box = summarize(
+        vec![Fact {
+            coordinates: vec![
+                candidate.width,
+                candidate.height,
+                candidate.margin_left,
+                candidate.margin_top,
+                candidate.margin_right,
+                candidate.margin_bottom,
+            ],
+            payload: Vec::new(),
+        }],
+        vec![Fact {
+            coordinates: vec![
+                oracle.width,
+                oracle.height,
+                oracle.margin_left,
+                oracle.margin_top,
+                oracle.margin_right,
+                oracle.margin_bottom,
+            ],
+            payload: Vec::new(),
+        }],
+    );
+    let blocks = summarize(
+        candidate
+            .blocks
+            .iter()
+            .map(|item| Fact {
+                coordinates: vec![item.x, item.y, item.w, item.h],
+                payload: vec![item.kind as u64],
+            })
+            .collect(),
+        oracle
+            .blocks
+            .iter()
+            .map(|item| Fact {
+                coordinates: vec![item.x, item.y, item.w, item.h],
+                payload: vec![item.kind as u64],
+            })
+            .collect(),
+    );
+    let tables = summarize(
+        candidate
+            .tables
+            .iter()
+            .map(|item| Fact {
+                coordinates: vec![item.x, item.y, item.w, item.h],
+                payload: vec![
+                    item.rows as u64,
+                    item.cols as u64,
+                    item.first_row as u64,
+                    item.last_row as u64,
+                    item.cells.len() as u64,
+                ],
+            })
+            .collect(),
+        oracle
+            .tables
+            .iter()
+            .map(|item| Fact {
+                coordinates: vec![item.x, item.y, item.w, item.h],
+                payload: vec![
+                    item.rows as u64,
+                    item.cols as u64,
+                    item.first_row as u64,
+                    item.last_row as u64,
+                    item.cells.len() as u64,
+                ],
+            })
+            .collect(),
+    );
+    let cells = summarize(
+        candidate
+            .tables
+            .iter()
+            .flat_map(|table| &table.cells)
+            .map(|item| Fact {
+                coordinates: vec![item.x, item.y, item.w, item.h],
+                payload: vec![item.row as u64, item.col as u64],
+            })
+            .collect(),
+        oracle
+            .tables
+            .iter()
+            .flat_map(|table| &table.cells)
+            .map(|item| Fact {
+                coordinates: vec![item.x, item.y, item.w, item.h],
+                payload: vec![item.row as u64, item.col as u64],
+            })
+            .collect(),
+    );
+    let rects = summarize(
+        candidate
+            .rects
+            .iter()
+            .map(|item| Fact {
+                coordinates: vec![item.x, item.y, item.w, item.h],
+                payload: vec![
+                    u64::from(item.fill.is_some()),
+                    item.fill.map_or(0, color_key),
+                ],
+            })
+            .collect(),
+        oracle
+            .rects
+            .iter()
+            .map(|item| Fact {
+                coordinates: vec![item.x, item.y, item.w, item.h],
+                payload: vec![
+                    u64::from(item.fill.is_some()),
+                    item.fill.map_or(0, color_key),
+                ],
+            })
+            .collect(),
+    );
+    let lines = summarize(
+        candidate
+            .lines
+            .iter()
+            .map(|item| Fact {
+                coordinates: vec![item.x1, item.y1, item.x2, item.y2, item.width],
+                payload: vec![item.style as u64, color_key(item.color)],
+            })
+            .collect(),
+        oracle
+            .lines
+            .iter()
+            .map(|item| Fact {
+                coordinates: vec![item.x1, item.y1, item.x2, item.y2, item.width],
+                payload: vec![item.style as u64, color_key(item.color)],
+            })
+            .collect(),
+    );
+    let images = summarize(
+        candidate
+            .images
+            .iter()
+            .map(|item| {
+                let mut payload = vec![u64::from(item.is_background)];
+                extend_optional_text_key(&mut payload, Some(&item.bin_ref));
+                extend_optional_text_key(&mut payload, item.svg.as_deref());
+                Fact {
+                    coordinates: vec![item.x, item.y, item.w, item.h],
+                    payload,
+                }
+            })
+            .collect(),
+        oracle
+            .images
+            .iter()
+            .map(|item| {
+                let mut payload = vec![u64::from(item.is_background)];
+                extend_optional_text_key(&mut payload, Some(&item.bin_ref));
+                extend_optional_text_key(&mut payload, item.svg.as_deref());
+                Fact {
+                    coordinates: vec![item.x, item.y, item.w, item.h],
+                    payload,
+                }
+            })
+            .collect(),
+    );
+
+    PagePlacementDelta {
+        page_ordinal: ordinal,
+        page_box,
+        decoration_glyphs: summarize(glyph_facts(candidate, true), glyph_facts(oracle, true)),
+        body_glyphs: summarize(glyph_facts(candidate, false), glyph_facts(oracle, false)),
+        blocks,
+        tables,
+        cells,
+        rects,
+        lines,
+        images,
+    }
+}
+
+/// Compare two positioned documents without retaining any source content or identifying metadata.
+pub fn compare_placed_docs(candidate: &PlacedDoc, oracle: &PlacedDoc) -> PlacedDocDeltaReport {
+    PlacedDocDeltaReport {
+        candidate_pages: candidate.pages.len(),
+        oracle_pages: oracle.pages.len(),
+        pages: candidate
+            .pages
+            .iter()
+            .zip(&oracle.pages)
+            .enumerate()
+            .map(|(ordinal, (candidate, oracle))| compare_page(ordinal, candidate, oracle))
+            .collect(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{BlockKind, PlacedBlock, PlacedGlyph, PlacedImage};
+    use hwp_model::types::Color;
+
+    fn glyph(x: f64, baseline: f64, ch: char) -> PlacedGlyph {
+        PlacedGlyph {
+            x,
+            baseline,
+            ch,
+            size: 1_000.0,
+            color: Color::default(),
+            underline: false,
+            bold: false,
+            italic: false,
+            font: None,
+            cluster: None,
+        }
+    }
+
+    fn page() -> PlacedPage {
+        PlacedPage {
+            width: 10_000.0,
+            height: 20_000.0,
+            margin_top: 2_000.0,
+            margin_bottom: 2_000.0,
+            ..PlacedPage::default()
+        }
+    }
+
+    #[test]
+    fn decoration_body_and_nontext_categories_do_not_collapse() {
+        let mut candidate = page();
+        candidate.glyphs = vec![glyph(100.0, 1_000.0, 'A'), glyph(100.0, 3_000.0, 'B')];
+        candidate.images.push(PlacedImage {
+            x: 10.0,
+            y: 20.0,
+            w: 30.0,
+            h: 40.0,
+            bin_ref: "must-not-be-observed".into(),
+            svg: None,
+            is_background: false,
+            section: 99,
+            block: 99,
+        });
+        let mut oracle = page();
+        oracle.glyphs = vec![glyph(100.0, 3_000.0, 'B')];
+        let report = compare_placed_docs(
+            &PlacedDoc {
+                pages: vec![candidate],
+            },
+            &PlacedDoc {
+                pages: vec![oracle],
+            },
+        );
+        assert_eq!(report.pages[0].decoration_glyphs.candidate_only, 1);
+        assert_eq!(report.pages[0].body_glyphs.exact_pairs, 1);
+        assert_eq!(report.pages[0].images.candidate_only, 1);
+        assert!(!format!("{report:?}").contains("must-not-be-observed"));
+    }
+
+    #[test]
+    fn ordinal_shift_repetition_and_nonfinite_values_fail_closed() {
+        let block = |x| PlacedBlock {
+            x,
+            y: 3_000.0,
+            w: 100.0,
+            h: 100.0,
+            section: 0,
+            block: 0,
+            kind: BlockKind::Paragraph,
+        };
+        let mut candidate = page();
+        candidate.blocks = vec![block(10.0), block(10.0), block(f64::NAN)];
+        let mut oracle = page();
+        oracle.blocks = vec![block(10.0), block(11.0), block(10.0)];
+        let report = compare_placed_docs(
+            &PlacedDoc {
+                pages: vec![candidate],
+            },
+            &PlacedDoc {
+                pages: vec![oracle],
+            },
+        );
+        let blocks = &report.pages[0].blocks;
+        assert_eq!(blocks.exact_pairs, 1);
+        assert_eq!(blocks.changed_within_one_px, 1);
+        assert_eq!(blocks.non_finite_pairs, 1);
+        assert!(!blocks.is_exact());
+    }
+
+    #[test]
+    fn missing_pages_never_compare_as_exact() {
+        let report = compare_placed_docs(
+            &PlacedDoc {
+                pages: vec![page()],
+            },
+            &PlacedDoc::default(),
+        );
+        assert!(report.pages.is_empty());
+        assert!(!report.is_exact());
+    }
+}

--- a/crates/hwp-typeset/src/lib.rs
+++ b/crates/hwp-typeset/src/lib.rs
@@ -22,6 +22,13 @@ pub use shaper::RealFontMetrics;
 /// (`subst_glyph` 측정 프록시 + `place::paragraph_glyphs` 그리기 확장)에서 소비된다.
 mod old_hangul;
 
+/// Content-free differential diagnostics for two already-positioned documents. This never replaces
+/// layout or rendering; it only classifies evidence produced by the shared typesetter.
+pub mod diagnostic;
+pub use diagnostic::{
+    compare_placed_docs, GeometryDeltaSummary, PagePlacementDelta, PlacedDocDeltaReport,
+};
+
 /// Positioned layout (glyphs/images/boxes per page) — the paint-IR bridge consumed by `hwp-render`.
 pub mod place;
 pub use place::{

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,6 +3,40 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
+- 갱신: 2026-08-24 · Codex(sol) — **PR #201 병합 · #202 착수**.
+  PR #201 exact head `cce9892` 상태에서 issue-link **4s**·build-test **9m35s**·licenses
+  **2m47s** green, CLEAN/MERGEABLE, review/general/inline 댓글 0을 확인하고 protected main
+  `585f9e92`로 squash 병합했다. #200은 close됐고 #94에 빈 run 조판 동등성과
+  `render-parity-unproven` no-cutover 근거를 동기화했다. 남은 candidate/rhwp 차이는
+  모두 8쪽·페이지별 block/table/rect/line 개수 동일이지만 exact geometry가 다르고,
+  candidate에 glyph가 **+24(매 페이지 +3)**다. 중복 검색에서 #164 page-number 소유는
+  이미 완료됐으나 현재 차이의 원인은 미증명이므로, classification-first 후속 **#202**를
+  R18/P1/area:hwp5/status:ready로 열고 exact main의 `codex/issue-202-hwp5-geometry`
+  worktree를 만들었다. **다음:** 원문·파일명·경로·hash/raw 없이 배치/조판/
+  PaintOp을 page-decoration/body/table-cell/other로 나누고 opaque ordinal·exact/quantized
+  delta만 기록한다. +3 glyph/page의 typed 소유과 body geometry를 독립 증명한 뒤
+  가장 작은 fail-closed 후속을 고른다. production route·`external/rhwp`·eligible=false는 불변.
+  content-free placed comparator는 page box/decoration glyph/body glyph/block/table/cell/rect/line/image를
+  페이지별로 나누고 exact/payload mismatch/one-sided/nonfinite·<1 HWPUNIT/≤1px/≤10px/>10px,
+  max delta와 opaque first ordinal/coordinate slot만 남긴다. 반복·ordinal shift·누락 page·non-text
+  image·NaN은 fail-closed hostile test로 잠김. shared PaintOp에도 원문/좌표 없는 1:1
+  body/page-decoration/boundary-crossing mask를 추가해 SVG·PDF replay가 같은 경계를 쓰게 했다.
+  실측상 +3 glyph/page는 #164에서 소유한 page-number decoration이고 rhwp projection의
+  누락이다. candidate에서 page_number만 제거하면 body glyph/block/table/cell/rect/line/image가
+  모두 exact이며, PDF도 페이지당 text replay 3개 차이를 같은 mask로 설명한다.
+  rhwp 대비 body는 8쪽 중 6쪽 exact. 0-based page 2만 block/table/cell/rect/line 차이가
+  남고 max **177 HWPUNIT**, page 7은 glyph x 8개만 max **72 HWPUNIT** 차이며 나머지
+  geometry는 exact이다. 쪽번호는 native regression이 아닌 oracle omission으로 분리됐지만,
+  body 2곳은 미증명이므로 `render-parity-unproven`/eligible=false를 유지한다. **다음:**
+  focused clippy/tests와 quick은 green: workspace/PDF visual **51**/canonical **8·18·24·98.9%+**/
+  public corpus **84**/oracle **82**/HWPX/wasm/licenses. full은 wasm **7,818,196B**, JS build/
+  crosscheck/i18n, Vitest **1,018**(269+64+427+247+11) green. sandbox port EPERM 후 실제
+  Chromium **85 pass/3 intentional skip/0 fail**. 임시 node_modules link는 제거했고 generated
+  wasm/assets는 git diff 0이다. **다음:** privacy/boundary audit → commit/push/`Closes #202`
+  PR → exact-head CI/comments/mergeability green이면 autonomous merge. 후속은 page 2의 첫 table/cell
+  geometry와 page 7 glyph ordinal 324의 x-only delta를 resolved semantic field별로 분해하는 더
+  작은 classification-first issue로 연다.
+
 - 갱신: 2026-08-24 · Codex(sol) — **PR #199 병합 · #200 착수**.
   PR #199 exact head `bdecc52`에서 issue-link **4s**·build-test **8m55s**·licenses **2m48s** green,
   CLEAN/MERGEABLE, review/general/inline 댓글 0을 확인하고 protected main `ffe25edb`로 squash

--- a/docs/HWP5-NATIVE-PARSER.md
+++ b/docs/HWP5-NATIVE-PARSER.md
@@ -125,6 +125,17 @@ painted glyphs (three per page). The empty-run difference is therefore semantica
 the completed benchmark remains ineligible as `render-parity-unproven`; the remaining parser-wide
 render delta must be isolated before cutover.
 
+#202 decomposes that aggregate without retaining source content or identifying metadata. The repeated
+three-glyph delta is entirely the first-party page-number decoration already owned by #164: rhwp's
+semantic projection does not carry it, and removing only `Section.page_number` leaves every body glyph,
+block, table, cell, rect, and line exact against the unmodified first-party candidate. Opaque masks over
+the shared `PageLayerTree` give SVG and PDF the same decoration/body boundary. Against rhwp, body SVG is
+exact on six of eight pages. Only zero-based page 2 has block/table/cell/rect/line deltas (all counts and
+payload classes match; maximum bounded delta is 177 HWPUNIT), while page 7 has eight glyph x-position
+deltas bounded by 72 HWPUNIT and otherwise exact geometry. This proves that page numbers are an oracle
+omission rather than a native regression, but it does not waive the two remaining body-layout deltas;
+the benchmark stays `render-parity-unproven` and ineligible.
+
 ## Cutover rule
 
 Completing one bounded benchmark is only the first eligibility milestone. The content-free committed

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,17 @@
 
 ---
 
+## 2026-08-24 (Codex sol) · #202 full green
+- quick/full green: canonical 8/18/24+98.9%, corpus84/oracle82, wasm 7,818,196B, PDF51.
+- JS/crosscheck/i18n + Vitest 1,018 green; Chromium 85 pass/3 intentional skip/0 fail.
+- temporary dependency links removed; next privacy/boundary audit, commit/push, `Closes #202` PR/CI/merge.
+
+## 2026-08-24 (Codex sol) · #202 decoration/body delta decomposition
+- PR #201 merged at `585f9e92`; #200 closed and #94 updated; #202 opened from exact main.
+- +3 glyph/page is native page-number decoration only; removing it leaves all candidate body placement exact.
+- rhwp body gap is page 2 table/cell max 177 HWPUNIT and page 7 glyph-x max 72; other six pages exact.
+- content-free placed summaries + shared SVG/PDF paint masks implemented; next gates/audit/PR then semantic-field slice.
+
 ## 2026-08-24 (Codex sol) · #200 full green
 - quick/full green: PDF51, canonical 8/18/24+98.9%, corpus84/oracle82, wasm 7,818,243B.
 - Vitest 1,018 and Chromium 85 pass/3 intentional skip/0 fail; temporary links removed.


### PR DESCRIPTION
## Summary

- add a content-free placed-layout comparator with typed page/body/table/cell/paint categories, opaque ordinals, bounded coordinate buckets, and fail-closed nonfinite/page-count handling
- add a source-free 1:1 PaintOp ownership mask shared by SVG and PDF diagnostics
- prove the native benchmark's +3 glyphs/page are owned page-number decoration only, while the remaining rhwp body delta is isolated to pages 2 and 7 (zero-based)
- keep production HWP5 routing, `external/rhwp`, parser eligibility, HWPX, scoring, and generated assets unchanged

## Evidence

- native/rhwp: 8 pages; six body pages SVG-exact
- page 2: matching typed counts/payload classes, table/cell geometry bounded to 177 HWPUNIT
- page 7: eight glyph x-coordinate deltas bounded to 72 HWPUNIT; other geometry exact
- removing only native `Section.page_number`: body glyph/block/table/cell/rect/line/image exact on all pages
- PDF replay differs by the same three text ops/page and no geometry/image/equation/chart replay counts

## Validation

- focused fmt/clippy `-D warnings` and HWP5/layout/SVG/PDF tests green
- `scripts/verify-local.sh`: workspace, canonical 8/18/24 + 98.9%+, PDF visual 51, public corpus 84, oracle 82, HWPX, wasm, licenses green
- full: wasm 7,818,196B; JS build/crosscheck/i18n; Vitest 1,018 green
- actual Chromium: 85 passed, 3 intentional skips, 0 failed
- final audit: no `external/rhwp`, production route, generated wasm/assets, private content/path/name/hash/raw, or credential diff

## Boundary

This is diagnostic evidence only. It does not normalize production documents, weaken the oracle, mark the benchmark eligible, or cut production over from rhwp. The benchmark remains `render-parity-unproven` and `eligible=false`.

Closes #202