### PR TITLE
fix(hwpx): preserve cell continuation and mixed page orientation

### DIFF
--- a/crates/hwp-core/tests/hwpx_rhwp_parity.rs
+++ b/crates/hwp-core/tests/hwpx_rhwp_parity.rs
@@ -154,8 +154,9 @@ fn typeset(doc: &SemanticDoc) -> (usize, usize) {
     (r.pages.len(), r.pages.iter().map(|p| p.lines.len()).sum())
 }
 
-/// 우리가 rhwp lift 보다 더 살린 요소 — 정합 비교에서 빼되, 개수는 고정한다 (T0 / #42).
-/// 제외가 침묵 구멍이 되지 않게, 픽스처마다 이 숫자가 바뀌면 테스트가 깨진다.
+/// 본문 줄수 부분집합 비교에서 의도적으로 제외하는 typed surface. 자체 파서와 rhwp가 둘 다
+/// 표현하는 항목도 비교 축 밖이면 여기서 계수한다. 제외가 침묵 구멍이 되지 않게, 픽스처마다
+/// 이 숫자가 바뀌면 테스트가 깨진다.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct RevivedExtras {
     /// 본문·머리말에 보이는 폼 컨트롤 표식(`☐`/`☑`) 런 수.
@@ -245,25 +246,26 @@ fn strip_form_marks(blocks: &mut [Block]) {
     // 픽스처가 폼을 품으면 extras.form_control_marks 가 먼저 깨진다.
 }
 
-/// rhwp lift 가 표현하는 부분집합 — 본문 문단·표. 폼 표식·머리말 표·HWP5 가로 스왑은 뺀다.
+/// 두 파서가 공유하는 본문 줄수 부분집합. 폼 표식·머리말 표·용지 방향은 별도 typed
+/// regression에서 잠그므로 이 비교에서는 정규화한다.
 fn rhwp_expressible_subset(doc: &SemanticDoc) -> SemanticDoc {
     let mut d = doc.clone();
     for sec in &mut d.sections {
         sec.decorations.clear();
-        // HWPX 규약: 가로 여부는 저장된 상자에서 유도한다. rhwp 가 HWPX 에 남긴
-        // `landscape=true` + 세로 상자(WIDELY 오표기)에 HWP5 스왑을 적용하지 않는다.
+        // 이 테스트는 본문 줄수 부분집합만 비교한다. 방향은 parser·place·PDF의 별도
+        // regression이 잠그므로 두 후보 모두 stored box 방향으로 정규화한다.
         sec.page.landscape = sec.page.width > sec.page.height;
         strip_form_marks(&mut sec.blocks);
     }
     d
 }
 
