### PR TITLE
fix(typeset): preserve inline object atom flow

### DIFF
--- a/crates/hwp-core/src/lib.rs
+++ b/crates/hwp-core/src/lib.rs
@@ -1069,9 +1069,15 @@ mod inplace_tests {
         ))
         .unwrap();
         let doc = Engine::open(&bytes).unwrap();
-        let eqs = doc.sections.iter().flat_map(|s| &s.blocks).filter(|b| matches!(b,
-            Block::Paragraph(p) if p.runs.iter().flat_map(|r| &r.content).any(|i| matches!(i, Inline::Equation(_))))).count();
-        assert!(eqs > 0, "lift captured equations: {eqs}");
+        let paragraphs = doc
+            .sections
+            .iter()
+            .flat_map(|section| &section.blocks)
+            .filter(|block| matches!(block, Block::Paragraph(_)))
+            .count();
+        let eqs = collect_equations(&doc).len();
+        assert_eq!(paragraphs, 19, "one rhwp paragraph stays one IR paragraph");
+        assert_eq!(eqs, 44, "every equation control stays inline on its host");
 
         let out = serialize_hwpx(&doc).unwrap();
         assert!(validate_hwpx(&out).ok, "equation output open-safe");

--- a/crates/hwp-export/examples/svg_pdf_parity.rs
+++ b/crates/hwp-export/examples/svg_pdf_parity.rs
@@ -89,6 +89,7 @@ fn fixture_doc() -> SemanticDoc {
         },
         width: 9000,
         height: 3600,
+        treat_as_char: true,
         version: "Equation Version 60".into(),
         rendered_svg: Some(
             r##"<g class="hwp-equation"><text x="8" y="20" font-size="18" font-style="italic" fill="#111">x</text><line x1="3" y1="25" x2="45" y2="25" stroke="#111" stroke-width="1.5"/><text x="18" y="43" font-size="16" fill="#111">2</text><path d="M58 8 Q70 24 58 42" fill="none" stroke="#0655c9" stroke-width="2" stroke-linecap="round"/></g>"##.into(),
@@ -97,6 +98,7 @@ fn fixture_doc() -> SemanticDoc {
     let chart = ChartRef {
         width: 24000,
         height: 13500,
+        treat_as_char: true,
         rendered_svg: Some(
             r##"<g class="hwp-gen-chart" data-chart-type="bar"><rect x="0" y="0" width="320" height="180" fill="#fff" stroke="#ccc" stroke-width="1"/><line x1="35" y1="145" x2="300" y2="145" stroke="#777"/><rect x="60" y="85" width="38" height="60" fill="#4472c4"/><rect x="125" y="52" width="38" height="93" fill="#ed7d31"/><rect x="190" y="105" width="38" height="40" fill="#70ad47"/><polyline points="60,72 144,35 228,82" fill="none" stroke="#a50021" stroke-width="3" stroke-linejoin="round"/><circle cx="144" cy="35" r="4" fill="#a50021"/><text x="160" y="22" font-family="sans-serif" font-size="14" font-weight="700" text-anchor="middle" fill="#222">PDF parity</text></g>"##.into(),
         ),

--- a/crates/hwp-export/src/lib.rs
+++ b/crates/hwp-export/src/lib.rs
@@ -730,6 +730,7 @@ mod tests {
                         color: Color::default(),
                         width: 1000,
                         height: 1000,
+                        treat_as_char: true,
                         version: String::new(),
                         // No precomputed SVG → the honest [수식] placeholder (this test asserts exactly
                         // that fallback; the rendered-SVG path is covered by a dedicated test below).
@@ -778,6 +779,7 @@ mod tests {
                     color: Color::default(),
                     width: 1500, // HWPUNIT → 1500/75 = 20px box width
                     height: 750, // → 10px
+                    treat_as_char: true,
                     version: String::new(),
                     rendered_svg: Some("<text x=\"0\" y=\"9\">1</text>".into()),
                 })],
@@ -821,6 +823,7 @@ mod tests {
                         content: vec![Inline::Chart(ChartRef {
                             width: 1500, // → 20px
                             height: 750, // → 10px
+                            treat_as_char: true,
                             rendered_svg: svg.map(str::to_string),
                         })],
                     }],

--- a/crates/hwp-export/src/pdf.rs
+++ b/crates/hwp-export/src/pdf.rs
@@ -1251,6 +1251,7 @@ mod tests {
             content: vec![Inline::Chart(ChartRef {
                 width: 30000,
                 height: 19500,
+                treat_as_char: true,
                 rendered_svg: Some(
                     "<g class=\"hwp-gen-chart\"><rect x=\"0\" y=\"0\" width=\"10\" height=\"10\"/></g>"
                         .into(),
@@ -1295,6 +1296,7 @@ mod tests {
                     },
                     width: 3000,
                     height: 1500,
+                    treat_as_char: true,
                     version: "Equation Version 60".into(),
                     rendered_svg: Some(svg.into()),
                 })],

--- a/crates/hwp-hwpx/src/parse.rs
+++ b/crates/hwp-hwpx/src/parse.rs
@@ -472,6 +472,7 @@ struct EqAccum {
     color: Color,
     width: i32,  // <hp:sz width> (HWPUNIT)
     height: i32, // <hp:sz height>
+    treat_as_char: bool,
     version: String,
 }
 
@@ -496,6 +497,7 @@ impl EqAccum {
                     a: 255,
                 }),
             version: attr_str(e, b"version").unwrap_or_default(),
+            treat_as_char: true,
             ..Default::default()
         }
     }
