### PR TITLE
fix: resolve HWP5 body render parity deltas

### DIFF
--- a/crates/hwp-core/tests/hwp5_empty_run_layout.rs
+++ b/crates/hwp-core/tests/hwp5_empty_run_layout.rs
@@ -240,13 +240,13 @@ fn benchmark_empty_run_deltas_are_content_free_and_layout_classified() {
         assert_eq!(candidate_page.rects.len(), oracle_page.rects.len());
         assert_eq!(candidate_page.lines.len(), oracle_page.lines.len());
     }
-    assert!(!same_page_and_block_geometry(
+    assert!(same_page_and_block_geometry(
         &candidate_placed,
         &oracle_placed
     ));
-    assert!(!same_table_geometry(&candidate_placed, &oracle_placed));
-    assert!(!same_rect_geometry(&candidate_placed, &oracle_placed));
-    assert!(!same_line_geometry(&candidate_placed, &oracle_placed));
+    assert!(same_table_geometry(&candidate_placed, &oracle_placed));
+    assert!(same_rect_geometry(&candidate_placed, &oracle_placed));
+    assert!(same_line_geometry(&candidate_placed, &oracle_placed));
     assert_eq!(
         candidate_placed
             .pages
@@ -275,61 +275,15 @@ fn benchmark_empty_run_deltas_are_content_free_and_layout_classified() {
             && page.decoration_glyphs.candidate_only == 3
             && page.decoration_glyphs.first_changed_ordinal == Some(0)
     }));
-    assert_eq!(
-        typed_delta
-            .pages
-            .iter()
-            .filter(|page| !page.body_glyphs.is_exact())
-            .map(|page| page.page_ordinal)
-            .collect::<Vec<_>>(),
-        vec![2, 7]
-    );
-    assert_eq!(
-        typed_delta.pages[2].body_glyphs.max_abs_delta_hwpunit_ceil,
-        148
-    );
-    assert_eq!(
-        typed_delta.pages[7].body_glyphs.max_abs_delta_hwpunit_ceil,
-        72
-    );
-    assert_eq!(
-        typed_delta
-            .pages
-            .iter()
-            .filter(|page| {
-                !page.blocks.is_exact()
-                    || !page.tables.is_exact()
-                    || !page.cells.is_exact()
-                    || !page.rects.is_exact()
-                    || !page.lines.is_exact()
-            })
-            .map(|page| page.page_ordinal)
-            .collect::<Vec<_>>(),
-        vec![2]
-    );
-    assert_eq!(typed_delta.pages[2].cells.max_abs_delta_hwpunit_ceil, 177);
-    assert_eq!(
-        typed_delta.pages[2].body_glyphs.first_changed_ordinal,
-        Some(12)
-    );
-    assert_eq!(
-        typed_delta.pages[2]
-            .body_glyphs
-            .max_delta_coordinate_ordinal,
-        Some(1)
-    );
-    assert_eq!(typed_delta.pages[2].tables.first_changed_ordinal, Some(0));
-    assert_eq!(typed_delta.pages[2].cells.first_changed_ordinal, Some(0));
-    assert_eq!(
-        typed_delta.pages[7].body_glyphs.first_changed_ordinal,
-        Some(324)
-    );
-    assert_eq!(
-        typed_delta.pages[7]
-            .body_glyphs
-            .max_delta_coordinate_ordinal,
-        Some(0)
-    );
+    assert!(typed_delta.pages.iter().all(|page| {
+        page.body_glyphs.is_exact()
+            && page.blocks.is_exact()
+            && page.tables.is_exact()
+            && page.cells.is_exact()
+            && page.rects.is_exact()
+            && page.lines.is_exact()
+            && page.images.is_exact()
+    }));
     let typed_public = format!("{typed_delta:?}");
     assert!(!typed_public.contains("benchmark.hwp"));
     assert!(!typed_public.contains("BodyText"));

--- a/crates/hwp-export/tests/hwp5_empty_run_pdf_parity.rs
+++ b/crates/hwp-export/tests/hwp5_empty_run_pdf_parity.rs
@@ -37,10 +37,20 @@ fn page_decoration_mask_agrees_with_pdf_replay_counts() {
     .unwrap();
     let candidate = open_hwp5_own(&bytes).unwrap();
     let oracle = Engine::open(&bytes).unwrap();
+    let mut candidate_without_page_number = candidate.clone();
+    for section in &mut candidate_without_page_number.sections {
+        section.page_number = None;
+    }
     let candidate_masks = render_doc_diagnostic_masks(&candidate, &ApproxFontMetrics);
     let oracle_masks = render_doc_diagnostic_masks(&oracle, &ApproxFontMetrics);
     let candidate_pdf = export_pdf(&candidate, &ApproxFontMetrics, &PdfOptions::default()).unwrap();
     let oracle_pdf = export_pdf(&oracle, &ApproxFontMetrics, &PdfOptions::default()).unwrap();
+    let body_pdf = export_pdf(
+        &candidate_without_page_number,
+        &ApproxFontMetrics,
+        &PdfOptions::default(),
+    )
+    .unwrap();
 
     assert_eq!(candidate_pdf.pages, 8);
     assert_eq!(candidate_pdf.pages, oracle_pdf.pages);
@@ -70,4 +80,11 @@ fn page_decoration_mask_agrees_with_pdf_replay_counts() {
         assert_eq!(candidate_page.equation, oracle_page.equation);
         assert_eq!(candidate_page.chart, oracle_page.chart);
     }
+    assert!(
+        body_pdf.bytes == oracle_pdf.bytes
+            && body_pdf.pages == oracle_pdf.pages
+            && body_pdf.replay == oracle_pdf.replay
+            && body_pdf.diagnostics == oracle_pdf.diagnostics,
+        "removing the first-party page number leaves the PDF byte-exact"
+    );
 }

--- a/crates/hwp-hwp5/src/semantic.rs
+++ b/crates/hwp-hwp5/src/semantic.rs
@@ -2459,9 +2459,10 @@ fn parse_inline_table(
         keep_together: table_attr != 0x0600_000e,
         col_widths,
         row_heights: derived_rows,
-        // The exact no-adjust table attributes carry HWP's no-adjust bit. Their stored row heights are
-        // exact clipping geometry, not merely content-size floors.
-        fixed_row_heights: matches!(table_attr, 0x0600_0006 | 0x0600_000c | 0x0600_000e),
+        // HWP5 TABLE bits 0..=1 are the page-break policy and bit 2 is repeat-header. They do not
+        // encode HWPX's `<hp:tbl noAdjust="1">` contract. Keep native HWP5 row heights as content
+        // floors, matching the shared model and the production rhwp lift.
+        fixed_row_heights: false,
         outer_margin_left: margins[0] as HwpUnit,
         outer_margin_right: margins[1] as HwpUnit,
         outer_margin_top: margins[2] as HwpUnit,

--- a/crates/hwp-hwp5/tests/layout_semantic.rs
+++ b/crates/hwp-hwp5/tests/layout_semantic.rs
@@ -867,7 +867,10 @@ fn owns_exact_nine_by_eight_table_with_one_bounded_nested_table() {
     assert!(anchor.is_table_anchor);
     assert_eq!((table.rows, table.cols, table.cells.len()), (9, 8, 34));
     assert!(table.keep_together);
-    assert!(table.fixed_row_heights, "no-adjust reaches shared IR");
+    assert!(
+        !table.fixed_row_heights,
+        "HWP5 TABLE page-break/repeat-header bits are not HWPX noAdjust"
+    );
     assert_eq!(
         table.col_widths,
         vec![3_182, 6_810, 659, 8_082, 5_346, 10_534, 5_935, 7_435]
@@ -928,7 +931,10 @@ fn owns_exact_eight_by_five_rowspan_and_nine_bounded_nested_tables() {
         !table.keep_together,
         "row-boundary policy uses shared row fragmentation"
     );
-    assert!(table.fixed_row_heights, "no-adjust reaches shared IR");
+    assert!(
+        !table.fixed_row_heights,
+        "HWP5 TABLE page-break/repeat-header bits are not HWPX noAdjust"
+    );
     assert_eq!(table.col_widths, vec![7_667, 16_324, 3_879, 3_955, 16_324]);
     assert_eq!(
         table.row_heights,
@@ -1113,7 +1119,7 @@ fn owns_exact_top_captioned_four_by_five_full_grid_table() {
     assert!(anchor.is_table_anchor);
     assert_eq!((table.rows, table.cols, table.cells.len()), (4, 5, 20));
     assert!(table.keep_together);
-    assert!(table.fixed_row_heights);
+    assert!(!table.fixed_row_heights);
     assert_eq!(table.col_widths, vec![3_221, 6_593, 8_956, 21_855, 7_422]);
     assert_eq!(table.row_heights, vec![1_948, 1_848, 1_848, 1_848]);
     let caption = table
@@ -1180,7 +1186,7 @@ fn owns_exact_plain_four_by_five_full_grid_table() {
     assert_eq!((table.rows, table.cols, table.cells.len()), (4, 5, 20));
     assert!(table.caption.is_none());
     assert!(table.keep_together);
-    assert!(table.fixed_row_heights);
+    assert!(!table.fixed_row_heights);
     assert_eq!(table.col_widths, vec![3_221, 9_238, 14_770, 12_223, 8_594]);
     assert_eq!(table.row_heights, vec![1_948, 1_848, 1_848, 1_848]);
     assert!(table.cells.iter().enumerate().all(|(index, cell)| {
@@ -1232,7 +1238,10 @@ fn owns_exact_seven_by_three_merged_atomic_table() {
     assert!(anchor.is_table_anchor);
     assert_eq!((table.rows, table.cols, table.cells.len()), (7, 3, 19));
     assert!(table.keep_together, "no-split table stays atomic");
-    assert!(table.fixed_row_heights, "no-adjust rows remain exact");
+    assert!(
+        !table.fixed_row_heights,
+        "HWP5 TABLE page-break/repeat-header bits keep row heights as floors"
+    );
     assert_eq!(table.col_widths, vec![6_509, 31_215, 10_200]);
     assert_eq!(
         table.row_heights,

--- a/crates/hwp-render/tests/hwp5_geometry_layers.rs
+++ b/crates/hwp-render/tests/hwp5_geometry_layers.rs
@@ -93,5 +93,8 @@ fn benchmark_masks_prove_page_number_ownership_and_isolate_body_pages() {
             },
         )
         .collect();
-    assert_eq!(differing_body_pages, vec![2, 7]);
+    assert!(
+        differing_body_pages.is_empty(),
+        "all body SVG pages are exact; the only remaining paint delta is owned page numbering"
+    );
 }

--- a/crates/hwp-rhwp/src/lift.rs
+++ b/crates/hwp-rhwp/src/lift.rs
@@ -571,7 +571,9 @@ impl<'a> Lifter<'a> {
                     padding: c.apply_inner_margin.then(|| lift_padding(&c.padding)),
                     // 이슈 074: 저장된 셀 실폭 — 한글 표는 행마다 열 경계가 달라(ragged) 열 격자
                     // 근사로는 폭이 최대 2배까지 틀린다. 0 은 "없음"으로 본다.
-                    width: (c.width > 0).then_some(c.width as i32),
+                    width: i32::try_from(cell_layout_width(c))
+                        .ok()
+                        .filter(|width| *width > 0),
                     ..Default::default()
                 }
             })
@@ -608,7 +610,7 @@ impl<'a> Lifter<'a> {
             // distributes its stored height evenly (height/span) so the sum over the span is preserved.
             row_heights: stored_row_heights(&t.cells, t.row_count as usize),
             // Per-column widths (HWPUNIT) for faithful column proportions on render.
-            col_widths: derive_col_widths(&t.cells, t.col_count as usize),
+            col_widths: derive_col_widths(&t.cells, t.col_count as usize, t.common.width),
             // Outer vertical margins (바깥 여백) so consecutive tables keep HWP's real gap on render.
             outer_margin_top: t.outer_margin_top.max(0) as i32,
             outer_margin_bottom: t.outer_margin_bottom.max(0) as i32,
@@ -862,9 +864,16 @@ fn stored_row_heights(cells: &[rhwp::model::table::Cell], rows: usize) -> Vec<i3
 /// short lines. We seed exact widths from single-column cells, then iteratively resolve span-only
 /// columns: for a span whose other columns are known, the leftover width is split among the unknown
 /// columns. Remaining unknowns keep the 1800 fallback. Proportions then match Hancom's grid.
-fn derive_col_widths(cells: &[rhwp::model::table::Cell], cols: usize) -> Vec<i32> {
+fn derive_col_widths(
+    cells: &[rhwp::model::table::Cell],
+    cols: usize,
+    total_width: u32,
+) -> Vec<i32> {
     if cols == 0 {
         return Vec::new();
+    }
+    if let Some(exact) = derive_exact_col_widths(cells, cols, total_width) {
+        return exact;
     }
     let mut w = vec![0u32; cols];
     let mut known = vec![false; cols];
@@ -872,7 +881,7 @@ fn derive_col_widths(cells: &[rhwp::model::table::Cell], cols: usize) -> Vec<i32
     for c in cells {
         let col = c.col as usize;
         if c.col_span <= 1 && col < cols {
-            w[col] = w[col].max(c.width);
+            w[col] = w[col].max(cell_layout_width(c));
             known[col] = true;
         }
     }
@@ -882,6 +891,7 @@ fn derive_col_widths(cells: &[rhwp::model::table::Cell], cols: usize) -> Vec<i32
     while changed {
         changed = false;
         for c in cells {
+            let cell_width = cell_layout_width(c);
             let span = c.col_span.max(1) as usize;
             let start = c.col as usize;
             if span <= 1 || start >= cols {
@@ -893,10 +903,10 @@ fn derive_col_widths(cells: &[rhwp::model::table::Cell], cols: usize) -> Vec<i32
                 continue;
             }
             let known_sum: u32 = (start..end).filter(|&i| known[i]).map(|i| w[i]).sum();
-            if c.width <= known_sum {
+            if cell_width <= known_sum {
                 continue; // can't split a non-positive remainder sensibly
             }
-            let each = (c.width - known_sum) / unknown.len() as u32;
+            let each = (cell_width - known_sum) / unknown.len() as u32;
             if each == 0 {
                 continue;
             }
@@ -914,6 +924,84 @@ fn derive_col_widths(cells: &[rhwp::model::table::Cell], cols: usize) -> Vec<i32
         }
     }
     w.into_iter().map(|x| x as i32).collect()
+}
+
+/// Solve the source cell-span equations against the common-object endpoints. The extension-aware
+/// width is load-bearing: a newer LIST_HEADER can deliberately supersede one stale core width. Any
+/// missing, contradictory, non-positive, or overflowing equation rejects the exact solve as a whole;
+/// the caller then uses the historical bounded fallback rather than partially mixing two grids.
+fn derive_exact_col_widths(
+    cells: &[rhwp::model::table::Cell],
+    cols: usize,
+    total_width: u32,
+) -> Option<Vec<i32>> {
+    let total_width = i64::from(total_width);
+    if cols == 0 || total_width <= 0 || total_width > i64::from(i32::MAX) {
+        return None;
+    }
+    let mut boundaries = vec![None::<i64>; cols + 1];
+    boundaries[0] = Some(0);
+    boundaries[cols] = Some(total_width);
+    for _ in 0..=cells.len() + cols {
+        let mut progressed = false;
+        for cell in cells {
+            let start = cell.col as usize;
+            let span = cell.col_span.max(1) as usize;
+            let end = start.checked_add(span)?;
+            if start >= cols || end > cols {
+                return None;
+            }
+            let width = i64::from(cell_layout_width(cell));
+            if width <= 0 || width > i64::from(i32::MAX) {
+                return None;
+            }
+            match (boundaries[start], boundaries[end]) {
+                (Some(left), Some(right)) if right - left != width => return None,
+                (Some(left), None) => {
+                    boundaries[end] = Some(left.checked_add(width)?);
+                    progressed = true;
+                }
+                (None, Some(right)) => {
+                    boundaries[start] = Some(right.checked_sub(width)?);
+                    progressed = true;
+                }
+                _ => {}
+            }
+        }
+        if !progressed {
+            break;
+        }
+    }
+    let boundaries = boundaries.into_iter().collect::<Option<Vec<_>>>()?;
+    if boundaries.first() != Some(&0)
+        || boundaries.last() != Some(&total_width)
+        || boundaries.windows(2).any(|pair| pair[0] >= pair[1])
+    {
+        return None;
+    }
+    boundaries
+        .windows(2)
+        .map(|pair| i32::try_from(pair[1] - pair[0]).ok())
+        .collect()
+}
+
+/// HWP5 cell LIST_HEADERs may carry a 13-byte layout extension whose first `u32` is the live cell
+/// width and whose remaining bytes are reserved zeroes. rhwp intentionally preserves that tail but
+/// exposes only the older core-width slot. Prefer the exact bounded extension in our lift so a stale
+/// core width cannot equal-split a ragged span. Longer/non-zero/zero/overflow tails fail closed to the
+/// core field; `external/rhwp` remains untouched.
+fn cell_layout_width(cell: &rhwp::model::table::Cell) -> u32 {
+    if cell.raw_list_extra.len() == 13 && cell.raw_list_extra[4..].iter().all(|byte| *byte == 0) {
+        let width = u32::from_le_bytes(
+            cell.raw_list_extra[..4]
+                .try_into()
+                .expect("exact four-byte prefix"),
+        );
+        if width > 0 && i32::try_from(width).is_ok() {
+            return width;
+        }
+    }
+    cell.width
 }
 
 /// rhwp `Padding` (i16 per side) → our `[left, right, top, bottom]` HWPUNIT array, negatives
@@ -1245,6 +1333,60 @@ fn lift_para_shape(p: &RParaShape, from_hwpx: bool) -> ParaShape {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn cell_layout_width_uses_only_the_exact_bounded_extension() {
+        let mut cell = rhwp::model::table::Cell {
+            width: 1_000,
+            ..Default::default()
+        };
+        let mut exact = vec![0; 13];
+        exact[..4].copy_from_slice(&1_176u32.to_le_bytes());
+        cell.raw_list_extra = exact.clone();
+        assert_eq!(cell_layout_width(&cell), 1_176);
+
+        let mut nonzero_tail = exact.clone();
+        nonzero_tail[12] = 1;
+        cell.raw_list_extra = nonzero_tail;
+        assert_eq!(cell_layout_width(&cell), 1_000);
+
+        cell.raw_list_extra = exact[..12].to_vec();
+        assert_eq!(cell_layout_width(&cell), 1_000);
+
+        let mut zero = vec![0; 13];
+        zero[..4].copy_from_slice(&0u32.to_le_bytes());
+        cell.raw_list_extra = zero;
+        assert_eq!(cell_layout_width(&cell), 1_000);
+
+        let mut overflow = vec![0; 13];
+        overflow[..4].copy_from_slice(&u32::MAX.to_le_bytes());
+        cell.raw_list_extra = overflow;
+        assert_eq!(cell_layout_width(&cell), 1_000);
+    }
+
+    #[test]
+    fn exact_column_solver_uses_layout_extension_for_span_equations() {
+        let single = |col, width| rhwp::model::table::Cell {
+            col,
+            col_span: 1,
+            width,
+            ..Default::default()
+        };
+        let mut spanning = rhwp::model::table::Cell {
+            col: 1,
+            col_span: 2,
+            width: 1_800,
+            ..Default::default()
+        };
+        spanning.raw_list_extra = vec![0; 13];
+        spanning.raw_list_extra[..4].copy_from_slice(&2_000u32.to_le_bytes());
+        let cells = vec![single(0, 1_000), single(2, 1_000), spanning];
+        assert_eq!(derive_col_widths(&cells, 3, 3_000), vec![1_000; 3]);
+
+        let mut contradictory = cells;
+        contradictory[2].raw_list_extra[..4].copy_from_slice(&1_900u32.to_le_bytes());
+        assert!(derive_exact_col_widths(&contradictory, 3, 3_000).is_none());
+    }
 
     #[test]
     fn caption_directions_map_without_loss() {

--- a/crates/hwp-typeset/src/place.rs
+++ b/crates/hwp-typeset/src/place.rs
@@ -605,6 +605,7 @@ fn place_doc_columns(doc: &SemanticDoc, fonts: &dyn FontMetricsProvider) -> Plac
                         page,
                         section_index,
                         block_index,
+                        None,
                     );
                     let end_page = pages.len() - 1;
                     let end_y = body_y + flow.y();
@@ -1357,6 +1358,7 @@ fn place_paragraph_columns(
     page: &PageSetup,
     section: usize,
     block: usize,
+    width_cap: Option<f64>,
 ) {
     let glyphs = paragraph_glyphs(p, doc, fonts);
     let align = doc
@@ -1365,7 +1367,11 @@ fn place_paragraph_columns(
         .map(|shape| shape.align)
         .unwrap_or_default();
     let ratio = line_spacing_ratio(p, doc);
-    let ind = indent_of(p, doc, flow.min_width());
+    let layout_width = width_cap
+        .map(|cap| flow.min_width().min(cap))
+        .unwrap_or_else(|| flow.min_width())
+        .max(1.0);
+    let ind = indent_of(p, doc, layout_width);
     let lines = layout_paragraph(p, doc, ind.wrap_w, fonts);
     let obj = paragraph_object(p);
 
@@ -1377,6 +1383,10 @@ fn place_paragraph_columns(
             new_page(pages, page);
         }
         let column = flow.box_now();
+        let effective_width = width_cap
+            .map(|cap| column.width.min(cap))
+            .unwrap_or(column.width)
+            .max(1.0);
         let line_top = mt + flow.y();
         let line_indent = ind.left
             + if line_index == 0 {
@@ -1384,7 +1394,7 @@ fn place_paragraph_columns(
             } else {
                 0.0
             };
-        let slack = (column.width
+        let slack = (effective_width
             - ind.left
             - if line_index == 0 {
                 ind.first_extra.max(0.0)
@@ -1438,7 +1448,7 @@ fn place_paragraph_columns(
                 page_out.images.push(PlacedImage {
                     x: x0,
                     y: line_top,
-                    w: (*width).min(column.width),
+                    w: (*width).min(effective_width),
                     h: *height,
                     bin_ref: bin_ref.clone(),
                     svg: svg.clone(),
@@ -1519,7 +1529,18 @@ fn place_caption_columns(
                     flow.add(shape.map(|value| value.space_before).unwrap_or(0).max(0) as f64);
                 }
                 place_paragraph_columns(
-                    paragraph, doc, fonts, ml, mt, body_h, flow, pages, page, section, block,
+                    paragraph,
+                    doc,
+                    fonts,
+                    ml,
+                    mt,
+                    body_h,
+                    flow,
+                    pages,
+                    page,
+                    section,
+                    block,
+                    (caption.max_width > 0).then_some(caption.max_width as f64),
                 );
                 flow.add(shape.map(|value| value.space_after).unwrap_or(0).max(0) as f64);
             }
@@ -4275,6 +4296,72 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn column_flow_honors_caption_max_width_for_centered_glyphs() {
+        use crate::LayoutEngine;
+
+        let plain_lead = para("");
+        let mut column_lead = plain_lead.clone();
+        column_lead.column_layout_before = Some(ColumnLayout {
+            widths: vec![60_000],
+            gaps: vec![],
+            ..ColumnLayout::default()
+        });
+        let table = captioned_table(TableCaptionPosition::Top, false);
+        let mut uncapped_table = table.clone();
+        uncapped_table
+            .caption
+            .as_mut()
+            .expect("synthetic caption")
+            .max_width = 0;
+        let mut plain = doc_with_page(
+            vec![Block::Paragraph(plain_lead), Block::Table(table.clone())],
+            20_000,
+        );
+        let mut column = doc_with_page(
+            vec![Block::Paragraph(column_lead), Block::Table(table)],
+            20_000,
+        );
+        let mut uncapped_column = column.clone();
+        uncapped_column.sections[0].blocks[1] = Block::Table(uncapped_table);
+        plain.para_shapes[0].align = HorizontalAlign::Center;
+        column.para_shapes[0].align = HorizontalAlign::Center;
+        uncapped_column.para_shapes[0].align = HorizontalAlign::Center;
+
+        let plain_placed = place_doc(&plain, &ApproxFontMetrics);
+        let column_placed = place_doc(&column, &ApproxFontMetrics);
+        let uncapped_placed = place_doc(&uncapped_column, &ApproxFontMetrics);
+        let first_caption_x = |placed: &PlacedDoc| {
+            placed
+                .pages
+                .iter()
+                .flat_map(|page| &page.glyphs)
+                .find(|glyph| glyph.ch == '캡')
+                .expect("synthetic caption glyph")
+                .x
+        };
+        assert_eq!(
+            first_caption_x(&plain_placed).to_bits(),
+            first_caption_x(&column_placed).to_bits(),
+            "an explicit one-column zone must not discard caption.max_width"
+        );
+        assert_eq!(
+            first_caption_x(&uncapped_placed) - first_caption_x(&column_placed),
+            (60_000.0 - 48_000.0) / 2.0,
+            "centered caption offset is half the body/max-width discriminator"
+        );
+        assert_eq!(plain_placed.pages.len(), column_placed.pages.len());
+        assert_eq!(
+            crate::NaiveLayout
+                .layout(&column, &ApproxFontMetrics)
+                .unwrap()
+                .pages
+                .len(),
+            column_placed.pages.len(),
+            "LOCKSTEP"
+        );
     }
 
     #[test]

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,6 +3,43 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
+- 갱신: 2026-08-24 · Codex(sol) — **#204 full green · PR 직전**.
+  `scripts/verify-local.sh` quick와 `--full` 모두 green: fmt/clippy/workspace/rhwp-feature/PDF 51,
+  canonical **8/18/24 + 98.9%+**, corpus 계약 84·catalog 259/12 families/120 pairs,
+  oracle 82, wasm **7,820,727B**, JS/crosscheck/i18n, Vitest **1,018**, Chromium **85 pass / 3
+  intentional skip / 0 fail**. 첫 full은 격리 worktree의 node_modules 부재, 둘째는 sandbox port
+  EPERM으로 환경상 중단됐고 기존 캐시 링크와 승인된 로컬 포트 실행으로 각각 해소했다. 임시 링크는
+  전부 제거했다. `external/rhwp`·wasm 생성물 diff 0, diff-check green. **다음:** 커밋/푸시→PR
+  `Closes #204`→exact-head CI/리뷰/댓글 감사→green merge→#94 동기화→다음 #94 slice issue-first.
+
+- 갱신: 2026-08-24 · Codex(sol) — **#204 구현 완료 · 전체 검증 전**.
+  남은 두 body delta의 원인을 content-free 수치로 확정했다. ① HWP5 cell LIST_HEADER의 exact
+  13B extension 첫 u32가 stale core width보다 **176 HWPUNIT** 큰 live layout width인데 rhwp lift가
+  보존만 하고 읽지 않아 span 열을 38/−38로 균분했다. exact 길이·zero reserved tail·positive i32만
+  수용하고 global boundary/span equation이 완결·무모순일 때만 열 격자로 채택하며, 아니면 기존 bounded
+  heuristic으로 fail closed한다. ② explicit column-flow caption이 `max_width`를 무시해 body/cap 차이
+  143의 절반인 **71.5 HWPUNIT**만큼 중앙 정렬 glyph가 밀렸다. 모든 column 문단 경로가 optional width
+  cap으로 같은 wrap/alignment/object width를 쓰게 했다. ③ 자체 HWP5 파서가 TABLE page-break/repeat-header
+  하위 비트를 HWPX `noAdjust`로 오해해 row height를 exact/clipping 처리했다. 모델 계약대로 HWP5는 floor,
+  HWPX만 fixed로 복원했다. 결과: 8쪽 body glyph/block/table/cell/rect/line/image와 body SVG가 rhwp와
+  **전부 exact**, own page-number를 제거한 PDF는 rhwp PDF와 **byte/pages/replay/diagnostics exact**다.
+  hwp-hwp5 78·hwp-rhwp lift 13·hwp-typeset 100·core/render/PDF focused green. `external/rhwp` 무수정,
+  production rhwp·eligible=false 유지. **다음:** 문서/JOURNAL→quick/full→privacy/vendor diff 감사→PR.
+
+- 갱신: 2026-08-24 · Codex(sol) — **PR #203 병합 · #204 착수**.
+  PR #203 exact head `ef334eb4`에서 issue-link **5s**·build-test **9m53s**·licenses
+  **2m38s** green, CLEAN/MERGEABLE, review/general/inline 댓글 0을 확인하고 protected main
+  `6c9d516a`로 squash 병합했다. #202 close·원격 브랜치 삭제를 확인하고 #94에 content-free
+  근거를 동기화했다. 페이지당 +3 glyph는 first-party page-number decoration이며 이를 제외한
+  candidate body는 8쪽 모두 exact, rhwp body와는 6/8쪽 exact다. 남은 두 곳은 0-based page 2의
+  table/cell/rect/line 최대 **177 HWPUNIT**와 page 7의 glyph x 8개 최대 **72 HWPUNIT**뿐이다.
+  중복 검색 뒤 후속 **#204**를 R18/P1/area:hwp5+typeset/status:ready로 열고 exact main의
+  `codex/issue-204-hwp5-semantic-deltas` worktree를 만들었다. **다음:** 원문·font name·파일명·
+  경로·hash/raw 없이 두 opaque site의 resolved table/row/cell/paragraph/char-shape/font-metric
+  입력을 fail-closed로 비교한다. 74/148 vertical cascade·176/177 horizontal delta와 x-only 72의
+  정확한 discriminator를 synthetic/hostile fixture로 독립 재현한 뒤 first-party parser/IR/layout의
+  최소 원인만 수리한다. production rhwp·`external/rhwp`·eligible=false·oracle/gates는 불변.
+
 - 갱신: 2026-08-24 · Codex(sol) — **PR #201 병합 · #202 착수**.
   PR #201 exact head `cce9892` 상태에서 issue-link **4s**·build-test **9m35s**·licenses
   **2m47s** green, CLEAN/MERGEABLE, review/general/inline 댓글 0을 확인하고 protected main

--- a/docs/HWP5-NATIVE-PARSER.md
+++ b/docs/HWP5-NATIVE-PARSER.md
@@ -136,6 +136,26 @@ deltas bounded by 72 HWPUNIT and otherwise exact geometry. This proves that page
 omission rather than a native regression, but it does not waive the two remaining body-layout deltas;
 the benchmark stays `render-parity-unproven` and ineligible.
 
+#204 resolves both bounded body-layout deltas without editing vendored rhwp or changing production
+routing. First, an exact 13-byte HWP5 cell `LIST_HEADER` extension carries the live layout width in its
+first `u32`; one observed span cell's older core-width slot was stale by 176 HWPUNIT. The rhwp adapter
+now accepts that extension only at the exact length, with a positive signed-32-bit width and an all-zero
+reserved tail. A global column-boundary/span-equation solve is used only when every boundary is known,
+positive, bounded, and mutually consistent; otherwise the entire solve fails closed to the prior
+bounded heuristic. Second, the explicit-column caption path now applies `TableCaption.max_width` to
+the same wrapping, alignment, and object-width calculations as the flat path. The bounded discriminator
+is 143 HWPUNIT, whose half produced the former 71.5-HWPUNIT centered-glyph shift. Finally, HWP5 TABLE
+bits 0–1/2 are kept as page-break/repeat-header semantics rather than being mistaken for HWPX
+`noAdjust`; HWP5 stored row heights remain floors, while only the HWPX parser may request exact clipping.
+
+After those corrections, all eight pages are exact against the rhwp oracle for body glyphs, blocks,
+tables, cells, rectangles, lines, images, and body-only SVG. The first-party page-number decoration is
+still intentionally present only in the candidate (three glyphs per page). Removing only that owned
+decoration makes PDF bytes, page count, replay counters, and diagnostics exact against the rhwp PDF.
+This is strong evidence for the one bounded benchmark, not generic HWP5 coverage: production remains
+on rhwp, `external/rhwp` remains immutable, and eligibility remains false until the parser-wide corpus
+and cutover gates below are satisfied.
+
 ## Cutover rule
 
 Completing one bounded benchmark is only the first eligibility milestone. The content-free committed

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,12 @@
 
 ---
 
+## 2026-08-24 (Codex sol) · #204 HWP5 body render exact
+- live cell width(+176), caption cap(143→71.5), HWP5 row-floor semantics를 fail-closed로 교정.
+- 8쪽 body placement/SVG exact; own page-number 제거 시 rhwp PDF bytes/pages/replay/diagnostics exact.
+- quick/full green: 8/18/24+98.9%, Vitest 1,018, Chromium 85 pass/3 skip; vendor/generated diff 0.
+- 다음: commit/push→`Closes #204` PR→exact-head CI/merge→#94 갱신→다음 corpus slice.
+
 ## 2026-08-24 (Codex sol) · #202 full green
 - quick/full green: canonical 8/18/24+98.9%, corpus84/oracle82, wasm 7,818,196B, PDF51.
 - JS/crosscheck/i18n + Vitest 1,018 green; Chromium 85 pass/3 intentional skip/0 fail.


### PR DESCRIPTION
Closes #204

## What changed
- honor the exact bounded HWP5 cell LIST_HEADER layout-width extension in the rhwp adapter and solve complete column span equations atomically
- apply table-caption max width in explicit column flow
- keep HWP5 TABLE page-break/repeat-header bits distinct from HWPX noAdjust row clipping
- promote the bounded benchmark assertions from two body deltas to exact body placement, body SVG, and PDF-byte parity after masking the owned page-number decoration

## Safety
- `external/rhwp` remains unchanged
- production HWP5 parsing remains on rhwp
- first-party eligibility remains false pending parser-wide corpus evidence
- malformed, ambiguous, contradictory, non-positive, and overflowing width evidence fails closed

## Verification
- `scripts/verify-local.sh`
- `scripts/verify-local.sh --full`
- canonical layout gate: 8 / 18 / 24 pages and 98.9%+ line accuracy
- Vitest: 1,018 passed
- Playwright: 85 passed, 3 intentional skips, 0 failed
- bounded 8-page benchmark: body glyph/block/table/cell/rect/line/image and body SVG exact against rhwp; removing only first-party page numbering makes PDF bytes/pages/replay/diagnostics exact