-/// `benchmark1.hwpx` 에서 우리가 살린 요소의 개수. rhwp 경로는 HWPX Skeleton 이
-/// 세로 상자에 `landscape=true` 를 붙여 스왑 후보가 1이다. 머리말 표·폼은 이 픽스처에 없다.
+/// `benchmark1.hwpx`에서 부분집합 밖 typed surface의 개수. 자체 parser와 rhwp 모두 OWPML
+/// NARROWLY 구역 하나를 landscape swap으로 해석한다. 머리말 표·폼은 이 픽스처에 없다.
 const BENCH1_OURS_EXTRAS: RevivedExtras = RevivedExtras {
     form_control_marks: 0,
     header_footer_tables: 0,
-    landscape_swaps: 0,
+    landscape_swaps: 1,
 };
 const BENCH1_RHWP_EXTRAS: RevivedExtras = RevivedExtras {
     form_control_marks: 0,
@@ -292,9 +294,8 @@ fn floor_rows_to_stored(blocks: &mut [Block]) {
 /// **조판 파리티 (T0 부분집합 동등)** — 같은 `.hwpx` 를 우리 파서 / rhwp lift 로 읽어
 /// **rhwp 가 표현하는 본문 부분집합**만 같은 엔진으로 조판한다.
 ///
-/// #42 수리가 폼 컨트롤·머리말 표·HWP5 가로 스왑을 살리면, 그 요소는 rhwp lift 에 없거나
-/// (HWPX Skeleton 의 오표기 `landscape=true`) 다르게 부호화된다. 그 차이를 "우리 301 vs
-/// rhwp 282"처럼 전량 동등으로 잠그면 수리가 게이트를 깨뜨린다. 그래서:
+/// 폼 컨트롤·머리말 표·용지 방향은 본문 줄수와 다른 typed surface다. 그 차이를 "우리 301 vs
+/// rhwp 282"처럼 전량 동등으로 잠그면 독립적인 수리가 게이트를 깨뜨린다. 그래서:
 /// 1. 살린 요소는 비교에서 **명시적으로 제외**하고 (`rhwp_expressible_subset`)
 /// 2. 제외 개수는 `BENCH1_*_EXTRAS` 로 **고정**한다 — 침묵 구멍 방지.
 /// 3. 살린 요소 자체는 이 파일이 아닌 픽스처 테스트가 잠근다.
@@ -341,7 +342,7 @@ fn hwpx_parser_typesets_like_the_rhwp_lift() {
     assert_eq!(
         (op, ol),
         (22, 301),
-        "benchmark1.hwpx 부분집합 조판이 22쪽/301줄에서 벗어났다: {op}쪽/{ol}줄"
+        "benchmark1.hwpx 방향 정규화 부분집합 조판이 22쪽/301줄에서 벗어났다: {op}쪽/{ol}줄"
     );
     assert_eq!(
         ol, tl,

--- a/crates/hwp-hwpx/src/parse.rs
+++ b/crates/hwp-hwpx/src/parse.rs
@@ -336,9 +336,11 @@ fn parse_page_setup(sec_xml: &str) -> Option<PageSetup> {
     if let Some(h) = tag_attr_i32(pp_tag, "height") {
         page.height = h;
     }
-    // `landscape` is unreliable across authoring tools (portrait docs are sometimes tagged WIDELY);
-    // derive the actual orientation from the dimensions, which is all layout consumes.
-    page.landscape = page.width > page.height;
+    // OWPML stores the short/long paper edges in width/height and carries orientation separately:
+    // WIDELY=portrait, NARROWLY=landscape. This deliberately mirrors the already-vendored rhwp
+    // parser and our serializer; deriving solely from width/height loses mixed-orientation sections.
+    page.landscape = tag_attr_str(pp_tag, "landscape")
+        .is_some_and(|value| value.eq_ignore_ascii_case("NARROWLY"));
     // The page `<hp:margin …/>` lives inside `<hp:pagePr>`; take the first one AFTER the pagePr open.
     if let Some(mrel) = sec_xml[pp_end..].find("<hp:margin") {
         let mstart = pp_end + mrel;
@@ -376,10 +378,15 @@ fn parse_page_setup(sec_xml: &str) -> Option<PageSetup> {
 
 /// The `i32` value of attribute `name` (its first occurrence) within a single XML tag substring.
 fn tag_attr_i32(tag: &str, name: &str) -> Option<i32> {
+    tag_attr_str(tag, name)?.trim().parse().ok()
+}
+
+/// The borrowed value of attribute `name` (its first occurrence) within one XML opening tag.
+fn tag_attr_str<'a>(tag: &'a str, name: &str) -> Option<&'a str> {
     let pat = format!("{name}=\"");
     let s = tag.find(&pat)? + pat.len();
     let e = tag[s..].find('"')? + s;
-    tag[s..e].trim().parse().ok()
+    Some(&tag[s..e])
 }
 
 struct TblFrame {
@@ -405,6 +412,10 @@ struct TblFrame {
     cur_cell_has_margin: bool,
     /// The in-progress cell's `<hp:cellMargin left right top bottom>` (HWPUNIT).
     cur_cell_margin: Option<[i32; 4]>,
+    /// Stored cell lineseg `vertpos` continuity. A decrease means Hancom continued this cell on a
+    /// new page; retained only as a render-cache lower bound for clean HWPX input.
+    cur_cell_last_vert: Option<i32>,
+    cur_cell_page_segments: usize,
 }
 
 impl TblFrame {
@@ -421,6 +432,8 @@ impl TblFrame {
             cur_cell_sz: None,
             cur_cell_has_margin: false,
             cur_cell_margin: None,
+            cur_cell_last_vert: None,
+            cur_cell_page_segments: 0,
         }
     }
 }
@@ -748,10 +761,16 @@ fn parse_section(
                         let border_ref = attr_u64(&e, b"borderFillIDRef");
                         // noAdjust=1 → fixed row heights; 0/absent → auto-fit (content drives; don't floor).
                         let no_adjust = attr_usize(&e, b"noAdjust") == Some(1);
+                        let split_over_tall_cells = attr_str(&e, b"pageBreak")
+                            .as_deref()
+                            .is_some_and(|value| value.eq_ignore_ascii_case("CELL"));
+                        let repeat_first_row = attr_usize(&e, b"repeatHeader") == Some(1);
                         tbls.push(TblFrame::new(
                             Table {
                                 rows,
                                 cols,
+                                split_over_tall_cells,
+                                repeat_first_row,
                                 provenance: hwpx_prov(),
                                 ..Default::default()
                             },
@@ -771,6 +790,8 @@ fn parse_section(
                             f.cur_cell_has_margin = attr_usize(&e, b"hasMargin") == Some(1);
                             f.cur_cell_sz = None;
                             f.cur_cell_margin = None;
+                            f.cur_cell_last_vert = None;
+                            f.cur_cell_page_segments = 0;
                         }
                     }
                     // D1: a `<hp:pic>` opens picture-capture mode (its `<hp:sz>` + `<hc:img>` fill a
@@ -989,6 +1010,18 @@ fn parse_section(
                 b"nbSpace" => push_inline_char(&mut paras, '\u{00A0}'),
                 b"tab" => push_inline_char(&mut paras, '\t'),
                 b"lineBreak" => push_inline_char(&mut paras, '\n'),
+                b"lineseg" => {
+                    if let Some(frame) = tbls.last_mut().filter(|frame| frame.cell.is_some()) {
+                        if let Some(vert) = attr_i32(&e, b"vertpos") {
+                            if frame.cur_cell_last_vert.is_none() {
+                                frame.cur_cell_page_segments = 1;
+                            } else if frame.cur_cell_last_vert.is_some_and(|last| vert < last) {
+                                frame.cur_cell_page_segments += 1;
+                            }
+                            frame.cur_cell_last_vert = Some(vert);
+                        }
+                    }
+                }
                 // 필드 끝 마커 — 항상 self-closing. 짝(`beginIDRef`)을 그대로 들고 간다.
                 b"fieldEnd" => {
                     let id = attr_u64(&e, b"beginIDRef").unwrap_or(0) as u32;
@@ -1212,6 +1245,7 @@ fn parse_section(
                             // 열 경계가 다른 한글 표에서 최대 2배까지 틀리고, 그만큼 셀 글이 더
                             // 줄바꿈돼 행 높이가 부푼다.
                             c.width = (w > 0).then_some(w);
+                            c.source_page_segments = f.cur_cell_page_segments;
                             f.geoms.push(CellGeom {
                                 row: c.row,
                                 col: c.col,
@@ -1226,6 +1260,8 @@ fn parse_section(
                         f.cur_cell_sz = None;
                         f.cur_cell_has_margin = false;
                         f.cur_cell_margin = None;
+                        f.cur_cell_last_vert = None;
+                        f.cur_cell_page_segments = 0;
                     }
                 }
                 b"tbl" => {
@@ -2166,7 +2202,15 @@ pub(crate) mod tests {
             pg.height - (pg.margin_top + pg.margin_header) - (pg.margin_bottom + pg.margin_footer),
             68597
         );
-        assert!(!pg.landscape, "portrait derived from width<height");
+        assert!(!pg.landscape, "OWPML WIDELY is portrait");
+        let landscape = sec.replace("WIDELY", "NARROWLY");
+        let pg = parse_page_setup(&landscape).expect("landscape secPr");
+        assert!(pg.landscape, "OWPML NARROWLY is landscape");
+        assert_eq!(
+            (pg.width, pg.height),
+            (59528, 84186),
+            "orientation does not rewrite OWPML's stored short/long paper edges"
+        );
         // No secPr → None (the caller keeps PageSetup::default()).
         assert!(parse_page_setup("<hs:sec><hp:p/></hs:sec>").is_none());
     }
@@ -2397,6 +2441,39 @@ pub(crate) mod tests {
             })
             .collect();
         assert_eq!(flags, vec![false, true, false]);
+    }
+
+    #[test]
+    fn table_cell_page_break_is_captured_for_render_flow_only() {
+        let xml = r#"<hs:sec xmlns:hs="s" xmlns:hp="p"><hp:p><hp:run><hp:tbl rowCnt="1" colCnt="1" pageBreak="CELL" repeatHeader="1" noAdjust="0"><hp:tr><hp:tc><hp:subList><hp:p><hp:run><hp:t>A</hp:t></hp:run><hp:linesegarray><hp:lineseg vertpos="100"/><hp:lineseg vertpos="0"/></hp:linesegarray></hp:p></hp:subList><hp:cellAddr colAddr="0" rowAddr="0"/><hp:cellSpan colSpan="1" rowSpan="1"/><hp:cellSz width="1000" height="500"/></hp:tc></hp:tr></hp:tbl></hp:run></hp:p></hs:sec>"#;
+        let mut blocks = Vec::new();
+        parse_section(xml, &mut blocks, &mut Vec::new(), &Default::default()).unwrap();
+        let table = blocks
+            .iter()
+            .find_map(|block| match block {
+                Block::Table(table) => Some(table),
+                _ => None,
+            })
+            .expect("table");
+        assert!(table.split_over_tall_cells);
+        assert!(table.repeat_first_row);
+        assert_eq!(table.cells[0].source_page_segments, 2);
+
+        let none = xml.replace("pageBreak=\"CELL\"", "pageBreak=\"NONE\"");
+        let mut blocks = Vec::new();
+        parse_section(&none, &mut blocks, &mut Vec::new(), &Default::default()).unwrap();
+        let table = blocks
+            .iter()
+            .find_map(|block| match block {
+                Block::Table(table) => Some(table),
+                _ => None,
+            })
+            .expect("table");
+        assert!(!table.split_over_tall_cells);
+        assert!(
+            table.repeat_first_row,
+            "repeat header is independent of split mode"
+        );
     }
 
     /// 표만 품은 호스트 문단의 `pageBreak="1"` 도 그대로 실린다. 우리 블록 순서는 `[Table, 앵커]`

--- a/crates/hwp-jsx/src/lib.rs
+++ b/crates/hwp-jsx/src/lib.rs
@@ -1162,6 +1162,9 @@ fn parse_table(el: &JsxElement) -> Result<Table> {
             .unwrap_or(0),
         cells,
         keep_together,
+        // Render-IR only (HWPX `pageBreak="CELL"`) — JSX has no page-break provenance yet.
+        split_over_tall_cells: false,
+        repeat_first_row: false,
         col_widths,
         row_heights,
         // Render-IR only (HWPX auto-fit floor) — the JSX surface never carries it (defaults empty).
@@ -1276,6 +1279,7 @@ fn parse_cell(el: &JsxElement) -> Result<Cell> {
         padding: None,
         // 저장된 셀 실폭(074)도 JSX 투영 대상이 아니다 — 없으면 조판기가 열 격자로 근사한다.
         width: None,
+        source_page_segments: 0,
         dirty: Dirty(el.attrs.contains_key("data-dirty")),
     })
 }

--- a/crates/hwp-model/src/document.rs
+++ b/crates/hwp-model/src/document.rs
@@ -471,6 +471,15 @@ pub struct Table {
     /// taller than a fresh lane still uses the existing row-fragmentation fallback, so hostile or
     /// genuinely over-tall input cannot create an advance loop. `false` preserves legacy behavior.
     pub keep_together: bool,
+    /// RENDER-IR ONLY: an HWPX `<hp:tbl pageBreak="CELL">` may continue the text of one
+    /// auto-fit cell/row on the next page when that row is taller than a page body. The old
+    /// row-boundary-only paginator clipped such rows onto one page. Binary HWP and synthesized
+    /// tables leave this false until their equivalent provenance is modeled. Ordinary rows retain
+    /// their stored sizing; only a text stack taller than a fresh page lane activates continuation.
+    pub split_over_tall_cells: bool,
+    /// RENDER-IR ONLY: HWPX `repeatHeader="1"`. The first table row is repeated before a
+    /// continued `pageBreak="CELL"` slice and consumes flow height on every continuation page.
+    pub repeat_first_row: bool,
     /// Per-column widths (HWPUNIT), `cols` entries — for faithful column proportions on render.
     /// Empty when unknown (then the renderer falls back to auto-layout).
     pub col_widths: Vec<HwpUnit>,
@@ -693,6 +702,11 @@ pub struct Cell {
     /// 잡는다. 폭이 절반이면 셀 글이 두 배로 줄바꿈되고 그만큼 행이 부풀어(+4285 HWPUNIT) 페이지가
     /// 밀린다. 격자 근사는 폭 조절 UI 용으로 남기고, **조판/그리기는 저장된 실폭**을 쓴다.
     pub width: Option<HwpUnit>,
+    /// RENDER-IR ONLY: number of page fragments observed in this HWPX cell's stored line layout
+    /// (`vertpos` reset count + 1). Used only as a lower bound for an unedited
+    /// `pageBreak="CELL"` continuation; cell/table dirtiness or table geometry edits discard this
+    /// stale cache and return pagination to live measurement.
+    pub source_page_segments: usize,
     pub dirty: Dirty,
 }
 
@@ -813,6 +827,7 @@ impl Default for Cell {
             src_span: None,
             padding: None,
             width: None,
+            source_page_segments: 0,
             dirty: Dirty::default(),
         }
     }

--- a/crates/hwp-typeset/src/lib.rs
+++ b/crates/hwp-typeset/src/lib.rs
@@ -46,6 +46,9 @@ const SPACE: f64 = 0.3;
 const DEFAULT_LINESPACE: f64 = 1.6;
 /// Baseline as a fraction of the line height (matches Hancom's 850/1000 convention).
 pub(crate) const BASELINE_RATIO: f64 = 0.85;
+/// Stored HWPX lineseg caches are untrusted hints, never authority to manufacture unbounded pages.
+/// Real public fixtures need single digits; this ceiling is intentionally generous and fail-closed.
+const MAX_SOURCE_CELL_PAGE_SEGMENTS: usize = 256;
 
 /// 본문 상자(HWPUNIT) — `(원점_x, 원점_y, 너비, 높이)`. **쪽수 계산의 단일 진실**이라
 /// `NaiveLayout`·`place_doc`·`block_pages` 셋이 전부 이걸 거쳐야 LOCKSTEP 이 깨지지 않는다.
@@ -61,9 +64,9 @@ pub(crate) const BASELINE_RATIO: f64 = 0.85;
 /// **71435 짜리 본문 상자에 맞고 77103 에는 한참 못 미친다** — 즉 71435 가 한컴이 실제로 쓴
 /// 본문 높이다.
 /// Paper size used for layout/paint. HWP5 stores unswapped A4 + `landscape=true`;
-/// rhwp swaps at render (`PageAreas::from_page_def_for_page`). HWPX already stores
-/// display width/height (`landscape` derived from width>height), so we only swap
-/// when the flag is set *and* the stored box is still portrait.
+/// rhwp swaps at render (`PageAreas::from_page_def_for_page`). OWPML likewise stores
+/// short/long paper edges plus a separate NARROWLY/WIDELY orientation token, so we
+/// swap only when the landscape flag is set and the stored box is still portrait.
 pub fn display_paper(page: &PageSetup) -> (i32, i32) {
     if page.landscape && page.width < page.height {
         (page.height, page.width)
@@ -547,7 +550,7 @@ impl LayoutEngine for NaiveLayout {
                         if vert > 0.0 {
                             vert += t.outer_margin_top.max(0) as f64;
                         }
-                        let rows = table_row_heights(t, body_w, doc, fonts);
+                        let rows = table_page_flow_row_heights(t, body_w, body_h, doc, fonts);
                         let caption_metrics = table_caption_metrics(t, body_w, doc, fonts);
                         if let Some((_, caption_height)) = caption_metrics {
                             if keep_captioned_table_on_fresh_lane(
@@ -580,7 +583,27 @@ impl LayoutEngine for NaiveLayout {
                             );
                             vert += t.caption.as_ref().unwrap().spacing.max(0) as f64;
                         }
-                        for rh in rows {
+                        let repeated_header = if t.repeat_first_row {
+                            rows.first().copied().unwrap_or(0.0)
+                        } else {
+                            0.0
+                        };
+                        for (row, rh) in rows.into_iter().enumerate() {
+                            let header = if row > 0 { repeated_header } else { 0.0 };
+                            let continued = (body_h - header).max(1.0);
+                            let first_available = (body_h - vert).max(1.0);
+                            if let Some(fragments) =
+                                over_tall_cell_fragments(t, row, rh, first_available, continued)
+                            {
+                                for (index, fragment) in fragments.iter().enumerate() {
+                                    if index > 0 {
+                                        pages.push(new_page(page));
+                                        vert = header;
+                                    }
+                                    vert += fragment;
+                                }
+                                continue;
+                            }
                             // `rh <= body_h`: a row taller than the whole body never triggers a break — it
                             // can't fit a fresh page either, so a break would only waste the current page
                             // (the 자가진단표 1×1 mega-cell). Mirrors place_table + block_pages for lockstep.
@@ -1213,6 +1236,201 @@ pub(crate) fn keep_table_on_fresh_lane(
         && total > 0.0
         && total <= available
         && vert + total > available
+}
+
+/// Return page-body slices for an HWPX `pageBreak="CELL"` row that is taller than every fresh
+/// continuation lane. `first_available` is the remainder of the page where the row begins;
+/// `continued_available` excludes a repeated header row. This is deliberately fail-closed: only a
+/// single, text-only row can be continued. Nested tables and paint objects keep bounded overflow
+/// until their clipping/replay semantics are modeled.
+pub(crate) fn over_tall_cell_fragments(
+    table: &Table,
+    row: usize,
+    row_height: f64,
+    first_available: f64,
+    continued_available: f64,
+) -> Option<Vec<f64>> {
+    if !table.split_over_tall_cells
+        || row >= table.rows
+        || !row_height.is_finite()
+        || !first_available.is_finite()
+        || !continued_available.is_finite()
+        || row_height <= continued_available
+        || first_available <= 0.0
+        || continued_available <= 0.0
+    {
+        return None;
+    }
+    let participating: Vec<&Cell> = table
+        .cells
+        .iter()
+        .filter(|cell| {
+            cell.active && cell.row <= row && row < cell.row.saturating_add(cell.row_span.max(1))
+        })
+        .collect();
+    if participating.is_empty()
+        || participating.iter().any(|cell| {
+            cell.row != row
+                || cell.row_span.max(1) != 1
+                || cell.fill_image.is_some()
+                || cell.blocks.iter().any(|block| match block {
+                    Block::Paragraph(paragraph) => paragraph.runs.iter().any(|run| {
+                        run.content.iter().any(|inline| {
+                            !matches!(
+                                inline,
+                                Inline::Text(_)
+                                    | Inline::FieldBegin(_)
+                                    | Inline::FieldEnd(_)
+                                    | Inline::Bookmark(_)
+                            )
+                        })
+                    }),
+                    Block::Table(_) => true,
+                })
+        })
+    {
+        return None;
+    }
+
+    let mut fragments = Vec::new();
+    let mut remaining = row_height;
+    let first = remaining.min(first_available);
+    fragments.push(first);
+    remaining -= first;
+    while remaining > continued_available {
+        fragments.push(continued_available);
+        remaining -= continued_available;
+    }
+    if remaining > 0.0 {
+        fragments.push(remaining);
+    }
+    let source_minimum = if table.geometry_edited || table.dirty.is_dirty() {
+        0
+    } else {
+        participating
+            .iter()
+            .filter(|cell| !cell.dirty.is_dirty())
+            .map(|cell| cell.source_page_segments)
+            .max()
+            .unwrap_or(0)
+    };
+    if source_minimum > fragments.len()
+        && source_minimum > 1
+        && source_minimum <= MAX_SOURCE_CELL_PAGE_SEGMENTS
+    {
+        let capacity =
+            first_available + continued_available * source_minimum.saturating_sub(1) as f64;
+        if row_height <= capacity {
+            fragments.clear();
+            let mut remaining = row_height;
+            for index in 0..source_minimum {
+                let slots = (source_minimum - index) as f64;
+                let cap = if index == 0 {
+                    first_available
+                } else {
+                    continued_available
+                };
+                let later_capacity =
+                    continued_available * source_minimum.saturating_sub(index + 1) as f64;
+                let minimum_here = (remaining - later_capacity).max(f64::EPSILON);
+                let slice = (remaining / slots).max(minimum_here).min(cap);
+                fragments.push(slice);
+                remaining -= slice;
+            }
+            if let Some(last) = fragments.last_mut() {
+                *last += remaining;
+            }
+        }
+    }
+    (fragments.len() > 1).then_some(fragments)
+}
+
+/// Row heights used only for `pageBreak="CELL"` pagination. A stored HWPX row normally retains
+/// its parsed height; when its text itself is taller than a fresh continuation lane, however,
+/// CELL flow must paginate that text. Re-measure only those overflowing rows from content while
+/// leaving every ordinary/fitting row exact. Paint geometry and serialization remain untouched.
+pub(crate) fn table_page_flow_row_heights(
+    table: &Table,
+    avail_w: f64,
+    body_h: f64,
+    doc: &SemanticDoc,
+    fonts: &dyn FontMetricsProvider,
+) -> Vec<f64> {
+    let mut rows = table_row_heights(table, avail_w, doc, fonts);
+    if !table.split_over_tall_cells || rows.is_empty() {
+        return rows;
+    }
+    let header = if table.repeat_first_row && table.rows > 1 {
+        rows[0]
+    } else {
+        0.0
+    };
+    let continued_available = (body_h - header).max(1.0);
+    for (row, measured_height) in rows.iter_mut().enumerate() {
+        let Some(content_height) = continued_text_row_height(table, row, avail_w, doc, fonts)
+        else {
+            continue;
+        };
+        if over_tall_cell_fragments(
+            table,
+            row,
+            content_height,
+            continued_available,
+            continued_available,
+        )
+        .is_some()
+        {
+            *measured_height = content_height;
+        }
+    }
+    rows
+}
+
+/// Text stack height for a row that continues through a page boundary. Ordinary cell sizing trims
+/// the last line's leading from every paragraph; in one continued cell, that leading remains the
+/// inter-paragraph gap and only the final paragraph trims it. This distinction is activated only
+/// after the stack exceeds a continuation lane, so the established row-height gates stay untouched.
+fn continued_text_row_height(
+    table: &Table,
+    row: usize,
+    avail_w: f64,
+    doc: &SemanticDoc,
+    fonts: &dyn FontMetricsProvider,
+) -> Option<f64> {
+    let mut maximum = 0.0f64;
+    let mut seen = false;
+    for (cell_index, cell) in table.cells.iter().enumerate() {
+        if !cell.active || cell.row != row || cell.row_span.max(1) != 1 || cell.fill_image.is_some()
+        {
+            continue;
+        }
+        if cell
+            .blocks
+            .iter()
+            .any(|block| !matches!(block, Block::Paragraph(_)))
+        {
+            return None;
+        }
+        let text_width = table_cell_text_width(table, avail_w, cell_index);
+        let paragraph_count = cell.blocks.len();
+        let mut height = 0.0;
+        for (index, block) in cell.blocks.iter().enumerate() {
+            let Block::Paragraph(paragraph) = block else {
+                unreachable!("checked above")
+            };
+            height += cell_paragraph_height(paragraph, doc, text_width, fonts);
+            if index + 1 < paragraph_count {
+                let ratio = line_spacing_ratio(paragraph, doc);
+                if let Some(last) = layout_cell_paragraph(paragraph, doc, text_width, fonts).last()
+                {
+                    height += (last.vert_size * (ratio - 1.0)).max(0.0);
+                }
+            }
+        }
+        maximum = maximum.max(height + CELL_PAD);
+        seen = true;
+    }
+    seen.then_some(maximum)
 }
 
 /// Apply per-row MINIMUM-height overrides (HWPUNIT) from [`Table::row_heights`] as a FLOOR on the

--- a/crates/hwp-typeset/src/place.rs
+++ b/crates/hwp-typeset/src/place.rs
@@ -862,7 +862,7 @@ pub fn block_pages(doc: &SemanticDoc, fonts: &dyn FontMetricsProvider) -> Vec<Ve
                     // Row-level split accounting, matching place_doc/place_table: a row that doesn't fit
                     // the remaining body flows to the next page. Record the page where the FIRST row
                     // lands as the table's start page (outline/page-nav only needs the start).
-                    let row_h = crate::table_row_heights(t, body_w, doc, fonts);
+                    let row_h = crate::table_page_flow_row_heights(t, body_w, body_h, doc, fonts);
                     let caption_metrics = crate::table_caption_metrics(t, body_w, doc, fonts);
                     if let Some((_, caption_height)) = caption_metrics {
                         if crate::keep_captioned_table_on_fresh_lane(
@@ -906,7 +906,29 @@ pub fn block_pages(doc: &SemanticDoc, fonts: &dyn FontMetricsProvider) -> Vec<Ve
                         vert = 0.0;
                     }
                     sec_pages.push(page_idx); // the table starts here (where its first row lands)
+                    let repeated_header = if t.repeat_first_row {
+                        row_h.first().copied().unwrap_or(0.0)
+                    } else {
+                        0.0
+                    };
                     for (r, rh) in row_h.iter().enumerate() {
+                        let header = if r > 0 { repeated_header } else { 0.0 };
+                        if let Some(fragments) = crate::over_tall_cell_fragments(
+                            t,
+                            r,
+                            *rh,
+                            (body_h - vert).max(1.0),
+                            (body_h - header).max(1.0),
+                        ) {
+                            for (index, fragment) in fragments.iter().enumerate() {
+                                if index > 0 {
+                                    page_idx += 1;
+                                    vert = header;
+                                }
+                                vert += fragment;
+                            }
+                            continue;
+                        }
                         if r > 0 && vert + rh > body_h && vert > 0.0 && *rh <= body_h {
                             page_idx += 1;
                             vert = 0.0;
@@ -1581,7 +1603,7 @@ fn place_table(
     let col_x = column_offsets(t, avail_w);
     // Per-row heights: the SAME sizing the reservation summed (table_height), so fragment heights add up
     // exactly and the page boundaries match NaiveLayout's row-level accounting.
-    let row_h = row_heights(t, avail_w, doc, fonts);
+    let row_h = crate::table_page_flow_row_heights(t, avail_w, body_h, doc, fonts);
 
     let mut vert = vert;
     if !crate::has_flow_caption(t) && crate::keep_table_on_fresh_lane(t, &row_h, vert, body_h) {
@@ -1601,12 +1623,43 @@ fn place_table(
     let mut frag_first = 0usize; // first row index of the current page fragment
     let mut frag_top = mt + vert; // absolute y of the current fragment's top edge
     let mut y = mt + vert; // absolute running top of the next row
+    let repeated_header = if t.repeat_first_row {
+        row_h.first().copied().unwrap_or(0.0)
+    } else {
+        0.0
+    };
     for r in 0..t.rows {
+        let header = if r > 0 { repeated_header } else { 0.0 };
+        if let Some(fragments) = crate::over_tall_cell_fragments(
+            t,
+            r,
+            row_h[r],
+            (body_h - (y - mt)).max(1.0),
+            (body_h - header).max(1.0),
+        ) {
+            if frag_first < r {
+                flush_fragment(
+                    pages, t, doc, fonts, ml, frag_top, &col_x, &row_h, frag_first, r, section,
+                    block, frame,
+                );
+            }
+            let final_height = flush_over_tall_row(
+                pages, t, doc, fonts, ml, y, mt, &col_x, &row_h, r, &fragments, header, page,
+                section, block, frame,
+            );
+            frag_first = r + 1;
+            y = mt + final_height;
+            frag_top = y;
+            continue;
+        }
         // Break BEFORE row r if it would cross the body bottom — but never before a fragment's own first
         // row (a row taller than a whole page draws and clips, like before, rather than looping forever),
         // and never to give a row TALLER than the whole body its own page (it can't fit there either, so
         // the break would only waste the current page). `rh <= body_h` mirrors NaiveLayout/block_pages.
-        if r > frag_first && (y - mt) + row_h[r] > body_h && row_h[r] <= body_h {
+        if ((r > frag_first) || (r == frag_first && frag_top > mt))
+            && (y - mt) + row_h[r] > body_h
+            && row_h[r] <= body_h
+        {
             flush_fragment(
                 pages, t, doc, fonts, ml, frag_top, &col_x, &row_h, frag_first, r, section, block,
                 frame,
@@ -1618,11 +1671,123 @@ fn place_table(
         }
         y += row_h[r];
     }
-    flush_fragment(
-        pages, t, doc, fonts, ml, frag_top, &col_x, &row_h, frag_first, t.rows, section, block,
-        frame,
-    );
+    if frag_first < t.rows {
+        flush_fragment(
+            pages, t, doc, fonts, ml, frag_top, &col_x, &row_h, frag_first, t.rows, section, block,
+            frame,
+        );
+    }
     y - mt // final page-relative cursor (bottom of the last fragment)
+}
+
+/// Paint one text-only over-tall row as repeated page fragments. Geometry is emitted from an empty
+/// clone through the ordinary `flush_fragment` path, so cell boxes/provenance stay identical. Text is
+/// laid out once in the full logical row, then each glyph is translated into exactly one page slice;
+/// no paragraph is re-shaped per page and no glyph can be duplicated.
+#[allow(clippy::too_many_arguments)]
+fn flush_over_tall_row(
+    pages: &mut Vec<PlacedPage>,
+    table: &Table,
+    doc: &SemanticDoc,
+    fonts: &dyn FontMetricsProvider,
+    ml: f64,
+    first_top: f64,
+    body_top: f64,
+    col_x: &[f64],
+    row_heights: &[f64],
+    row: usize,
+    fragments: &[f64],
+    repeated_header: f64,
+    page: &PageSetup,
+    section: usize,
+    block: usize,
+    frame: Option<CellEdge>,
+) -> f64 {
+    let mut logical = vec![PlacedPage::default()];
+    flush_fragment(
+        &mut logical,
+        table,
+        doc,
+        fonts,
+        ml,
+        0.0,
+        col_x,
+        row_heights,
+        row,
+        row + 1,
+        section,
+        block,
+        None,
+    );
+    let logical_glyphs = std::mem::take(&mut logical[0].glyphs);
+
+    let mut shell = table.clone();
+    for cell in &mut shell.cells {
+        cell.blocks.clear();
+        cell.fill_image = None;
+    }
+    let mut slice_heights = row_heights.to_vec();
+    let mut offset = 0.0;
+    for (index, height) in fragments.iter().copied().enumerate() {
+        let slice_top = if index == 0 {
+            first_top
+        } else {
+            new_page(pages, page);
+            if repeated_header > 0.0 && row > 0 {
+                flush_fragment(
+                    pages,
+                    table,
+                    doc,
+                    fonts,
+                    ml,
+                    body_top,
+                    col_x,
+                    row_heights,
+                    0,
+                    1,
+                    section,
+                    block,
+                    frame,
+                );
+            }
+            body_top + repeated_header
+        };
+        slice_heights[row] = height;
+        flush_fragment(
+            pages,
+            &shell,
+            doc,
+            fonts,
+            ml,
+            slice_top,
+            col_x,
+            &slice_heights,
+            row,
+            row + 1,
+            section,
+            block,
+            frame,
+        );
+        let end = offset + height;
+        if let Some(current) = pages.last_mut() {
+            current.glyphs.extend(
+                logical_glyphs
+                    .iter()
+                    .filter(|glyph| glyph.baseline > offset && glyph.baseline <= end)
+                    .cloned()
+                    .map(|mut glyph| {
+                        glyph.baseline = slice_top + glyph.baseline - offset;
+                        glyph
+                    }),
+            );
+        }
+        offset = end;
+    }
+    if fragments.len() > 1 {
+        repeated_header + fragments.last().copied().unwrap_or(0.0)
+    } else {
+        (first_top - body_top) + fragments.last().copied().unwrap_or(0.0)
+    }
 }
 
 /// Column-aware row fragmentation twin of [`place_table`]. Row heights are measured at the
@@ -4624,6 +4789,108 @@ mod tests {
         assert_eq!(frags.len(), 1, "a fitting table is one fragment");
         assert_eq!((frags[0].first_row, frags[0].last_row), (0, 2));
         assert_eq!(placed.pages.len(), 1, "no extra pages");
+    }
+
+    #[test]
+    fn text_only_cell_row_taller_than_page_continues_without_duplicate_glyphs() {
+        use crate::LayoutEngine;
+
+        let mut table = n_row_table(2);
+        table.split_over_tall_cells = true;
+        table.cells[1].blocks = vec![Block::Paragraph(para(
+            "가\n나\n다\n라\n마\n바\n사\n아\n자\n차\n카\n타",
+        ))];
+        let doc = doc_with_page(vec![Block::Table(table.clone())], 5_000);
+        let placed = place_doc(&doc, &ApproxFontMetrics);
+        let naive = crate::NaiveLayout
+            .layout(&doc, &ApproxFontMetrics)
+            .expect("continued cell layout");
+        assert_eq!(placed.pages.len(), naive.pages.len(), "LOCKSTEP");
+        assert!(placed.pages.len() >= 3, "one over-tall row must continue");
+        assert_eq!(
+            placed
+                .pages
+                .iter()
+                .flat_map(|page| &page.glyphs)
+                .filter(|glyph| glyph.ch != '행')
+                .count(),
+            12,
+            "each continued cell glyph is painted exactly once"
+        );
+        assert_eq!(block_pages(&doc, &ApproxFontMetrics)[0], vec![0]);
+
+        table.cells[1].source_page_segments = 5;
+        assert_eq!(
+            crate::over_tall_cell_fragments(&table, 1, 12_000.0, 4_000.0, 5_000.0)
+                .expect("stored clean continuation lower bound")
+                .len(),
+            5,
+            "clean HWPX lineseg resets preserve a content-free minimum fragment count"
+        );
+        table.geometry_edited = true;
+        assert_eq!(
+            crate::over_tall_cell_fragments(&table, 1, 12_000.0, 4_000.0, 5_000.0)
+                .expect("edited geometry falls back to measured continuation")
+                .len(),
+            3,
+            "stale source segment caches cannot constrain an edited table"
+        );
+        table.geometry_edited = false;
+        table.cells[1].source_page_segments = 257;
+        assert_eq!(
+            crate::over_tall_cell_fragments(&table, 1, 12_000.0, 4_000.0, 5_000.0)
+                .expect("oversize untrusted cache falls back to measurement")
+                .len(),
+            3,
+            "hostile lineseg reset counts cannot manufacture unbounded pages"
+        );
+        table.cells[1].source_page_segments = 5;
+        table.repeat_first_row = true;
+        let source_locked = doc_with_page(vec![Block::Table(table.clone())], 5_000);
+        let source_placed = place_doc(&source_locked, &ApproxFontMetrics);
+        assert!(source_placed.pages.len() >= 5);
+        assert_eq!(
+            source_placed
+                .pages
+                .iter()
+                .flat_map(|page| &page.glyphs)
+                .filter(|glyph| glyph.ch == '행')
+                .count(),
+            source_placed.pages.len(),
+            "the first row is repeated once per continued page"
+        );
+        assert_eq!(
+            source_placed
+                .pages
+                .iter()
+                .flat_map(|page| &page.glyphs)
+                .filter(|glyph| glyph.ch != '행')
+                .count(),
+            12,
+            "source fragment lower bounds cannot duplicate or lose body glyphs"
+        );
+        assert_eq!(
+            crate::NaiveLayout
+                .layout(&source_locked, &ApproxFontMetrics)
+                .unwrap()
+                .pages
+                .len(),
+            source_placed.pages.len(),
+            "source-fragment continuation remains LOCKSTEP"
+        );
+
+        table.split_over_tall_cells = false;
+        let legacy = doc_with_page(vec![Block::Table(table)], 5_000);
+        assert_eq!(place_doc(&legacy, &ApproxFontMetrics).pages.len(), 1);
+        assert_eq!(
+            crate::NaiveLayout
+                .layout(&legacy, &ApproxFontMetrics)
+                .unwrap()
+                .pages
+                .len(),
+            1,
+            "pageBreak=NONE remains bounded legacy overflow"
+        );
     }
 
     #[test]

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,6 +3,44 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
+- 갱신: 2026-08-24 · Codex(sol) — **#95/#96 full green · PR 직전**.
+  focused HWPX **96**·typeset **97**·hostile **7** 및 clippy green. quick/full은 canonical
+  **8/18/24 + 98.9%+**, public corpus 계약 **84**, catalog **259/12 families/120 pairs**,
+  oracle **82**, PDF visual **51**, wasm **7,825,742B**, JS/crosscheck/i18n, Vitest
+  **1,018**, Chromium **85 pass/3 intentional skip/0 fail**이다. 첫 full의 유일 실패는 sandbox
+  port 3100 EPERM이며 승인된 로컬 E2E로 환경 원인을 해소했다. OWPML 방향 복원으로
+  benchmark1.hwpx는 종전 잘못된 세로 해석의 비-참값 잠금 **22→30**으로 의도 이동했고,
+  stored-lineseg 25쪽과의 잔여 +5는 숨기지 않았다. body exact **89.5%**·within1 **98.2%** 및
+  cell floors 5/5·9/9는 불변, oracle logic/tolerance/82 baseline은 무변경이다. 임시 node/target
+  링크를 제거했고 generated wasm/assets diff 0, rhwp exact gitlink clean이다. **다음:** privacy/diff
+  최종 감사→commit/push→PR `Closes #95`·`Closes #96`→exact-head CI/comments green merge→#93/#114 동기화.
+
+- 갱신: 2026-08-24 · Codex(sol) — **#95 구현·T1 실측 완료 · #96도 함께 해소**.
+  비공개 official pair를 원문 없이 구조화해 #95의 원인을 HWPX `pageBreak=CELL`인 1행짜리
+  text-only over-tall cell 2곳과 repeat-header, 저장 lineseg의 페이지별 `vertpos` reset으로
+  최소화했다. 자체 parser가 CELL/repeatHeader와 clean cell의 fragment lower-bound만 IR에
+  보존하고, `place_doc`·`NaiveLayout`·`block_pages`가 같은 fail-closed 분할을 쓴다. nested
+  table/image/object, dirty cell/table, geometry edit는 source cache를 거부한다. 결과 pair 03은
+  **4→6쪽**, body **25/25 exact**, cell **77/83 exact·83/83 within1**, LOCKSTEP이며 T1 visual이
+  `structural_mismatch`→**6쪽 scored_report**로 전환됐다. 동시에 자체 HWPX parser가 무시하던
+  OWPML 방향 계약(`WIDELY=portrait`, `NARROWLY=landscape`)을 vendored rhwp·자체 serializer와
+  일치시켜 pair 03의 1~3 세로/4~6 가로, #96 pair 04의 **1~2 세로/3 가로** MediaBox가 official과
+  구조 exact가 됐다. pair 04 cell lines도 **111/111 exact, 149=149**로 회복됐다. oracle scoring은
+  무변경이고 visual은 threshold 없는 report-only다. **다음:** 문서 표 갱신→focused/workspace→
+  quick/full gate→privacy/vendor/generated audit→PR에서 `Closes #95`·`Closes #96`→CI green merge.
+
+- 갱신: 2026-08-24 · Codex(sol) — **PR #205 병합 · #95 착수**.
+  PR #205 exact head `99f6cd75`의 issue-link·build-test·licenses green, CLEAN/MERGEABLE,
+  review/general/inline 댓글 0을 확인하고 protected main `51741a51`로 squash 병합했다. #204는
+  close됐고 #94에 body/SVG exact 및 owned page-number를 제외한 PDF byte exact 근거와
+  production rhwp·eligible=false 유지 결정을 동기화했다. 다음 P0는 공식 MOHW HWPX/PDF pair에서
+  own export가 **6쪽을 4쪽으로 축소**하는 #95다. #101 visual calibration과 #102 PDF replay는 이미
+  완료됐으므로 중복 없이 table/cell pagination 원인을 최소화한다. 원문·파일명·로컬 경로·hash/raw는
+  공개하지 않고, synthetic fixture로만 회귀를 커밋한다. `place_doc`/`NaiveLayout` LOCKSTEP,
+  oracle scoring 불변, 8/18/24 및 98.9%+ 게이트 유지가 수용 조건이다. **다음:** private pair를
+  content-free 구조 통계로 재현→section/table/cell flow의 첫 divergent decision을 추적→최소
+  synthetic regression→두 layout 경로 동시 수리→#93 report-only 재측정.
+
 - 갱신: 2026-08-24 · Codex(sol) — **#204 full green · PR 직전**.
   `scripts/verify-local.sh` quick와 `--full` 모두 green: fmt/clippy/workspace/rhwp-feature/PDF 51,
   canonical **8/18/24 + 98.9%+**, corpus 계약 84·catalog 259/12 families/120 pairs,

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,12 @@
 
 ---
 
+## 2026-08-24 (Codex sol) · #95/#96 HWPX page structure
+- CELL continuation/repeat-header와 clean lineseg fragment lower-bound를 자체 parser/typesetter에 구현.
+- pair03 4→6쪽, pair04 final landscape; 두 T1 report 모두 structural match/scored, threshold 없음.
+- quick/full green: 8/18/24+98.9%, Vitest 1,018, Chromium 85 pass/3 skip; vendor/generated diff 0.
+- 다음: commit/push→`Closes #95`·`Closes #96` PR→exact-head CI/merge→#93/#114 동기화.
+
 ## 2026-08-24 (Codex sol) · #204 HWP5 body render exact
 - live cell width(+176), caption cap(143→71.5), HWP5 row-floor semantics를 fail-closed로 교정.
 - 8쪽 body placement/SVG exact; own page-number 제거 시 rhwp PDF bytes/pages/replay/diagnostics exact.

--- a/docs/PDF-VISUAL-ORACLE.md
+++ b/docs/PDF-VISUAL-ORACLE.md
@@ -373,13 +373,19 @@ Source binaries and full reports remained under ignored/private paths; no docume
 |---|---:|---|---:|---:|---|
 | 01 | 4 → 4 | `scored_report` | 0.150700 | 0.318802 | typography/table geometry drift |
 | 02 | 4 → 4 | `scored_report` | 0.123952 | 0.173607 | typography/table geometry drift |
-| 03 | 4 → 6 | `structural_mismatch` | — | — | table/cell flow collapse; #95 |
-| 04 | 3 → 3 | `structural_mismatch` | — | — | final page portrait vs official landscape; #96 |
+| 03 | 6 → 6 | `scored_report` | 0.151803 | 0.283513 | CELL continuation restored; pages 1–3 portrait, 4–6 landscape; #95 |
+| 04 | 3 → 3 | `scored_report` | 0.124490 | 0.175401 | final-page landscape restored; #96 |
 | 05 | 9 → 9 | `scored_report` | 0.074480 | 0.257094 | page count alone hides large visual drift |
 
-All three scored documents had worst-tile recall `0.0`. This run proves that the structure-first
-stage and local-region alarm expose failures that a page-count or white-background-dominated score
-would miss. It does **not** provide enough samples to define an acceptance threshold.
+The three documents scored in the initial pass had worst-tile recall `0.0`. This run proves that the
+structure-first stage and local-region alarm expose failures that a page-count or
+white-background-dominated score would miss. It does **not** provide enough samples to define an
+acceptance threshold.
+
+The #95/#96 follow-up on 2026-08-24 re-ran the same two private T1 pairs after the own HWPX parser
+and paginator fixes. Both are now structurally comparable, so pixel metrics are reported instead of
+silently assigning structural failures a score. Both still have worst-tile recall `0.0`; restoring
+page count and orientation is therefore a prerequisite, not evidence of complete visual fidelity.
 
 ## Tests
 

--- a/scripts/verify-local.sh
+++ b/scripts/verify-local.sh
@@ -82,10 +82,12 @@ hwpx_ge() { awk -v a="$1" -v b="$2" 'BEGIN{exit !(a+0 >= b-0)}'; }
 hwpx_check() { cargo run -q -p auto-hwp-cli --features "shaper rhwp" -- layout-check "$1"; }
 
 # ① benchmark1.hwpx — 쪽수 + 본문 문단 줄수 exact/±1 바닥.
-#    2026-07-30 실측 기준선: 우리 22쪽 · 정확 291/325(89.5%) · ±1 319/325(98.2%).
+#    2026-08-24 실측 기준선: 우리 30쪽 · 정확 291/325(89.5%) · ±1 319/325(98.2%).
+#    OWPML NARROWLY 구역을 세로로 무시하던 parser 결함(#96)을 고쳐 22→30으로 이동했다.
+#    stored-lineseg 비교는 25쪽이라 남은 5쪽 과대조판은 숨기지 않는다. 줄수 바닥은 완전 불변.
 #    (같은 파일이 apps/hwp-lab/public/samples/sample-18p.hwpx 로도 배포된다 — 한 번만 잰다.)
 HWPX_MAIN=benchmarks/benchmark1.hwpx
-HWPX_MAIN_PAGES=22
+HWPX_MAIN_PAGES=30
 HWPX_MAIN_EXACT_MIN=89.5
 HWPX_MAIN_W1_MIN=98.2
 out=$(hwpx_check "$HWPX_MAIN")


### PR DESCRIPTION
Closes #95
Closes #96

## What changed
- preserve HWPX `pageBreak=CELL`, repeat-header, and clean stored-line fragment provenance in first-party IR
- continue fail-closed text-only over-tall rows through the shared `place_doc` / `NaiveLayout` / `block_pages` flow without duplicating glyphs
- reject nested objects, dirty/geometry-edited caches, and hostile fragment counts above a bounded ceiling
- parse OWPML `WIDELY` as portrait and `NARROWLY` as landscape, matching the vendored fork and our serializer
- refresh the explicitly non-ground-truth HWPX regression lock from 22 to 30 pages after the orientation correction; its stored-lineseg 25-page gap remains visible and all line floors stay unchanged

## Evidence
- official pair A: own PDF 4→6 pages; pages 1–3 portrait and 4–6 landscape; body lines 25/25 exact; cell lines 77/83 exact and 83/83 within one
- official pair B: 3 pages with final page landscape; cell lines 111/111 exact and 149=149
- both T1 comparisons moved from structural mismatch to scored report-only; no visual threshold or pass claim was introduced
- synthetic continuation, repeated-header, dirty-cache, hostile-cache, mixed-orientation, and LOCKSTEP regressions

## Verification
- `scripts/verify-local.sh` green
- `scripts/verify-local.sh --full` green except sandbox-local port EPERM; the exact Chromium suite was rerun with local port access: 85 passed, 3 intentional skips, 0 failed
- canonical layout 8/18/24 pages and 98.9%+ unchanged
- Vitest 1,018 passed; PDF visual tests 51 passed; public corpus contract 84 passed; oracle summary 82 unchanged
- `external/rhwp`, generated wasm/assets, oracle scoring, and visual tolerances unchanged

Private source documents and reports remain outside Git; this PR contains only synthetic fixtures and content-free measurements.