@@ -509,6 +511,7 @@ impl EqAccum {
             color: self.color,
             width: self.width,
             height: self.height,
+            treat_as_char: self.treat_as_char,
             version: self.version,
             // 파생 캐시 — rhwp 의 수식 엔진이 필요하고 이 크레이트는 rhwp 를 모른다(wasm 대상).
             // `None` = 예전과 바이트동일한 스텁 박스 폴백이라 순수 가산이다.
@@ -917,14 +920,16 @@ fn parse_section(
             // Inside a `<hp:equation>`: only its `<hp:sz>` matters (the reserved box the typesetter
             // and the own-render stub use). Everything else (pos/outMargin/…) is structural.
             Ok(Event::Empty(e)) if eq.is_some() => {
-                if e.local_name().as_ref() == b"sz" {
-                    if let Some(a) = eq.as_mut() {
+                if let Some(a) = eq.as_mut() {
+                    if e.local_name().as_ref() == b"sz" {
                         if let Some(w) = attr_i32(&e, b"width") {
                             a.width = w;
                         }
                         if let Some(h) = attr_i32(&e, b"height") {
                             a.height = h;
                         }
+                    } else if e.local_name().as_ref() == b"pos" {
+                        a.treat_as_char = attr_usize(&e, b"treatAsChar") != Some(0);
                     }
                 }
                 mark_not_simple(&mut paras);
@@ -1772,7 +1777,7 @@ pub(crate) mod tests {
         let xml = r##"<hs:sec xmlns:hs="s" xmlns:hp="p"><hp:p><hp:run charPrIDRef="7"><hp:t>앞</hp:t>
           <hp:equation id="9" version="Equation Version 60" baseLine="70" textColor="#FF0000" baseUnit="1200" lineMode="CHAR" font="HYhwpEQ">
             <hp:sz width="4300" height="2100" widthRelTo="ABSOLUTE" heightRelTo="ABSOLUTE" protect="0"/>
-            <hp:pos treatAsChar="1"/><hp:outMargin left="56" right="56" top="0" bottom="0"/>
+            <hp:pos treatAsChar="0"/><hp:outMargin left="56" right="56" top="0" bottom="0"/>
             <hp:script>1 over 2 + sqrt {a &lt; b}</hp:script>
           </hp:equation><hp:t>뒤</hp:t></hp:run></hp:p></hs:sec>"##;
         let blocks = parse_sec(xml);
@@ -1790,6 +1795,10 @@ pub(crate) mod tests {
         assert_eq!(eq.baseline, 70);
         assert_eq!(eq.color, Color::from_hex("#FF0000").unwrap());
         assert_eq!(eq.version, "Equation Version 60");
+        assert!(
+            !eq.treat_as_char,
+            "floating equation placement survives parse"
+        );
         // 파생 캐시는 rhwp 의존 → 항상 None(렌더러가 스텁 박스로 폴백).
         assert!(eq.rendered_svg.is_none());
         // 주변 텍스트는 그대로 살아 있어야 한다("사용자 콘텐츠 삭제 금지").

--- a/crates/hwp-hwpx/src/serialize.rs
+++ b/crates/hwp-hwpx/src/serialize.rs
@@ -2115,10 +2115,11 @@ fn equation_xml(eqid: u64, eq: &EquationRef) -> String {
     let baseline = eq.baseline;
     let color = eq.color.to_hex();
     let script = xml_escape(&eq.script);
+    let treat_as_char = usize::from(eq.treat_as_char);
     format!(
         "<hp:equation id=\"{eqid}\" zOrder=\"0\" numberingType=\"EQUATION\" textWrap=\"TOP_AND_BOTTOM\" textFlow=\"BOTH_SIDES\" lock=\"0\" dropcapstyle=\"None\" version=\"{version}\" baseLine=\"{baseline}\" textColor=\"{color}\" baseUnit=\"{base_unit}\" lineMode=\"CHAR\" font=\"{font}\">\
 <hp:sz width=\"{w}\" widthRelTo=\"ABSOLUTE\" height=\"{h}\" heightRelTo=\"ABSOLUTE\" protect=\"0\"/>\
-<hp:pos treatAsChar=\"1\" affectLSpacing=\"0\" flowWithText=\"1\" allowOverlap=\"0\" holdAnchorAndSO=\"0\" vertRelTo=\"PARA\" horzRelTo=\"PARA\" vertAlign=\"TOP\" horzAlign=\"LEFT\" vertOffset=\"0\" horzOffset=\"0\"/>\
+<hp:pos treatAsChar=\"{treat_as_char}\" affectLSpacing=\"0\" flowWithText=\"1\" allowOverlap=\"0\" holdAnchorAndSO=\"0\" vertRelTo=\"PARA\" horzRelTo=\"PARA\" vertAlign=\"TOP\" horzAlign=\"LEFT\" vertOffset=\"0\" horzOffset=\"0\"/>\
 <hp:outMargin left=\"56\" right=\"56\" top=\"0\" bottom=\"0\"/>\
 <hp:script>{script}</hp:script></hp:equation>"
     )
@@ -2453,6 +2454,7 @@ mod tests {
             color: Color::from_hex("#000000").unwrap(),
             width: 3000,
             height: 1500,
+            treat_as_char: true,
             version: String::new(),
             rendered_svg: None,
         }

--- a/crates/hwp-jsx/src/equality.rs
+++ b/crates/hwp-jsx/src/equality.rs
@@ -122,7 +122,10 @@ fn inline_eq(a: &Inline, b: &Inline) -> bool {
     match (a, b) {
         (Inline::Text(x), Inline::Text(y)) => x == y,
         (Inline::Image(x), Inline::Image(y)) => {
-            x.bin_ref == y.bin_ref && x.width == y.width && x.height == y.height
+            x.bin_ref == y.bin_ref
+                && x.width == y.width
+                && x.height == y.height
+                && x.treat_as_char == y.treat_as_char
         }
         (Inline::Equation(x), Inline::Equation(y)) => {
             x.script == y.script
@@ -132,11 +135,14 @@ fn inline_eq(a: &Inline, b: &Inline) -> bool {
                 && x.color == y.color
                 && x.width == y.width
                 && x.height == y.height
+                && x.treat_as_char == y.treat_as_char
                 && x.version == y.version
         }
         // Issue 062-7: a chart's identity is its reserved box; the SVG is a derived cache (like the
         // equation's rendered_svg, excluded above), so it doesn't gate value-equality.
-        (Inline::Chart(x), Inline::Chart(y)) => x.width == y.width && x.height == y.height,
+        (Inline::Chart(x), Inline::Chart(y)) => {
+            x.width == y.width && x.height == y.height && x.treat_as_char == y.treat_as_char
+        }
         (Inline::FieldBegin(x), Inline::FieldBegin(y)) => {
             x.id == y.id && x.field_type == y.field_type && x.command == y.command
         }

--- a/crates/hwp-jsx/src/lib.rs
+++ b/crates/hwp-jsx/src/lib.rs
@@ -351,7 +351,8 @@ fn emit_inline(inl: &Inline) -> JsxNode {
             JsxElement::new(Tag::Image)
                 .with_attr("src", format!("assets/{}", img.bin_ref))
                 .with_attr("data-w", img.width.to_string())
-                .with_attr("data-h", img.height.to_string()),
+                .with_attr("data-h", img.height.to_string())
+                .with_attr("data-tac", if img.treat_as_char { "1" } else { "0" }),
         ),
         Inline::Equation(e) => {
             // The editable model rides in `data-b64` (round-trips every field incl. the cached SVG).
@@ -361,7 +362,8 @@ fn emit_inline(inl: &Inline) -> JsxNode {
             let mut el = JsxElement::new(Tag::Equation)
                 .with_attr("data-b64", b64(&encode_equation(e)))
                 .with_attr("data-w", e.width.to_string())
-                .with_attr("data-h", e.height.to_string());
+                .with_attr("data-h", e.height.to_string())
+                .with_attr("data-tac", if e.treat_as_char { "1" } else { "0" });
             if let Some(svg) = &e.rendered_svg {
                 el = el.with_attr("data-eq-svg", svg.clone());
             }
@@ -373,7 +375,8 @@ fn emit_inline(inl: &Inline) -> JsxNode {
             // [차트] placeholder (rhwp-off / legacy OLE / un-rendered).
             let mut el = JsxElement::new(Tag::Chart)
                 .with_attr("data-w", c.width.to_string())
-                .with_attr("data-h", c.height.to_string());
+                .with_attr("data-h", c.height.to_string())
+                .with_attr("data-tac", if c.treat_as_char { "1" } else { "0" });
             if let Some(svg) = &c.rendered_svg {
                 el = el.with_attr("data-chart-svg", svg.clone());
             }
@@ -671,6 +674,7 @@ fn encode_equation(e: &EquationRef) -> Vec<u8> {
         color: [e.color.r, e.color.g, e.color.b, e.color.a],
         width: e.width,
         height: e.height,
+        treat_as_char: e.treat_as_char,
         version: e.version.clone(),
         rendered_svg: e.rendered_svg.clone(),
     })
@@ -692,6 +696,7 @@ fn decode_equation(bytes: &[u8]) -> EquationRef {
         },
         width: b.width,
         height: b.height,
+        treat_as_char: b.treat_as_char,
         version: b.version,
         rendered_svg: b.rendered_svg,
     }
@@ -1052,7 +1057,7 @@ fn parse_inline(node: &JsxNode) -> Result<Inline> {
                     .get("data-h")
                     .and_then(|v| v.parse().ok())
                     .unwrap_or(0),
-                ..Default::default()
+                treat_as_char: e.attrs.get("data-tac").map(|v| v != "0").unwrap_or(true),
             })),
             Some(Tag::Equation) => {
                 let bytes = unb64(e.attrs.get("data-b64").map(String::as_str).unwrap_or(""))
@@ -1070,6 +1075,7 @@ fn parse_inline(node: &JsxNode) -> Result<Inline> {
                     .get("data-h")
                     .and_then(|v| v.parse().ok())
                     .unwrap_or(0),
+                treat_as_char: e.attrs.get("data-tac").map(|v| v != "0").unwrap_or(true),
                 rendered_svg: e
                     .attrs
                     .get("data-chart-svg")
@@ -1389,11 +1395,17 @@ struct EqBlob {
     color: [u8; 4],
     width: i32,
     height: i32,
+    #[serde(default = "default_true")]
+    treat_as_char: bool,
     version: String,
     /// Precomputed equation SVG fragment (issue 062-5). `#[serde(default)]` keeps blobs written
     /// before this field parseable (→ `None`), so the JSX round-trip stays backward-compatible.
     #[serde(default)]
     rendered_svg: Option<String>,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 #[derive(Serialize, Deserialize)]

--- a/crates/hwp-jsx/tests/roundtrip.rs
+++ b/crates/hwp-jsx/tests/roundtrip.rs
@@ -503,6 +503,7 @@ fn t5_raw_and_passthrough_byte_identical() {
                 },
                 width: 10,
                 height: 20,
+                treat_as_char: true,
                 version: "Equation Version 60".into(),
                 rendered_svg: Some("<text>1</text>".into()),
             }),
@@ -510,6 +511,7 @@ fn t5_raw_and_passthrough_byte_identical() {
             Inline::Chart(ChartRef {
                 width: 30000,
                 height: 20000,
+                treat_as_char: true,
                 rendered_svg: Some("<g class=\"hwp-ooxml-chart\"><rect/></g>".into()),
             }),
             Inline::FieldBegin(FieldMarker {

--- a/crates/hwp-model/src/document.rs
+++ b/crates/hwp-model/src/document.rs
@@ -430,6 +430,9 @@ pub struct EquationRef {
     pub color: crate::types::Color,
     pub width: HwpUnit,
     pub height: HwpUnit,
+    /// Whether the equation participates in the text line as one inline atom. Floating equations
+    /// retain their anchor/order but do not reserve line width or height.
+    pub treat_as_char: bool,
     /// e.g. "Equation Version 60"; empty → the default on export.
     pub version: String,
     /// PRECOMPUTED render (issue 062-5): the `<g>`-embeddable SVG fragment rhwp's equation engine
@@ -453,6 +456,8 @@ pub struct EquationRef {
 pub struct ChartRef {
     pub width: HwpUnit,
     pub height: HwpUnit,
+    /// Whether the chart participates in the text line as one inline atom.
+    pub treat_as_char: bool,
     pub rendered_svg: Option<String>,
 }
 

--- a/crates/hwp-ops/src/lib.rs
+++ b/crates/hwp-ops/src/lib.rs
@@ -2471,6 +2471,7 @@ fn build_chart_ref(spec: &ChartSpec) -> Result<ChartRef> {
     Ok(ChartRef {
         width: (w_px * HWPUNIT_PER_PX).round() as HwpUnit,
         height: (h_px * HWPUNIT_PER_PX).round() as HwpUnit,
+        treat_as_char: true,
         rendered_svg: Some(svg),
     })
 }

--- a/crates/hwp-render/src/lib.rs
+++ b/crates/hwp-render/src/lib.rs
@@ -899,6 +899,7 @@ mod tests {
                 color: Color::default(),
                 width: 10000,
                 height: 8000,
+                treat_as_char: true,
                 version: String::new(),
                 rendered_svg: rendered_svg.map(str::to_string),
             })],
@@ -945,6 +946,7 @@ mod tests {
             content: vec![Inline::Chart(ChartRef {
                 width: 30000,
                 height: 20000,
+                treat_as_char: true,
                 rendered_svg: Some("<g class=\"hwp-ooxml-chart\"><rect/></g>".into()),
             })],
             ..Default::default()

--- a/crates/hwp-rhwp/src/lift.rs
+++ b/crates/hwp-rhwp/src/lift.rs
@@ -149,6 +149,27 @@ impl<'a> Lifter<'a> {
     /// block-level objects (tables, pictures, equations) anchored in its controls.
     fn push_paragraph(&self, p: &RParagraph, blocks: &mut Vec<Block>) {
         let mut runs = self.lift_runs(p);
+        // rhwp already decoded each extended control's character position from PARA_TEXT's UTF-16
+        // gaps. Preserve that evidence in our source-neutral Run/Inline order instead of appending
+        // pictures or manufacturing a second paragraph for equations/charts (#89).
+        let positions = p.control_text_positions();
+        let mut objects = Vec::new();
+        for (index, ctrl) in p.controls.iter().enumerate() {
+            let position = positions
+                .get(index)
+                .copied()
+                .unwrap_or_else(|| p.text.chars().count());
+            let inline = match ctrl {
+                Control::Picture(pic) => self.lift_picture(pic).map(Inline::Image),
+                Control::Equation(eq) => Some(Inline::Equation(lift_equation(eq))),
+                Control::Shape(shape) => self.lift_chart(shape).map(Inline::Chart),
+                _ => None,
+            };
+            if let Some(inline) = inline {
+                objects.push((position, inline));
+            }
+        }
+        splice_inline_objects(&mut runs, objects);
         // Inline foot/endnote reference markers — appended at paragraph end for v1 (exact mid-run
         // anchoring is a later refinement); the note body renders at the page foot / document end.
         for ctrl in &p.controls {
@@ -231,33 +252,11 @@ impl<'a> Lifter<'a> {
             ..Default::default()
         }));
 
-        // The host we just pushed — pictures ride here (issue 82). Tables still follow as
-        // `Block::Table` (scoring zips paragraphs only, so a table does not shift the pair).
-        let host_idx = blocks.len() - 1;
+        // Tables remain block-level. Renderable picture/equation/chart controls were already woven
+        // into the host run above, in stable source order.
         for ctrl in &p.controls {
             match ctrl {
                 Control::Table(t) => blocks.push(Block::Table(self.lift_table(t))),
-                Control::Picture(pic) => {
-                    // A Picture is a control ON an existing rhwp paragraph, not a second body
-                    // paragraph. Emitting `object_paragraph` made layout-check zip 1:1 slip
-                    // (issue_265.hwp: 199 vs 195, +4). Caption/text-box lists stay nested on the
-                    // rhwp object and are not flattened — they were not the leak.
-                    if let Some(img) = self.lift_picture(pic) {
-                        if let Some(Block::Paragraph(host)) = blocks.get_mut(host_idx) {
-                            attach_inline_object(host, Inline::Image(img));
-                        }
-                    }
-                }
-                Control::Equation(eq) => {
-                    blocks.push(object_paragraph(Inline::Equation(lift_equation(eq))));
-                }
-                // Issue 062-7: an OOXML (DrawingML) chart hosted in a drawing shape. Rendered (or a
-                // reserved stub box) only for the OOXML path; native/legacy charts stay dropped.
-                Control::Shape(shape) => {
-                    if let Some(chart) = self.lift_chart(shape) {
-                        blocks.push(object_paragraph(Inline::Chart(chart)));
-                    }
-                }
                 Control::Form(form) => {
                     if let Some(text) = form_visible_text(form) {
                         append_form_text(blocks, text);
@@ -385,6 +384,7 @@ impl<'a> Lifter<'a> {
         Some(ChartRef {
             width: w,
             height: h,
+            treat_as_char: ole.common.treat_as_char,
             rendered_svg: crate::chart_render::chart_svg(&xml, w, h),
         })
     }
@@ -791,29 +791,72 @@ fn utf16_to_char_idx(text: &str, utf16_pos: u32) -> usize {
 /// Attach an image to the host paragraph it was anchored on. A following `object_paragraph`
 /// would be an extra body paragraph rhwp does not have, so layout-check's 1:1 zip shifts
 /// (issue 82). Equations/charts still use [`object_paragraph`] — that leak was not identified.
-fn attach_inline_object(host: &mut Paragraph, inline: Inline) {
-    host.runs.push(Run {
-        char_shape: host.runs.last().map(|r| r.char_shape).unwrap_or(0),
-        content: vec![inline],
-        ..Default::default()
-    });
-}
+/// Weave decoded controls into the already style-split text runs. Positions are Unicode scalar
+/// indices (rhwp's contract), equal positions keep control order, and a literal U+FFFC placeholder
+/// is consumed once so it cannot become a second visible slot. Non-text markers stay in place.
+fn splice_inline_objects(runs: &mut Vec<Run>, mut objects: Vec<(usize, Inline)>) {
+    if objects.is_empty() {
+        return;
+    }
+    objects.sort_by_key(|(position, _)| *position); // stable sort preserves control order
+    let mut objects = objects.into_iter().peekable();
+    let mut char_pos = 0usize;
+    let mut rebuilt = Vec::with_capacity(runs.len() + 1);
 
-/// Wrap a single inline object (equation / chart) in its own paragraph block, emitted in reading
-/// order after the text paragraph it was anchored in. Pictures no longer use this (issue 82).
-fn object_paragraph(inline: Inline) -> Block {
-    Block::Paragraph(Paragraph {
-        runs: vec![Run {
-            char_shape: 0,
-            content: vec![inline],
+    for run in runs.drain(..) {
+        let mut out = Run {
+            char_shape: run.char_shape,
+            char_ref: run.char_ref,
+            content: Vec::new(),
+        };
+        for inline in run.content {
+            match inline {
+                Inline::Text(text) => {
+                    let mut chunk = String::new();
+                    for ch in text.chars() {
+                        let has_anchor = objects
+                            .peek()
+                            .map(|(position, _)| *position <= char_pos)
+                            .unwrap_or(false);
+                        if has_anchor {
+                            if !chunk.is_empty() {
+                                out.content.push(Inline::Text(std::mem::take(&mut chunk)));
+                            }
+                            while objects
+                                .peek()
+                                .map(|(position, _)| *position <= char_pos)
+                                .unwrap_or(false)
+                            {
+                                let (_, object) = objects.next().unwrap();
+                                out.content.push(object);
+                            }
+                            if ch == '\u{FFFC}' {
+                                char_pos += 1;
+                                continue;
+                            }
+                        }
+                        chunk.push(ch);
+                        char_pos += 1;
+                    }
+                    if !chunk.is_empty() {
+                        out.content.push(Inline::Text(chunk));
+                    }
+                }
+                marker => out.content.push(marker),
+            }
+        }
+        rebuilt.push(out);
+    }
+
+    if objects.peek().is_some() {
+        let mut tail = Run {
+            char_shape: rebuilt.last().map(|run| run.char_shape).unwrap_or(0),
             ..Default::default()
-        }],
-        provenance: Provenance {
-            source: Some(SourceFormat::Hwp5),
-            raw: None,
-        },
-        ..Default::default()
-    })
+        };
+        tail.content.extend(objects.map(|(_, object)| object));
+        rebuilt.push(tail);
+    }
+    *runs = rebuilt;
 }
 
 /// Per-row MINIMUM-height floors (HWPUNIT) from Hancom's stored cell heights — the min-row-height
@@ -1104,6 +1147,7 @@ fn lift_equation(eq: &rhwp::model::control::Equation) -> EquationRef {
         color: lift_text_color(eq.color),
         width: eq.common.width as i32,
         height: eq.common.height as i32,
+        treat_as_char: eq.common.treat_as_char,
         version: eq.version_info.clone(),
         // Issue 062-5: precompute the equation SVG via rhwp's own engine (raw `eq.color` is rhwp's
         // ColorRef 0x00BBGGRR — pass it straight to `eq_color_to_svg`). `None` on empty/failed render
@@ -1816,5 +1860,149 @@ mod tests {
                 .any(|i| matches!(i, Inline::Image(_))),
             "image must ride on the same paragraph"
         );
+    }
+
+    #[test]
+    fn equation_controls_keep_same_position_order_without_extra_paragraphs() {
+        use rhwp::model::control::Equation;
+        use rhwp::model::document::{Document, Section};
+        use rhwp::model::paragraph::Paragraph as RPara;
+
+        let equation = |script: &str| {
+            let equation = Equation {
+                script: script.into(),
+                common: rhwp::model::shape::CommonObjAttr {
+                    width: 800,
+                    height: 1200,
+                    treat_as_char: true,
+                    ..Default::default()
+                },
+                ..Default::default()
+            };
+            Control::Equation(Box::new(equation))
+        };
+        // A ends at UTF-16 1; B begins at 17, so the 16-unit gap carries two controls at char 1.
+        let para = RPara {
+            text: "AB".into(),
+            char_offsets: vec![0, 17],
+            controls: vec![equation("EqA"), equation("EqB")],
+            ..Default::default()
+        };
+        let mut doc = Document::default();
+        doc.sections.push(Section {
+            paragraphs: vec![para],
+            ..Default::default()
+        });
+
+        let semantic = Lifter::new(&doc).run();
+        assert_eq!(semantic.sections[0].blocks.len(), 1);
+        let Block::Paragraph(paragraph) = &semantic.sections[0].blocks[0] else {
+            panic!("host remains one paragraph")
+        };
+        let tokens: Vec<String> = paragraph
+            .runs
+            .iter()
+            .flat_map(|run| &run.content)
+            .filter_map(|inline| match inline {
+                Inline::Text(text) => Some(text.clone()),
+                Inline::Equation(equation) => Some(equation.script.clone()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(tokens, ["A", "EqA", "EqB", "B"]);
+    }
+
+    #[test]
+    fn object_placeholder_is_consumed_once_at_the_anchor() {
+        let mut runs = vec![Run {
+            char_shape: 0,
+            content: vec![Inline::Text("A\u{FFFC}B".into())],
+            ..Default::default()
+        }];
+        splice_inline_objects(
+            &mut runs,
+            vec![(
+                1,
+                Inline::Image(ImageRef {
+                    bin_ref: "image1".into(),
+                    width: 10,
+                    height: 10,
+                    treat_as_char: true,
+                }),
+            )],
+        );
+        let visible: String = runs
+            .iter()
+            .flat_map(|run| &run.content)
+            .filter_map(|inline| match inline {
+                Inline::Text(text) => Some(text.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            visible, "AB",
+            "U+FFFC must not become a second visible slot"
+        );
+        assert_eq!(
+            runs.iter()
+                .flat_map(|run| &run.content)
+                .filter(|inline| matches!(inline, Inline::Image(_)))
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn math_fixture_keeps_19_paragraphs_and_44_equations_through_paint_ir() {
+        use hwp_model::layout::PaintOp;
+
+        let bytes = std::fs::read(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../corpus/hwp/math-001.hwp"
+        ))
+        .unwrap();
+        let parsed = rhwp::parse_document(&bytes).unwrap();
+        let semantic = Lifter::new(&parsed).run();
+        let paragraphs = semantic
+            .sections
+            .iter()
+            .flat_map(|section| &section.blocks)
+            .filter(|block| matches!(block, Block::Paragraph(_)))
+            .count();
+        let equations = semantic
+            .sections
+            .iter()
+            .flat_map(|section| &section.blocks)
+            .filter_map(|block| match block {
+                Block::Paragraph(paragraph) => Some(paragraph),
+                _ => None,
+            })
+            .flat_map(|paragraph| &paragraph.runs)
+            .flat_map(|run| &run.content)
+            .filter(|inline| matches!(inline, Inline::Equation(_)))
+            .count();
+        assert_eq!(paragraphs, 19);
+        assert_eq!(equations, 44);
+
+        let placed = hwp_typeset::place_doc(&semantic, &hwp_typeset::ApproxFontMetrics);
+        let placed_equations = placed
+            .pages
+            .iter()
+            .flat_map(|page| &page.images)
+            .filter(|image| image.bin_ref.is_empty() && image.svg.is_some())
+            .count();
+        assert_eq!(placed_equations, 44);
+
+        let paint_equations = (0..placed.pages.len())
+            .map(|page| hwp_render::render_page(&semantic, &hwp_typeset::ApproxFontMetrics, page))
+            .collect::<Result<Vec<_>>>()
+            .unwrap()
+            .iter()
+            .flat_map(|tree| &tree.ops)
+            .filter(|op| {
+                matches!(op, PaintOp::Image { bin_ref, svg: Some(_), .. } if bin_ref.is_empty())
+            })
+            .count();
+        assert_eq!(paint_equations, 44);
     }
 }

--- a/crates/hwp-typeset/src/lib.rs
+++ b/crates/hwp-typeset/src/lib.rs
@@ -1629,29 +1629,70 @@ pub fn layout_paragraph(
     line_width: f64,
     fonts: &dyn FontMetricsProvider,
 ) -> Vec<LineSeg> {
-    // (char, size_hwpunit) for every text glyph, in order, plus its 장평/자간-scaled advance.
+    // One ordered flow slot per text glyph or embedded object. U+FFFC is only an internal metric
+    // proxy: the placer walks the identical Inline order and draws the actual object at that slot.
     let mut chars: Vec<(char, i32)> = Vec::new();
     let mut advs: Vec<f64> = Vec::new();
+    let mut object_heights: Vec<f64> = Vec::new();
     let font = plain_font();
     for run in &p.runs {
         let cs = doc.char_shapes.get(run.char_shape);
         let size = cs.map(|c| c.height).filter(|&h| h > 0).unwrap_or(1000);
         for inl in &run.content {
-            if let Inline::Text(t) = inl {
-                for ch in t.chars() {
-                    let sch = subst_glyph(ch);
-                    chars.push((sch, size));
-                    advs.push(scaled_advance(sch, size, cs, &font, fonts));
+            match inl {
+                Inline::Text(t) => {
+                    for ch in t.chars() {
+                        let sch = subst_glyph(ch);
+                        chars.push((sch, size));
+                        advs.push(scaled_advance(sch, size, cs, &font, fonts));
+                        object_heights.push(0.0);
+                    }
                 }
+                Inline::Image(image) => {
+                    chars.push(('\u{FFFC}', 1));
+                    advs.push(if image.treat_as_char {
+                        image.width.max(0) as f64
+                    } else {
+                        0.0
+                    });
+                    object_heights.push(if image.treat_as_char {
+                        image.height.max(0) as f64
+                    } else {
+                        0.0
+                    });
+                }
+                Inline::Equation(equation) => {
+                    chars.push(('\u{FFFC}', 1));
+                    advs.push(if equation.treat_as_char {
+                        equation.width.max(0) as f64
+                    } else {
+                        0.0
+                    });
+                    object_heights.push(if equation.treat_as_char {
+                        equation.height.max(0) as f64
+                    } else {
+                        0.0
+                    });
+                }
+                Inline::Chart(chart) => {
+                    chars.push(('\u{FFFC}', 1));
+                    advs.push(if chart.treat_as_char {
+                        chart.width.max(0) as f64
+                    } else {
+                        0.0
+                    });
+                    object_heights.push(if chart.treat_as_char {
+                        chart.height.max(0) as f64
+                    } else {
+                        0.0
+                    });
+                }
+                _ => {}
             }
         }
     }
     let n = chars.len();
     let adv = |i: usize| advs[i];
-
-    // Tallest anchored object (image/equation) — an object paragraph is ONE line, but as tall as
-    // the object (so pagination accounts for a half-page image, not a 1000-unit text line).
-    let obj_h = object_height(p);
 
     if n == 0 {
         // An empty paragraph still occupies one line — height = the object's if it anchors one.
@@ -1662,11 +1703,7 @@ pub fn layout_paragraph(
         // 이슈 074: 빈 줄의 EM 은 **그 문단의 글자 크기**다 — 1000(10pt) 고정이 아니다. 한컴 실측
         // (benchmark1 page 2, 빈 문단): vpos 7665→8317 = 652 = 500(5pt) × 130%. 우리는 1000×130%
         // = 1300 을 잡아 빈 줄마다 두 배로 부풀렸고, 표가 많은 양식에서 누적돼 페이지가 밀렸다.
-        let lh = if obj_h > 0 {
-            obj_h as f64
-        } else {
-            fonts.line_height(empty_para_size(p, doc))
-        };
+        let lh = fonts.line_height(empty_para_size(p, doc));
         let mut lines = vec![mk_line(0, lh, 0.0)];
         apply_source_line_metrics(p, &mut lines);
         return lines;
@@ -1748,7 +1785,15 @@ pub fn layout_paragraph(
         };
         // Line box height = the font's real leading for the tallest glyph (real shaper) or flat EM
         // (approximation), NOT the bare EM — so rows match the actual face's line height.
-        lines.push(mk_line(start as u32, fonts.line_height(max_size), lw));
+        let object_height = object_heights[start..line_end]
+            .iter()
+            .copied()
+            .fold(0.0f64, f64::max);
+        lines.push(mk_line(
+            start as u32,
+            fonts.line_height(max_size).max(object_height),
+            lw,
+        ));
         // Consume the '\n' itself on a forced break so the next line starts after it (it draws
         // nothing — the place step skips '\n'). Otherwise advance to the computed break point.
         start = if forced && line_end < n {
@@ -1756,17 +1801,6 @@ pub fn layout_paragraph(
         } else {
             line_end
         };
-    }
-    // An inline object taller than the text bumps the line it sits on (approximated as the first).
-    if obj_h > 0 {
-        if let Some(first) = lines.first_mut() {
-            if obj_h as f64 > first.vert_size {
-                let h = obj_h as f64;
-                first.vert_size = h;
-                first.text_height = h;
-                first.baseline = h * BASELINE_RATIO;
-            }
-        }
     }
     lines
 }
@@ -1794,27 +1828,6 @@ fn apply_source_line_metrics(p: &Paragraph, lines: &mut [LineSeg]) {
             line.baseline = source.baseline as f64;
         }
     }
-}
-
-/// Tallest anchored image/equation in the paragraph (HWPUNIT), or 0 if none.
-fn object_height(p: &Paragraph) -> i32 {
-    let mut h = 0;
-    for run in &p.runs {
-        for inl in &run.content {
-            match inl {
-                // Floating wrap pictures (!treat_as_char) do not advance the body: Hancom's
-                // host lineseg stays at text height (issue 82). Treat-as-char / HWPX pics still
-                // reserve the box (LOCKSTEP with place_doc via the same layout_paragraph).
-                Inline::Image(img) if img.treat_as_char => h = h.max(img.height),
-                Inline::Equation(eq) => h = h.max(eq.height),
-                // Issue 062-7: LOCKSTEP with place_doc's paragraph_object — a chart reserves the same
-                // stored-size box in the NaiveLayout twin, so pagination stays identical across both.
-                Inline::Chart(c) => h = h.max(c.height),
-                _ => {}
-            }
-        }
-    }
-    h.max(0)
 }
 
 /// Sum of (pre-scaled) advances + max glyph size over `[a, b)`. `advs` parallels `chars` and already
@@ -2437,6 +2450,7 @@ mod tests {
             content: vec![Inline::Chart(ChartRef {
                 width: 30000,
                 height: 40000,
+                treat_as_char: true,
                 rendered_svg: Some("<g class=\"hwp-gen-chart\"><rect/></g>".into()),
             })],
             ..Default::default()
@@ -2483,6 +2497,93 @@ mod tests {
             (chart_img.h - 40000.0).abs() < 1.0,
             "the reserved box height is honored on the placed surface"
         );
+    }
+
+    #[test]
+    fn mixed_inline_objects_wrap_in_source_order_with_per_line_height() {
+        let mut doc = SemanticDoc::default();
+        doc.char_shapes.push(CharShape::default());
+        let equation = |script: &str, height| {
+            Inline::Equation(EquationRef {
+                script: script.into(),
+                font: String::new(),
+                base_unit: 1000,
+                baseline: 0,
+                color: Color::default(),
+                width: 900,
+                height,
+                treat_as_char: true,
+                version: String::new(),
+                rendered_svg: None,
+            })
+        };
+        let paragraph = Paragraph {
+            runs: vec![Run {
+                char_shape: 0,
+                content: vec![
+                    Inline::Text("A".into()),
+                    equation("EqA", 1300),
+                    Inline::Text("B".into()),
+                    equation("EqB", 1800),
+                    Inline::Text("C".into()),
+                    Inline::Chart(ChartRef {
+                        width: 900,
+                        height: 1600,
+                        treat_as_char: true,
+                        rendered_svg: None,
+                    }),
+                ],
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        let lines = layout_paragraph(&paragraph, &doc, 2000.0, &ApproxFontMetrics);
+        assert_eq!(
+            lines.len(),
+            3,
+            "objects take width and wrap as ordered atoms"
+        );
+        assert_eq!(
+            lines.iter().map(|line| line.text_pos).collect::<Vec<_>>(),
+            [0, 3, 5]
+        );
+        assert_eq!(lines[0].vert_size, 1300.0);
+        assert_eq!(lines[1].vert_size, 1800.0);
+        assert_eq!(lines[2].vert_size, 1600.0);
+    }
+
+    #[test]
+    fn floating_equation_keeps_anchor_without_affecting_line_metrics() {
+        let mut doc = SemanticDoc::default();
+        doc.char_shapes.push(CharShape::default());
+        let paragraph = Paragraph {
+            runs: vec![Run {
+                char_shape: 0,
+                content: vec![
+                    Inline::Text("A".into()),
+                    Inline::Equation(EquationRef {
+                        script: "floating".into(),
+                        font: String::new(),
+                        base_unit: 1000,
+                        baseline: 0,
+                        color: Color::default(),
+                        width: 5000,
+                        height: 9000,
+                        treat_as_char: false,
+                        version: String::new(),
+                        rendered_svg: None,
+                    }),
+                    Inline::Text("B".into()),
+                ],
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let lines = layout_paragraph(&paragraph, &doc, 1100.0, &ApproxFontMetrics);
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0].horz_size, 1000.0);
+        assert_eq!(lines[0].vert_size, 1000.0);
     }
 
     /// A doc with NO chart is byte-identical to before (the chart path is purely additive): the two

--- a/crates/hwp-typeset/src/place.rs
+++ b/crates/hwp-typeset/src/place.rs
@@ -400,7 +400,7 @@ pub fn place_doc(doc: &SemanticDoc, fonts: &dyn FontMetricsProvider) -> PlacedDo
                     // touched. Tag it IMAGE when it carries an anchored object so the UI can label it.
                     let bend_page = pages.len() - 1;
                     let bend_y = mt + vert;
-                    let kind = if paragraph_object(p).is_some() {
+                    let kind = if paragraph_has_object(p) {
                         BlockKind::Image
                     } else {
                         BlockKind::Paragraph
@@ -609,7 +609,7 @@ fn place_doc_columns(doc: &SemanticDoc, fonts: &dyn FontMetricsProvider) -> Plac
                     );
                     let end_page = pages.len() - 1;
                     let end_y = body_y + flow.y();
-                    let kind = if paragraph_object(paragraph).is_some() {
+                    let kind = if paragraph_has_object(paragraph) {
                         BlockKind::Image
                     } else {
                         BlockKind::Paragraph
@@ -1263,7 +1263,7 @@ fn place_paragraph(
 ) {
     // Flat (char, size, color, underline) over the paragraph's text — same order layout_paragraph
     // breaks on, so line `text_pos` indexes straight into this.
-    let glyphs = paragraph_glyphs(p, doc, fonts);
+    let atoms = paragraph_atoms(p, doc, fonts);
     let align = doc
         .para_shapes
         .get(p.para_shape)
@@ -1273,9 +1273,6 @@ fn place_paragraph(
     // Paragraph indent: block left/right margins shrink the wrap width; first-line indent shifts line 0.
     let ind = indent_of(p, doc, body_w);
     let lines = layout_paragraph(p, doc, ind.wrap_w, fonts);
-
-    // Anchored object (image/equation) on this paragraph — placed on its (single) line.
-    let obj = paragraph_object(p);
 
     for (li, ls) in lines.iter().enumerate() {
         if *vert + ls.vert_size > body_h && *vert > 0.0 {
@@ -1310,31 +1307,10 @@ fn place_paragraph(
         let end = lines
             .get(li + 1)
             .map(|n| n.text_pos as usize)
-            .unwrap_or(glyphs.len());
+            .unwrap_or(atoms.len());
         let mut x = x0;
-        let plain = FontKey {
-            family: String::new(),
-            bold: false,
-            italic: false,
-        };
-        for g in glyphs.get(start..end.min(glyphs.len())).unwrap_or(&[]) {
-            let adv =
-                fonts.advance_width(&plain, g.ch, g.size as i32) * g.ratio + g.spacing_em * g.size;
-            if g.ch != ' ' && g.ch != '\t' && g.ch != '\n' {
-                pg.glyphs.push(PlacedGlyph {
-                    x,
-                    baseline,
-                    ch: g.ch,
-                    size: g.size,
-                    color: g.color,
-                    underline: g.underline,
-                    bold: g.bold,
-                    italic: g.italic,
-                    font: g.font.clone(),
-                    cluster: g.cluster.clone(),
-                });
-            }
-            x += adv;
+        for atom in atoms.get(start..end.min(atoms.len())).unwrap_or(&[]) {
+            x += place_atom(pg, atom, x, line_top, baseline, fonts, section, block);
         }
 
         // (No per-line text-box: the SvgSink strokes fill:None rects as borders, so a box per line
@@ -1342,23 +1318,6 @@ fn place_paragraph(
         // read-only fidelity view — caret hit-testing uses the rhwp path, not these boxes — so only
         // table/cell borders are drawn. Line-level hit geometry can come back behind a flag if the
         // own surface ever becomes editable.)
-
-        // An anchored object sits on the first line of its paragraph.
-        if li == 0 {
-            if let Some((w, h, bin_ref, svg)) = &obj {
-                pg.images.push(PlacedImage {
-                    x: x0,
-                    y: line_top,
-                    w: *w,
-                    h: *h,
-                    bin_ref: bin_ref.clone(),
-                    svg: svg.clone(),
-                    is_background: false,
-                    section,
-                    block,
-                });
-            }
-        }
 
         *vert += ls.vert_size * ratio;
     }
@@ -1382,7 +1341,7 @@ fn place_paragraph_columns(
     block: usize,
     width_cap: Option<f64>,
 ) {
-    let glyphs = paragraph_glyphs(p, doc, fonts);
+    let atoms = paragraph_atoms(p, doc, fonts);
     let align = doc
         .para_shapes
         .get(p.para_shape)
@@ -1395,7 +1354,6 @@ fn place_paragraph_columns(
         .max(1.0);
     let ind = indent_of(p, doc, layout_width);
     let lines = layout_paragraph(p, doc, ind.wrap_w, fonts);
-    let obj = paragraph_object(p);
 
     for (line_index, line) in lines.iter().enumerate() {
         if flow.vert() + line.vert_size > flow.available_height(body_h)
@@ -1438,47 +1396,11 @@ fn place_paragraph_columns(
         let end = lines
             .get(line_index + 1)
             .map(|next| next.text_pos as usize)
-            .unwrap_or(glyphs.len());
+            .unwrap_or(atoms.len());
         let mut x = x0;
-        let plain = FontKey {
-            family: String::new(),
-            bold: false,
-            italic: false,
-        };
         let page_out = pages.last_mut().expect("placed document always has a page");
-        for glyph in glyphs.get(start..end.min(glyphs.len())).unwrap_or(&[]) {
-            let advance = fonts.advance_width(&plain, glyph.ch, glyph.size as i32) * glyph.ratio
-                + glyph.spacing_em * glyph.size;
-            if glyph.ch != ' ' && glyph.ch != '\t' && glyph.ch != '\n' {
-                page_out.glyphs.push(PlacedGlyph {
-                    x,
-                    baseline,
-                    ch: glyph.ch,
-                    size: glyph.size,
-                    color: glyph.color,
-                    underline: glyph.underline,
-                    bold: glyph.bold,
-                    italic: glyph.italic,
-                    font: glyph.font.clone(),
-                    cluster: glyph.cluster.clone(),
-                });
-            }
-            x += advance;
-        }
-        if line_index == 0 {
-            if let Some((width, height, bin_ref, svg)) = &obj {
-                page_out.images.push(PlacedImage {
-                    x: x0,
-                    y: line_top,
-                    w: (*width).min(effective_width),
-                    h: *height,
-                    bin_ref: bin_ref.clone(),
-                    svg: svg.clone(),
-                    is_background: false,
-                    section,
-                    block,
-                });
-            }
+        for atom in atoms.get(start..end.min(atoms.len())).unwrap_or(&[]) {
+            x += place_atom(page_out, atom, x, line_top, baseline, fonts, section, block);
         }
         flow.add(line.vert_size * ratio);
     }
@@ -2327,11 +2249,6 @@ fn place_cell_content(
         .map(|b| block_height_for_place(b, doc, textw, fonts))
         .sum();
     let mut vy = cy + ((ch - content_h) / 2.0).max(0.0);
-    let plain = FontKey {
-        family: String::new(),
-        bold: false,
-        italic: false,
-    };
     for (bi, b) in blocks.iter().enumerate() {
         let Block::Paragraph(p) = b else {
             // A NESTED table (a table inside this cell): DRAW it at the current cursor — its height is
@@ -2354,8 +2271,7 @@ fn place_cell_content(
             vy += block_height_for_place(b, doc, textw, fonts);
             continue;
         };
-        let para_top = vy;
-        let glyphs = paragraph_glyphs(p, doc, fonts);
+        let atoms = paragraph_atoms(p, doc, fonts);
         let align = doc
             .para_shapes
             .get(p.para_shape)
@@ -2365,22 +2281,6 @@ fn place_cell_content(
         // Same paragraph indent as the body: block left/right margins shrink wrap; first line shifts.
         let ind = indent_of(p, doc, textw);
         let lines = layout_paragraph(p, doc, ind.wrap_w, fonts);
-        // A cell-anchored image/equation/chart (issue #196 Batch D): draw it at the paragraph top.
-        // `layout_paragraph` already bumped the first line's height to the object, so the cell row
-        // reserved this space — drawing is pagination-neutral (the vy advance below is unchanged).
-        if let Some((w, h, bin_ref, svg)) = paragraph_object(p) {
-            pg.images.push(PlacedImage {
-                x: cx + pad_left,
-                y: para_top,
-                w,
-                h,
-                bin_ref,
-                svg,
-                is_background: false,
-                section: ctx.section,
-                block: ctx.outer_block,
-            });
-        }
         for (li, ls) in lines.iter().enumerate() {
             let line_indent = ind.left + if li == 0 { ind.first_extra } else { 0.0 };
             let slack = (ind.wrap_w
@@ -2404,26 +2304,19 @@ fn place_cell_content(
             let end = lines
                 .get(li + 1)
                 .map(|n| n.text_pos as usize)
-                .unwrap_or(glyphs.len());
+                .unwrap_or(atoms.len());
             let mut x = x0;
-            for g in glyphs.get(start..end.min(glyphs.len())).unwrap_or(&[]) {
-                let adv = fonts.advance_width(&plain, g.ch, g.size as i32) * g.ratio
-                    + g.spacing_em * g.size;
-                if g.ch != ' ' && g.ch != '\t' && g.ch != '\n' {
-                    pg.glyphs.push(PlacedGlyph {
-                        x,
-                        baseline,
-                        ch: g.ch,
-                        size: g.size,
-                        color: g.color,
-                        underline: g.underline,
-                        bold: g.bold,
-                        italic: g.italic,
-                        font: g.font.clone(),
-                        cluster: g.cluster.clone(),
-                    });
-                }
-                x += adv;
+            for atom in atoms.get(start..end.min(atoms.len())).unwrap_or(&[]) {
+                x += place_atom(
+                    pg,
+                    atom,
+                    x,
+                    vy,
+                    baseline,
+                    fonts,
+                    ctx.section,
+                    ctx.outer_block,
+                );
             }
             vy += ls.vert_size * ratio;
         }
@@ -2532,18 +2425,27 @@ fn walk_cell_lines(
         .map(|b| block_height_for_place(b, doc, textw, fonts))
         .sum();
     let mut vy = cy + ((ch - content_h) / 2.0).max(0.0);
-    let plain = FontKey {
-        family: String::new(),
-        bold: false,
-        italic: false,
-    };
     let mut seg_base = 0usize; // cell-global ordinal of this model paragraph's FIRST "\n"-segment
     for b in blocks {
         let Block::Paragraph(p) = b else {
             vy += block_height_for_place(b, doc, textw, fonts);
             continue;
         };
-        let glyphs = paragraph_glyphs(p, doc, fonts);
+        let atoms = paragraph_atoms(p, doc, fonts);
+        let glyphs: Vec<&GlyphInfo> = atoms
+            .iter()
+            .filter_map(|atom| match atom {
+                ParagraphAtom::Glyph(glyph) => Some(glyph),
+                ParagraphAtom::Object { .. } => None,
+            })
+            .collect();
+        let mut text_prefix = Vec::with_capacity(atoms.len() + 1);
+        text_prefix.push(0usize);
+        for atom in &atoms {
+            let next = text_prefix.last().copied().unwrap_or(0)
+                + usize::from(matches!(atom, ParagraphAtom::Glyph(_)));
+            text_prefix.push(next);
+        }
         // "\n"-segment map (the EDITOR address space — see CellTextHit): positions of the forced
         // breaks split the paragraph into nl_pos.len()+1 segments; a glyph at index i belongs to the
         // segment holding it, with segment-local offset i - seg_start.
@@ -2586,21 +2488,26 @@ fn walk_cell_lines(
             let end = lines
                 .get(li + 1)
                 .map(|n| n.text_pos as usize)
-                .unwrap_or(glyphs.len())
-                .min(glyphs.len());
-            let line_glyphs = glyphs.get(start..end).unwrap_or(&[]);
-            let advances: Vec<f64> = line_glyphs
-                .iter()
-                .map(|g| {
-                    fonts.advance_width(&plain, g.ch, g.size as i32) * g.ratio
-                        + g.spacing_em * g.size
-                })
-                .collect();
-            let chars: Vec<char> = line_glyphs.iter().map(|g| g.ch).collect();
-            let s = seg_of(start); // the line's segment (a '\n' ends its line, so lines never straddle)
+                .unwrap_or(atoms.len())
+                .min(atoms.len());
+            let text_start = text_prefix[start.min(atoms.len())];
+            let mut pending_object_advance = 0.0;
+            let mut advances = Vec::new();
+            let mut chars = Vec::new();
+            for atom in atoms.get(start..end).unwrap_or(&[]) {
+                match atom {
+                    ParagraphAtom::Object { .. } => pending_object_advance += atom.advance(fonts),
+                    ParagraphAtom::Glyph(glyph) => {
+                        advances.push(pending_object_advance + atom.advance(fonts));
+                        pending_object_advance = 0.0;
+                        chars.push(glyph.ch);
+                    }
+                }
+            }
+            let s = seg_of(text_start); // a '\n' ends its line, so lines never straddle segments
             let stop = on_line(&CellLineGeom {
                 para: seg_base + s,
-                line_start: start - seg_start(s),
+                line_start: text_start - seg_start(s),
                 x0,
                 top: vy,
                 height: ls.vert_size,
@@ -3098,6 +3005,7 @@ fn block_height_for_place(
 
 /// Flat (char, size, color, underline) over a paragraph's text runs — the SAME enumeration order
 /// `layout_paragraph` breaks on, so a line's `text_pos` indexes straight into this slice.
+#[derive(Clone)]
 struct GlyphInfo {
     ch: char,
     size: f64,
@@ -3118,11 +3026,102 @@ struct GlyphInfo {
     cluster: Option<String>,
 }
 
-fn paragraph_glyphs(
+#[derive(Clone)]
+enum ParagraphAtom {
+    Glyph(GlyphInfo),
+    Object {
+        width: f64,
+        height: f64,
+        bin_ref: String,
+        svg: Option<String>,
+        treat_as_char: bool,
+    },
+}
+
+impl ParagraphAtom {
+    fn advance(&self, fonts: &dyn FontMetricsProvider) -> f64 {
+        match self {
+            Self::Glyph(glyph) => {
+                let plain = FontKey {
+                    family: String::new(),
+                    bold: false,
+                    italic: false,
+                };
+                fonts.advance_width(&plain, glyph.ch, glyph.size as i32) * glyph.ratio
+                    + glyph.spacing_em * glyph.size
+            }
+            Self::Object {
+                width,
+                treat_as_char,
+                ..
+            } => {
+                if *treat_as_char {
+                    *width
+                } else {
+                    0.0
+                }
+            }
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn place_atom(
+    page: &mut PlacedPage,
+    atom: &ParagraphAtom,
+    x: f64,
+    line_top: f64,
+    baseline: f64,
+    fonts: &dyn FontMetricsProvider,
+    section: usize,
+    block: usize,
+) -> f64 {
+    match atom {
+        ParagraphAtom::Glyph(glyph) => {
+            if glyph.ch != ' ' && glyph.ch != '\t' && glyph.ch != '\n' {
+                page.glyphs.push(PlacedGlyph {
+                    x,
+                    baseline,
+                    ch: glyph.ch,
+                    size: glyph.size,
+                    color: glyph.color,
+                    underline: glyph.underline,
+                    bold: glyph.bold,
+                    italic: glyph.italic,
+                    font: glyph.font.clone(),
+                    cluster: glyph.cluster.clone(),
+                });
+            }
+            atom.advance(fonts)
+        }
+        ParagraphAtom::Object {
+            width,
+            height,
+            bin_ref,
+            svg,
+            ..
+        } => {
+            page.images.push(PlacedImage {
+                x,
+                y: line_top,
+                w: *width,
+                h: *height,
+                bin_ref: bin_ref.clone(),
+                svg: svg.clone(),
+                is_background: false,
+                section,
+                block,
+            });
+            atom.advance(fonts)
+        }
+    }
+}
+
+fn paragraph_atoms(
     p: &Paragraph,
     doc: &SemanticDoc,
     fonts: &dyn FontMetricsProvider,
-) -> Vec<GlyphInfo> {
+) -> Vec<ParagraphAtom> {
     let mut out = Vec::new();
     for run in &p.runs {
         let cs = doc.char_shapes.get(run.char_shape);
@@ -3132,42 +3131,81 @@ fn paragraph_glyphs(
         let bold = cs.map(|c| c.bold).unwrap_or(false);
         let italic = cs.map(|c| c.italic).unwrap_or(false);
         for inl in &run.content {
-            if let Inline::Text(t) = inl {
-                for ch in t.chars() {
-                    // Issue 062-2: a Hanyang-PUA 옛한글 음절 draws as its 첫가끝 자모 시퀀스 (an OFL-
-                    // coverable cluster) while `subst_glyph` swaps `ch` to the full-width metric proxy
-                    // — so advances/breaking (via layout_paragraph) stay in lockstep with the drawn cell.
-                    let cluster = crate::old_hangul_cluster(ch);
-                    let sch = crate::subst_glyph(ch);
-                    let slot = crate::script_slot(sch);
-                    let (ratio, spacing_em) = cs
-                        .map(|c| {
-                            let r = match *c.ratio.get(slot) {
-                                0 => 100,
-                                r => r.clamp(50, 200),
-                            } as f64
-                                / 100.0;
-                            let s = (*c.spacing.get(slot)).clamp(-50, 50) as f64 / 100.0;
-                            (r, s)
-                        })
-                        .unwrap_or((1.0, 0.0));
-                    out.push(GlyphInfo {
-                        ch: sch,
-                        size,
-                        color,
-                        underline,
-                        bold,
-                        italic,
-                        font: display_font(cs, slot, fonts),
-                        ratio,
-                        spacing_em,
-                        cluster,
-                    });
+            match inl {
+                Inline::Text(t) => {
+                    for ch in t.chars() {
+                        // Issue 062-2: a Hanyang-PUA 옛한글 음절 draws as its 첫가끝 자모 시퀀스 (an OFL-
+                        // coverable cluster) while `subst_glyph` swaps `ch` to the full-width metric proxy
+                        // — so advances/breaking (via layout_paragraph) stay in lockstep with the drawn cell.
+                        let cluster = crate::old_hangul_cluster(ch);
+                        let sch = crate::subst_glyph(ch);
+                        let slot = crate::script_slot(sch);
+                        let (ratio, spacing_em) = cs
+                            .map(|c| {
+                                let r = match *c.ratio.get(slot) {
+                                    0 => 100,
+                                    r => r.clamp(50, 200),
+                                } as f64
+                                    / 100.0;
+                                let s = (*c.spacing.get(slot)).clamp(-50, 50) as f64 / 100.0;
+                                (r, s)
+                            })
+                            .unwrap_or((1.0, 0.0));
+                        out.push(ParagraphAtom::Glyph(GlyphInfo {
+                            ch: sch,
+                            size,
+                            color,
+                            underline,
+                            bold,
+                            italic,
+                            font: display_font(cs, slot, fonts),
+                            ratio,
+                            spacing_em,
+                            cluster,
+                        }));
+                    }
                 }
+                Inline::Image(image) => out.push(ParagraphAtom::Object {
+                    width: image.width.max(0) as f64,
+                    height: image.height.max(0) as f64,
+                    bin_ref: image.bin_ref.clone(),
+                    svg: None,
+                    treat_as_char: image.treat_as_char,
+                }),
+                Inline::Equation(equation) => out.push(ParagraphAtom::Object {
+                    width: equation.width.max(0) as f64,
+                    height: equation.height.max(0) as f64,
+                    bin_ref: String::new(),
+                    svg: equation.rendered_svg.clone(),
+                    treat_as_char: equation.treat_as_char,
+                }),
+                Inline::Chart(chart) => out.push(ParagraphAtom::Object {
+                    width: chart.width.max(0) as f64,
+                    height: chart.height.max(0) as f64,
+                    bin_ref: String::new(),
+                    svg: chart.rendered_svg.clone(),
+                    treat_as_char: chart.treat_as_char,
+                }),
+                _ => {}
             }
         }
     }
     out
+}
+
+#[cfg(test)]
+fn paragraph_glyphs(
+    p: &Paragraph,
+    doc: &SemanticDoc,
+    fonts: &dyn FontMetricsProvider,
+) -> Vec<GlyphInfo> {
+    paragraph_atoms(p, doc, fonts)
+        .into_iter()
+        .filter_map(|atom| match atom {
+            ParagraphAtom::Glyph(glyph) => Some(glyph),
+            ParagraphAtom::Object { .. } => None,
+        })
+        .collect()
 }
 
 /// The OFL substitute display family for a glyph (issue 058): resolve the char shape's per-script font
@@ -3202,45 +3240,15 @@ fn display_font(
     hwp_model::font_class::substitute_family_with_panose(name, panose).map(str::to_string)
 }
 
-/// The tallest anchored image/equation/chart on the paragraph as `(w, h, bin_ref, svg)` — `bin_ref`
-/// empty for an equation/chart (the renderer draws a placeholder box unless `svg` is present), and
-/// `svg` is the precomputed fragment (equation: issue 062-5; chart: issue 062-7; `None` for images and
-/// un-rendered equations/charts). `None` if the paragraph anchors no object.
-fn paragraph_object(p: &Paragraph) -> Option<(f64, f64, String, Option<String>)> {
-    let mut best: Option<(f64, f64, String, Option<String>)> = None;
-    for run in &p.runs {
-        for inl in &run.content {
-            let cand = match inl {
-                Inline::Image(img) => Some((
-                    img.width as f64,
-                    img.height as f64,
-                    img.bin_ref.clone(),
-                    None,
-                )),
-                Inline::Equation(eq) => Some((
-                    eq.width as f64,
-                    eq.height as f64,
-                    String::new(),
-                    eq.rendered_svg.clone(),
-                )),
-                // Issue 062-7: a chart rides the same object channel as an equation — empty bin_ref +
-                // its precomputed SVG fragment (`None` → stub box). Box from the stored chart size.
-                Inline::Chart(c) => Some((
-                    c.width as f64,
-                    c.height as f64,
-                    String::new(),
-                    c.rendered_svg.clone(),
-                )),
-                _ => None,
-            };
-            if let Some((w, h, r, svg)) = cand {
-                if best.as_ref().map(|(_, bh, _, _)| h > *bh).unwrap_or(true) {
-                    best = Some((w, h, r, svg));
-                }
-            }
-        }
-    }
-    best
+fn paragraph_has_object(p: &Paragraph) -> bool {
+    p.runs.iter().any(|run| {
+        run.content.iter().any(|inline| {
+            matches!(
+                inline,
+                Inline::Image(_) | Inline::Equation(_) | Inline::Chart(_)
+            )
+        })
+    })
 }
 
 fn set_page_size(pg: &mut PlacedPage, page: &PageSetup) {
@@ -3529,6 +3537,125 @@ mod tests {
         };
         doc.sections.push(sec);
         doc
+    }
+
+    fn mixed_object_paragraph() -> Paragraph {
+        let equation = |name: &str, height| {
+            Inline::Equation(EquationRef {
+                script: name.into(),
+                font: String::new(),
+                base_unit: 1000,
+                baseline: 0,
+                color: Color::default(),
+                width: 800,
+                height,
+                treat_as_char: true,
+                version: String::new(),
+                rendered_svg: Some(format!("<g id=\"{name}\"/>")),
+            })
+        };
+        Paragraph {
+            runs: vec![Run {
+                char_shape: 0,
+                content: vec![
+                    Inline::Text("A".into()),
+                    equation("EqA", 1200),
+                    Inline::Text("B".into()),
+                    equation("EqB", 1400),
+                    Inline::Text("C".into()),
+                    Inline::Chart(ChartRef {
+                        width: 800,
+                        height: 1600,
+                        treat_as_char: true,
+                        rendered_svg: Some("<g id=\"ChartC\"/>".into()),
+                    }),
+                ],
+                ..Default::default()
+            }],
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn mixed_inline_objects_place_in_order_in_body_and_cell() {
+        let mut body = doc_with(vec![Block::Paragraph(mixed_object_paragraph())]);
+        body.sections[0].page.width = 3000;
+        body.sections[0].page.height = 10000;
+        body.sections[0].page.margin_left = 0;
+        body.sections[0].page.margin_right = 0;
+        body.sections[0].page.margin_top = 0;
+        body.sections[0].page.margin_bottom = 0;
+        let placed = place_doc(&body, &ApproxFontMetrics);
+        let images = &placed.pages[0].images;
+        assert_eq!(images.len(), 3, "every object atom is painted exactly once");
+        assert!(images[0].svg.as_deref().unwrap().contains("EqA"));
+        assert!(images[1].svg.as_deref().unwrap().contains("EqB"));
+        assert!(images[2].svg.as_deref().unwrap().contains("ChartC"));
+        assert_ne!((images[0].x, images[0].y), (images[1].x, images[1].y));
+        assert!(images[2].y > images[1].y, "ChartC wraps to the next line");
+        assert_eq!(
+            placed.pages.len(),
+            crate::NaiveLayout
+                .layout(&body, &ApproxFontMetrics)
+                .unwrap()
+                .pages
+                .len(),
+            "body placement stays in LOCKSTEP"
+        );
+
+        let table = Table {
+            rows: 1,
+            cols: 1,
+            col_widths: vec![6000],
+            cells: vec![Cell {
+                row: 0,
+                col: 0,
+                width: Some(6000),
+                blocks: vec![Block::Paragraph(mixed_object_paragraph())],
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let cell_doc = doc_with(vec![Block::Table(table)]);
+        let cell_placed = place_doc(&cell_doc, &ApproxFontMetrics);
+        assert_eq!(cell_placed.pages[0].images.len(), 3);
+        let start = cell_caret_rect(
+            &cell_doc,
+            &cell_placed,
+            &ApproxFontMetrics,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        )
+        .expect("cell caret before mixed flow");
+        let end = cell_caret_rect(
+            &cell_doc,
+            &cell_placed,
+            &ApproxFontMetrics,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+        )
+        .expect("cell caret after mixed flow");
+        assert!(
+            end.x > start.x,
+            "caret geometry includes inline object advances"
+        );
+        assert_eq!(
+            cell_placed.pages.len(),
+            crate::NaiveLayout
+                .layout(&cell_doc, &ApproxFontMetrics)
+                .unwrap()
+                .pages
+                .len(),
+            "cell placement stays in LOCKSTEP"
+        );
     }
 
     #[test]

--- a/crates/hwp-viewer/src/native_print.rs
+++ b/crates/hwp-viewer/src/native_print.rs
@@ -248,6 +248,7 @@ mod tests {
                 color: Color::default(),
                 width: 3000,
                 height: 1500,
+                treat_as_char: true,
                 version: "Equation Version 60".into(),
                 rendered_svg: Some(
                     r##"<g><text x="1" y="12" font-size="12" fill="#000">x</text><line x1="0" y1="14" x2="12" y2="14" stroke="#000"/></g>"##.into(),
@@ -256,6 +257,7 @@ mod tests {
         let chart_paragraph = paragraph(vec![Inline::Chart(ChartRef {
                 width: 6000,
                 height: 3600,
+                treat_as_char: true,
                 rendered_svg: Some(
                     r##"<g class="hwp-gen-chart"><rect x="0" y="0" width="30" height="18" fill="#fff"/><polyline points="0,16 10,4 20,12 30,2" fill="none" stroke="#06c"/></g>"##.into(),
                 ),

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,6 +3,38 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
+- 갱신: 2026-08-24 · Codex(sol) — **#89 inline object atom flow full green · PR 직전**.
+  원인은 rhwp 미해결이 아니라 우리 lift가 이미 파싱된 `control_text_positions()`를 버리고 수식/차트를
+  가짜 별도 문단으로 만들며, 자체 조판이 문단당 tallest object 하나만 소비한 데 있었다. 외부 rhwp는
+  무수정으로 두고 HWP5 Picture/Equation/OOXML Chart를 Unicode char anchor에 stable splice하며 U+FFFC를
+  한 번만 소비한다. IR에 Equation/Chart `treat_as_char`를 additive 보존했고 HWPX/JSX codec과 semantic
+  equality도 동기화했다. shared layout/place는 모든 Text/Object atom을 동일 순서·폭으로 줄바꿈하고
+  line별 높이, floating no-reserve, body/column/cell/caret를 같은 advance로 소비한다. synthetic body/cell
+  LOCKSTEP 및 real `math-001.hwp` **19 paragraph = 44 Equation = 44 PlacedImage = 44 PaintOp** 회귀가 green;
+  layout-check는 종전 main **3쪽·20줄·16/19 exact → 2쪽·24줄·19/19 exact**로 개선됐다(한컴 1쪽 잔여는
+  숨기지 않음). quick/full은 fmt·clippy·workspace·rhwp feature·PDF visual **51**, canonical
+  **8/18/24 + 98.9%+**, public corpus **84**, catalog **259/12 families/120 pairs**, oracle **82**,
+  HWPX non-truth lock 89.5% exact/98.2% within1 및 cell floor 5/5·9/9, wasm **7,831,754B**,
+  JS/crosscheck/i18n, Vitest **1,018**, Chromium **85 pass/3 intentional skip/0 fail**로 green이다.
+  첫 browser 실행의 port EPERM과 둘째의 ENOSPC는 각각 승인 실행과 재생성 가능한 target 15.5GiB
+  정리로 해소했다. 임시 node 링크 제거, generated wasm/assets diff 0, rhwp gitlink clean이다.
+  **다음:** privacy/diff 최종 감사→JOURNAL→commit/push/PR `Closes #89`→exact-head CI/comments green
+  autonomous merge→#84/#93/#114 content-free 동기화→#104 canonical AI Proposal 착수.
+
+- 갱신: 2026-08-24 · Codex(sol) — **PR #206 병합 · #89 착수**.
+  PR #206 exact head `62470347`에서 issue-link **5s**·build-test **9m35s**·licenses
+  **2m45s** green, CLEAN/MERGEABLE, review/general/inline 댓글 0을 확인하고 protected main
+  `59033031`로 squash 병합했다. #95/#96 close·원격 브랜치 삭제를 확인했고 #93/#114에
+  content-free T1 구조 회복과 worst-tile recall 0.0 잔여를 동기화했다. open PR 0, 신규 외부
+  요청·보안/스팸 신호 0이며 외부 #50은 이미 Proposal/provider roadmap으로 접수돼 있다.
+  다음 P0는 #84의 실제 수식 **44 중 33개 손실**과 #93 객체 타일 누락을 동시에 막는 #89다.
+  #104 AI Proposal보다 먼저 source-order Text/Equation/Chart atom flow를 자체 typesetter에 세워,
+  AI의 atomic edit가 render에서 객체를 잃지 않게 한다. exact main의
+  `codex/issue-89-inline-object-flow` worktree를 만들었다. **다음:** production 경로의
+  `paragraph_object()` 단수 소비자와 rhwp `control_text_positions()` lift를 읽기 전용으로 지도화→
+  synthetic Text/EqA/Text/EqB/ChartC RED→shared flow의 최소 additive IR/placement contract→
+  body/cell/caret/Naive/place lockstep. 실제 원문·파일명·경로/hash/raw는 공개하지 않는다.
+
 - 갱신: 2026-08-24 · Codex(sol) — **#95/#96 full green · PR 직전**.
   focused HWPX **96**·typeset **97**·hostile **7** 및 clippy green. quick/full은 canonical
   **8/18/24 + 98.9%+**, public corpus 계약 **84**, catalog **259/12 families/120 pairs**,

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,12 @@
 
 ---
 
+## 2026-08-24 (Codex sol) · #89 inline object atom flow
+- HWP5 control anchor와 shared Text/Object atom flow를 복원해 body/cell/caret LOCKSTEP을 구현.
+- math 실측 19 paragraph = 44 Equation = 44 PlacedImage = 44 PaintOp; 3쪽/16 exact→2쪽/19 exact.
+- quick/full green: 8/18/24+98.9%, oracle82, Vitest 1,018, Chromium 85 pass/3 skip; rhwp 무수정.
+- 다음: commit/push→`Closes #89` PR/CI/merge→#84/#93/#114 동기화→#104 AI Proposal.
+
 ## 2026-08-24 (Codex sol) · #95/#96 HWPX page structure
 - CELL continuation/repeat-header와 clean lineseg fragment lower-bound를 자체 parser/typesetter에 구현.
 - pair03 4→6쪽, pair04 final landscape; 두 T1 report 모두 structural match/scored, threshold 없음.


### PR DESCRIPTION
Closes #89

## What changed

- preserve rhwp-parsed Picture/Equation/OOXML Chart controls at their Unicode scalar anchors instead of lifting equations/charts into synthetic paragraphs
- model text and every inline object as a stable ordered atom stream shared by naive layout, production placement, table cells, and caret geometry
- preserve additive `treat_as_char` semantics through IR, HWPX, and JSX codecs; floating objects keep their anchor without reserving line width or height
- add synthetic multi-object body/cell/lockstep regressions and a real `math-001.hwp` count contract

## Measured result

- real fixture: 19 IR paragraphs = 44 Equation = 44 PlacedImage = 44 PaintOp::Image
- layout-check: 3 pages / 20 lines / 16 of 19 exact paragraphs on main → 2 pages / 24 lines / 19 of 19 exact
- Hancom remains 1 page; the residual page-height/line-spacing delta is documented rather than hidden or absorbed into this source-order fix

## Verification

- `scripts/verify-local.sh` green
- `scripts/verify-local.sh --full` green apart from sandbox port denial; the identical Playwright suite passed outside the port sandbox: 85 passed, 3 intentional skipped, 0 failed
- canonical page gates 8/18/24 and line agreement 98.9%+; public corpus 84; oracle 82; PDF visual 51
- Vitest 1,018 passed
- no oracle/tolerance relaxation, no generated wasm/assets diff, and no `external/rhwp` modification

## Security / privacy

- no user document content, local path, credential, or private fixture is included
- parsing remains behind existing input bounds; the change consumes the already-bounded rhwp control list without adding an external allocation loop
