### PR TITLE
feat: add one-command semantic PDF visual diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,8 +109,11 @@ jobs:
             benchmarks/benchmark1.hwp \
             benchmarks/benchmark2.hwp \
             | node scripts/canonical-layout-gate.mjs
-      - name: PDF visual oracle foundation (issue 121)
-        run: python3 -m unittest discover -s scripts/tests -p 'test_pdf_visual_check.py'
+      - name: PDF visual oracle and one-command document runner (issues 121, 213)
+        run: |
+          python3 -m unittest discover -s scripts/tests -p 'test_pdf_visual_check.py'
+          node --check scripts/document-visual-check.mjs
+          node --test scripts/tests/document-visual-check.test.mjs
       - name: SVG sink to PDF sink vector parity (issue 102)
         run: python3 scripts/pdf-svg-parity-check.py --output-dir "$RUNNER_TEMP/pdf-svg-parity"
       - name: desktop adapter contract (vitest)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2075,6 +2075,8 @@ dependencies = [
  "kurbo 0.13.1",
  "quick-xml 0.37.5",
  "rhwp",
+ "serde",
+ "sha2",
  "svgtypes 0.16.1",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ cfb = "0.14"
 aes = "0.8"
 cipher = "0.4"
 sha1 = "0.10"
+sha2 = "0.10"
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/auto-hwp-cli/src/main.rs
+++ b/crates/auto-hwp-cli/src/main.rs
@@ -214,6 +214,10 @@ enum Cmd {
         /// Output PDF path.
         #[arg(long, short, default_value = "out.pdf")]
         out: PathBuf,
+        /// Write schema-v1 content-free text/table/image/object regions from the exact placement
+        /// used for this PDF. The sidecar is candidate-SHA-bound and never contains document text.
+        #[arg(long)]
+        visual_regions: Option<PathBuf>,
     },
     /// PIVOT M0: apply ONE CSS-only AI-routing op (CssSetDecl) to a project dir, proving
     /// content/design separation — only styles/document.css is re-written; the .jsx are untouched.
@@ -348,7 +352,11 @@ fn run() -> Result<(), String> {
         }
         Cmd::OpenProject { file, out_dir } => open_project(&file, &out_dir)?,
         Cmd::ExportHtml { file, out } => export_html(&file, &out)?,
-        Cmd::ExportPdf { file, out } => export_pdf(&file, &out)?,
+        Cmd::ExportPdf {
+            file,
+            out,
+            visual_regions,
+        } => export_pdf(&file, &out, visual_regions.as_deref())?,
         Cmd::EditOp {
             proj,
             node,
@@ -773,13 +781,51 @@ fn export_html(file: &PathBuf, out: &Path) -> Result<(), String> {
 /// PHASE P4: export to PDF from OUR OWN layout (paint IR → krilla, Korean font subsetting). The PDF
 /// matches own-render because both replay the same paint IR. Needs `--features pdf`.
 #[cfg(feature = "pdf")]
-fn export_pdf(file: &PathBuf, out: &Path) -> Result<(), String> {
+fn export_pdf(file: &PathBuf, out: &Path, visual_regions: Option<&Path>) -> Result<(), String> {
+    if let Some(path) = visual_regions {
+        if path == out {
+            return Err("--visual-regions must not be the PDF output path".into());
+        }
+        if path
+            .try_exists()
+            .map_err(|error| format!("inspect {}: {error}", path.display()))?
+        {
+            return Err(format!(
+                "visual region output already exists; refusing to overwrite {}",
+                path.display()
+            ));
+        }
+    }
     let bytes = read(file)?;
     // Engine::open handles both: .hwpx parse (default build) + .hwp lift (needs --features rhwp).
     let doc = hwp_core::Engine::open(&bytes).map_err(|e| e.to_string())?;
     let title = file.file_stem().map(|s| s.to_string_lossy().into_owned());
     let result = hwp_session::emit_pdf(&doc, title)?;
+    let evidence = visual_regions
+        .map(|_| {
+            let mut bytes = serde_json::to_vec_pretty(&result.visual_evidence)
+                .map_err(|error| format!("serialize visual regions: {error}"))?;
+            bytes.push(b'\n');
+            Ok::<_, String>(bytes)
+        })
+        .transpose()?;
     std::fs::write(out, &result.bytes).map_err(|e| format!("write {}: {e}", out.display()))?;
+    if let (Some(path), Some(bytes)) = (visual_regions, evidence) {
+        use std::io::Write as _;
+        let mut options = std::fs::OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt as _;
+            options.mode(0o600);
+        }
+        let mut output = options
+            .open(path)
+            .map_err(|error| format!("create {}: {error}", path.display()))?;
+        output
+            .write_all(&bytes)
+            .map_err(|error| format!("write {}: {error}", path.display()))?;
+    }
     match &result.font_path {
         Some(p) => println!(
             "wrote {} ({} pages, {} KB) — Korean font embedded from {p}",
@@ -801,7 +847,7 @@ fn export_pdf(file: &PathBuf, out: &Path) -> Result<(), String> {
 /// INTERIM (no `pdf` feature): explain the build flag + the headless-print fallback. We do NOT
 /// silently produce a wrong/empty file — the user gets an actionable message.
 #[cfg(not(feature = "pdf"))]
-fn export_pdf(file: &PathBuf, _out: &Path) -> Result<(), String> {
+fn export_pdf(file: &PathBuf, _out: &Path, _visual_regions: Option<&Path>) -> Result<(), String> {
     let _ = file;
     Err("export-pdf needs a build with `--features pdf` (krilla PDF backend + Korean font embedding).\n\
          Interim fallback without that feature: `auto-hwp export-html <doc> -o doc.html` then print the \

--- a/crates/hwp-export/Cargo.toml
+++ b/crates/hwp-export/Cargo.toml
@@ -19,12 +19,14 @@ krilla = { version = "0.8", optional = true, default-features = false, features 
 quick-xml = { workspace = true, optional = true }
 svgtypes = { version = "0.16", optional = true }
 kurbo = { version = "0.13", optional = true }
+serde = { workspace = true, optional = true }
+sha2 = { workspace = true, optional = true }
 
 [features]
 default = []
 # High-level PDF export (krilla): own layout → paint IR → PDF with Korean font subsetting. Pairs with
 # the caller's font provider; under `shaper` the real rustybuzz advances drive placement.
-pdf = ["dep:krilla", "dep:hwp-render", "dep:hwp-typeset", "dep:quick-xml", "dep:svgtypes", "dep:kurbo"]
+pdf = ["dep:krilla", "dep:hwp-render", "dep:hwp-typeset", "dep:quick-xml", "dep:svgtypes", "dep:kurbo", "dep:serde", "dep:sha2"]
 # Drive the PDF export's placement with the real shaper (forwarded to hwp-render/hwp-typeset).
 shaper = ["hwp-render?/shaper", "hwp-typeset?/shaper"]
 

--- a/crates/hwp-export/src/pdf.rs
+++ b/crates/hwp-export/src/pdf.rs
@@ -23,6 +23,7 @@ use hwp_model::font_class::{classify, FontCategory};
 use hwp_model::layout::{PageLayerTree, PaintOp};
 use hwp_model::prelude::FontMetricsProvider;
 use hwp_model::types::Color;
+use hwp_typeset::{BlockKind, PlacedDoc};
 
 use krilla::color::rgb;
 use krilla::geom::{PathBuilder, Point, Rect};
@@ -33,6 +34,8 @@ use krilla::paint::{
 };
 use krilla::text::{Font, TextDirection};
 use krilla::Document;
+use serde::Serialize;
+use sha2::{Digest, Sha256};
 
 use crate::svg_fragment::{
     DominantBaseline, Fragment, LineCap as SvgLineCap, LineJoin as SvgLineJoin, PathCommand,
@@ -240,6 +243,36 @@ pub struct PdfOptions {
     pub title: Option<String>,
 }
 
+/// Content-free visual regions derived from the exact placement that produced a PDF. Coordinates
+/// are HWPUNIT in page space; no glyph text, model address, file path, font path, or binary id is
+/// exposed. The candidate hash binds this evidence to one exact PDF byte stream.
+#[derive(Clone, Debug, Serialize)]
+pub struct PdfVisualEvidence {
+    pub schema_version: u32,
+    pub coordinate_space: &'static str,
+    pub candidate_pdf_sha256: String,
+    pub pages: Vec<PdfPageVisualEvidence>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct PdfPageVisualEvidence {
+    pub page: usize,
+    pub width: f64,
+    pub height: f64,
+    pub regions: Vec<PdfVisualRegion>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct PdfVisualRegion {
+    pub id: String,
+    pub category: &'static str,
+    pub x: f64,
+    pub y: f64,
+    pub w: f64,
+    pub h: f64,
+    pub clipped: bool,
+}
+
 /// Result of a PDF export: the bytes plus what font path (if any) backed the glyphs.
 #[derive(Clone, Debug)]
 pub struct PdfExport {
@@ -251,6 +284,114 @@ pub struct PdfExport {
     pub replay: Vec<PdfPageReplayStats>,
     /// Bounded capability failures. An unsupported SVG never becomes an unexplained blank object.
     pub diagnostics: Vec<PdfCapabilityDiagnostic>,
+    /// Additive report-only regions from the same placement and font provider as `bytes`.
+    pub visual_evidence: PdfVisualEvidence,
+}
+
+fn push_visual_region(
+    regions: &mut Vec<PdfVisualRegion>,
+    counters: &mut [usize; 4],
+    category_index: usize,
+    category: &'static str,
+    page_width: f64,
+    page_height: f64,
+    raw: (f64, f64, f64, f64),
+) -> Result<(), String> {
+    let (x, y, w, h) = raw;
+    if ![page_width, page_height, x, y, w, h]
+        .into_iter()
+        .all(f64::is_finite)
+    {
+        return Err("pdf.visual_evidence.non_finite_geometry".into());
+    }
+    if page_width <= 0.0 || page_height <= 0.0 || w <= 0.0 || h <= 0.0 {
+        return Ok(());
+    }
+    let raw_right = x + w;
+    let raw_bottom = y + h;
+    let left = x.clamp(0.0, page_width);
+    let top = y.clamp(0.0, page_height);
+    let right = raw_right.clamp(0.0, page_width);
+    let bottom = raw_bottom.clamp(0.0, page_height);
+    if right <= left || bottom <= top {
+        return Ok(());
+    }
+    counters[category_index] += 1;
+    regions.push(PdfVisualRegion {
+        id: format!("{category}-{:04}", counters[category_index]),
+        category,
+        x: left,
+        y: top,
+        w: right - left,
+        h: bottom - top,
+        clipped: left != x || top != y || right != raw_right || bottom != raw_bottom,
+    });
+    Ok(())
+}
+
+fn visual_evidence(
+    placed: &PlacedDoc,
+    candidate_pdf_sha256: String,
+) -> Result<PdfVisualEvidence, String> {
+    let mut pages = Vec::with_capacity(placed.pages.len());
+    for (page_index, page) in placed.pages.iter().enumerate() {
+        let mut regions = Vec::new();
+        let mut counters = [0usize; 4];
+        for block in page
+            .blocks
+            .iter()
+            .filter(|block| block.kind == BlockKind::Paragraph)
+        {
+            push_visual_region(
+                &mut regions,
+                &mut counters,
+                0,
+                "text",
+                page.width,
+                page.height,
+                (block.x, block.y, block.w, block.h),
+            )?;
+        }
+        for table in &page.tables {
+            push_visual_region(
+                &mut regions,
+                &mut counters,
+                1,
+                "table",
+                page.width,
+                page.height,
+                (table.x, table.y, table.w, table.h),
+            )?;
+        }
+        for image in page.images.iter().filter(|image| !image.is_background) {
+            let (category_index, category) = if image.svg.is_some() {
+                (3, "object")
+            } else {
+                (2, "image")
+            };
+            push_visual_region(
+                &mut regions,
+                &mut counters,
+                category_index,
+                category,
+                page.width,
+                page.height,
+                (image.x, image.y, image.w, image.h),
+            )?;
+        }
+        pages.push(PdfPageVisualEvidence {
+            page: page_index + 1,
+            width: page.width,
+            height: page.height,
+            regions,
+        });
+    }
+    Ok(PdfVisualEvidence {
+        schema_version: 1,
+        coordinate_space: "HWPUNIT",
+        candidate_pdf_sha256,
+        pages,
+    })
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -342,7 +483,7 @@ pub fn export_pdf_with_fonts(
     injected_fonts: &[(String, Vec<u8>)],
 ) -> Result<PdfExport, String> {
     // One PageLayerTree per page from our own pipeline — the SAME IR the SVG sink replays.
-    let trees = hwp_render::render_doc_trees(doc, fonts);
+    let (placed, trees) = hwp_render::render_doc_trees_with_placement(doc, fonts);
     // Injected bytes win over discover (wasm has no fs fonts); an empty slice → pure discover (native
     // path, byte-identical). A non-empty-but-unparseable injection still falls back to discover.
     let embed = if injected_fonts.is_empty() {
@@ -376,12 +517,15 @@ pub fn export_pdf_with_fonts(
     let bytes = document
         .finish()
         .map_err(|e| format!("krilla finish: {e:?}"))?;
+    let candidate_pdf_sha256 = format!("{:x}", Sha256::digest(&bytes));
+    let visual_evidence = visual_evidence(&placed, candidate_pdf_sha256)?;
     Ok(PdfExport {
         pages: trees.len(),
         bytes,
         font_path: embed.as_ref().map(|f| f.path.clone()),
         replay,
         diagnostics,
+        visual_evidence,
     })
 }
 
@@ -1157,6 +1301,23 @@ mod tests {
             "non-trivial PDF size, got {}",
             out.bytes.len()
         );
+        assert_eq!(out.visual_evidence.schema_version, 1);
+        assert_eq!(out.visual_evidence.coordinate_space, "HWPUNIT");
+        assert_eq!(out.visual_evidence.pages.len(), out.pages);
+        assert_eq!(
+            out.visual_evidence.candidate_pdf_sha256,
+            format!("{:x}", Sha256::digest(&out.bytes))
+        );
+        let regions = &out.visual_evidence.pages[0].regions;
+        assert!(regions.iter().any(|region| region.category == "text"));
+        assert!(regions.iter().all(|region| {
+            region.x >= 0.0
+                && region.y >= 0.0
+                && region.w > 0.0
+                && region.h > 0.0
+                && region.x + region.w <= out.visual_evidence.pages[0].width
+                && region.y + region.h <= out.visual_evidence.pages[0].height
+        }));
     }
 
     #[test]
@@ -1275,6 +1436,12 @@ mod tests {
         assert_eq!(chart.produced, chart.replayed);
         assert_eq!(chart.stubbed, 0);
         assert!(out.diagnostics.iter().all(|d| d.kind != "chart"));
+        assert!(out
+            .visual_evidence
+            .pages
+            .iter()
+            .flat_map(|page| &page.regions)
+            .any(|region| region.category == "object"));
     }
 
     #[test]

--- a/crates/hwp-render/src/lib.rs
+++ b/crates/hwp-render/src/lib.rs
@@ -496,7 +496,19 @@ pub fn render_doc_svg(doc: &SemanticDoc, fonts: &dyn FontMetricsProvider) -> Vec
 /// SAME trees, so every export matches own-render. (The SVG sink uses this under the hood via
 /// [`render_doc_svg`]; PDF export in `hwp-export` consumes these directly.)
 pub fn render_doc_trees(doc: &SemanticDoc, fonts: &dyn FontMetricsProvider) -> Vec<PageLayerTree> {
-    place_doc(doc, fonts).pages.iter().map(lower_page).collect()
+    render_doc_trees_with_placement(doc, fonts).1
+}
+
+/// Lower `doc` to paint trees while retaining the exact positioned document that produced them.
+/// Visual evidence and PDF export use this entry point so diagnostic regions can never come from a
+/// second layout pass or a different font provider.
+pub fn render_doc_trees_with_placement(
+    doc: &SemanticDoc,
+    fonts: &dyn FontMetricsProvider,
+) -> (hwp_typeset::PlacedDoc, Vec<PageLayerTree>) {
+    let placed = place_doc(doc, fonts);
+    let trees = placed.pages.iter().map(lower_page).collect();
+    (placed, trees)
 }
 
 /// Content-free paint ownership for one operation in the shared page tree. The mask carries no

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,6 +3,36 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
+- 갱신: 2026-08-25 · Codex(sol) — **#213 one-command semantic PDF visual check full green · PR 직전**.
+  `render_doc_trees_with_placement` 한 번의 first-party placement에서 own PDF와 SHA-bound content-free
+  text/table/image/object 영역을 함께 만들고, strict schema/쪽·MediaBox/유한·범위·중복·symlink·8MiB·
+  10k/2k count 및 페이지 16배 overlap-work 상한으로 검증한다. comparator schema 4는 페이지의 단일
+  ±3px 정렬만 재사용해 영역별 SSIM-like/MAE/ink/edge, 채점불가 사유, category count와 worst 5를 낸다.
+  `document-visual-check.mjs`는 HWP/HWPX→own PDF+evidence→report를 private stage에서 전부 성공한 뒤
+  atomic rename하며 overwrite/partial/private subprocess output을 거부한다. HWPX 표·수식 self-compare는
+  table/text/object 영역 1.0, 공개 HWP 8쪽은 102영역(70 text/32 table)을 실측해 page 8 ink F1
+  **0.218434**, 여러 text 영역 **0.0**을 다음 조판 결함으로 노출했다(참값 threshold/pass는 계속 null).
+  focused Rust/Python **55**/Node **3**, quick, full canonical **8/18/24+98.9%**, oracle **82**,
+  wasm **8,002,199B**, Vitest **1,012**, Chromium **85 pass/3 intentional skip** green이다. sandbox port
+  EPERM만 승인된 동일 E2E로 해소했고 rhwp `f137b4c9`는 무수정이다. **다음:** privacy/diff 최종 감사→
+  commit/push→PR `Closes #213`·`Refs #93`→exact-head CI/댓글 green 자율 병합→#93에 content-free 실측을
+  동기화하고 worst text-region을 최소 fixture로 만드는 다음 bounded fidelity child를 issue-first 착수한다.
+
+- 갱신: 2026-08-24 · Codex(sol) — **PR #212 병합 · #93 end-to-end PDF fidelity 재감사 착수**.
+  #106은 exact head `558b168`에서 issue-link **4s**·licenses **17m44s**·build-test **19m33s** green,
+  CLEAN/MERGEABLE, review/general/inline 댓글 0으로 protected main `e0b1c8d`에 squash 병합됐다.
+  합성 20문서·120작업의 12축 평가와 safety/무권한 변경·전송/atomicity/reversibility 100% gate가
+  contributor CI에 들어갔고 live provider는 exact model/version/no-fallback report-only로 분리됐다.
+  최신 main에서 시각 fidelity worktree와 pinned rhwp `f137b4c9`를 oracle로만 초기화했다.
+  **판단:** #94 first-party HWP5는 공개 benchmark body parity까지 왔지만 corpus cutover 근거가 부족해
+  production decode는 아직 rhwp다. 현재 ready P0는 #93이며, 이미 병합된 #101/#102/#121과 pair 03/04
+  구조 복구 위에서 JSON/HTML/worst-region/manifest/20-pair 근거 중 실제 잔여만 식별해 구현한다.
+  재감사 결과 20 T1 manifest, 구조 우선, JSON/HTML+5종 PNG, worst page/tile, sink parity는 이미 구현됐고,
+  단일 document→own PDF→report 명령과 의미영역 점수만 미완이다. 이를 child #213으로 등재하고 브랜치를
+  `codex/issue-213-visual-regions`로 확정했다. **다음:** 같은 first-party placement에서 content-free
+  text/table/image/object region manifest를 생성하고 comparator·one-command runner·hostile tests를 구현한다.
+  기존 page/tile 판정과 오라클·threshold는 완화하지 않는다.
+
 - 갱신: 2026-08-24 · Codex(sol) — **#106 AI-native task suite 구현·full green · PR 직전**.
   합성 문서 20종×6 시나리오=120 작업을 versioned manifest/recorded result로 잠그고 schema, target,
   semantic, atomicity, undo, stale, layout, export, safety, 무권한 변경·전송, reversibility를 독립 채점한다.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,12 @@
 
 ---
 
+## 2026-08-25 (Codex sol) · #213 semantic PDF visual check
+- HWP/HWPX→own PDF→SHA-bound text/table/image/object metrics를 한 atomic 명령으로 연결.
+- strict manifest·resource/privacy hostile 경계와 worst 5 region JSON/HTML, CI 계약을 추가.
+- quick/full green: 8/18/24+98.9%, oracle82, Vitest1,012, Chromium85 pass/3 skip; rhwp 무수정.
+- 다음: commit/push→`Closes #213` PR/CI/merge→#93 worst text-region 최소 fixture.
+
 ## 2026-08-24 (Codex sol) · #106 AI-native task suite
 - 합성 20문서·120작업을 12개 독립 점수와 안전/원자성/가역성 100% gate로 잠금.
 - provider no-fallback live report를 contributor CI에서 분리하고 prompt-injection hostile 11건 추가.

--- a/docs/PDF-VISUAL-ORACLE.md
+++ b/docs/PDF-VISUAL-ORACLE.md
@@ -1,10 +1,11 @@
-# PDF visual oracle (report-only V0/V1)
+# PDF visual oracle (report-only V0/V1/V2)
 
 This document describes the bounded report-only foundation in GitHub issue #121, under the broader
-#93 visual-oracle track. It compares a PDF already exported by auto-hwp's own engine with an
-explicitly classified PDF reference. It does **not** render HWP/HWPX itself, infer that a nearby PDF
-is ground truth, or decide pass/fail.
-Current reports use `schema_version: 3`; non-finite values are rejected rather than emitted as
+#93 visual-oracle track. The low-level comparator compares an auto-hwp PDF with an explicitly
+classified PDF reference. Issue #213 adds a one-command HWP/HWPX runner and semantic regions emitted
+from the exact placement used by the PDF export. It does **not** infer that a nearby PDF is ground
+truth or decide pass/fail.
+Current reports use `schema_version: 4`; non-finite values are rejected rather than emitted as
 non-standard JSON `NaN`/`Infinity` tokens.
 
 The existing stored-lineseg `layout-check` remains the fast layout regression gate. This visual report
@@ -63,6 +64,9 @@ and self-compare determinism suite.
 - deterministic integer translation alignment bounded to ±3 px;
 - complementary global, local, foreground, ink, edge, bounding-box, and tile metrics;
 - local side-by-side, overlay, and heatmap diagnostics;
+- content-free text/table/image/object region metrics bound to the exact candidate PDF SHA-256;
+- a worst-five semantic-region ranking that reuses the one whole-page translation and performs no
+  object-local alignment;
 - explicit JSON `null` plus reasons when a metric is unscorable;
 - no absolute thresholds and no pass/fail field.
 
@@ -104,21 +108,32 @@ report because raster output can change across versions.
 
 ## Usage
 
-First export the candidate with our PDF path. Binary `.hwp` additionally needs the `rhwp` parser
-feature; this does not make rhwp the renderer.
+For normal document diagnosis, build the CLI and run the atomic one-command path. Binary `.hwp`
+additionally needs the `rhwp` parser feature; this does not make rhwp the renderer. The candidate PDF
+and content-free region evidence are both derived from our shared IR and placement.
 
 ```bash
-cargo run -p auto-hwp-cli --features pdf,shaper,rhwp -- \
-  export-pdf benchmarks/benchmark.hwp -o /tmp/benchmark-own.pdf
+cargo build -p auto-hwp-cli --features "pdf shaper rhwp"
+node scripts/document-visual-check.mjs benchmarks/benchmark.hwp \
+  --reference benchmarks/benchmark.pdf \
+  --reference-tier T3 \
+  --output-dir /tmp/benchmark-visual-report \
+  --cli target/debug/auto-hwp
 ```
 
-Then compare that explicit candidate with a reference. The output directory must not already exist.
-The report is built in a sibling staging directory and renamed into place only after JSON, HTML, and
-all assets succeed, so a failed run does not leave a partial report that blocks retry.
+Use T0/T1 only with the complete self-attested provenance options documented below. The output
+directory must not already exist. Candidate export, region evidence, JSON, HTML, and assets are built
+in a private sibling staging directory and renamed together only after every step succeeds.
+
+The lower-level two-step interface remains available for isolated comparator work:
 
 ```bash
+target/debug/auto-hwp export-pdf benchmarks/benchmark.hwp \
+  -o /tmp/benchmark-own.pdf \
+  --visual-regions /tmp/benchmark-own.regions.json
 python3 scripts/pdf-visual-check.py /tmp/benchmark-own.pdf \
   --reference benchmarks/benchmark.pdf \
+  --candidate-regions /tmp/benchmark-own.regions.json \
   --reference-tier T1 \
   --reference-product "official publication PDF" \
   --reference-build "recorded by fixture manifest" \
@@ -129,8 +144,9 @@ python3 scripts/pdf-visual-check.py /tmp/benchmark-own.pdf \
   --output-dir /tmp/benchmark-visual-report
 ```
 
-Open `/tmp/benchmark-visual-report/index.html` locally. Machine-readable results are in
-`report.json`; stable PNG assets are under `assets/`.
+Open `/tmp/benchmark-visual-report/index.html` locally. The one-command result keeps the comparator
+under `report/report.json` and `report/assets/`, alongside the exact candidate PDF, SHA-bound region
+evidence, and a content-free `summary.json`.
 
 Input paths are redacted to their basenames by default so private directory names do not leak into a
 shared report. `--include-input-paths` is an explicit local-only override; SHA-256 remains the stable
@@ -303,8 +319,24 @@ exact ink-recall value, and the worst tile is reported with its coordinates and 
 the first report-only local-region alarm: a tiny missing equation or chart cannot disappear inside an
 otherwise white, globally similar page.
 
-Future slices may add semantic text/table/image/equation/chart regions from `PageLayerTree`; these
-fixed tiles do not claim to identify object types.
+### Semantic regions
+
+When `--candidate-regions` is supplied, the exporter evidence divides the candidate placement into
+four content-free categories: paragraph bands (`text`), placed table boxes (`table`), raster images
+(`image`), and SVG-backed equations/charts/other objects (`object`). IDs and HWPUNIT geometry are
+present; source text, paths, binary identifiers, and font paths are absent.
+
+The manifest must be strict UTF-8 JSON with exactly the known fields, ordered one-based pages, finite
+positive in-page geometry, unique per-page IDs, matching MediaBox dimensions, and an exact SHA-256
+match to the candidate PDF. It is rejected on unknown categories/fields, non-finite values, duplicate
+IDs, page mismatch, symlink input, excessive entries, or more than 16 page-equivalents of overlapping
+region area. These bounds keep repeated full-page regions from multiplying metric work.
+
+Each region is cropped only after the page's single bounded translation is chosen. There is no second
+search that could hide a locally misplaced object. The report records independent SSIM-like, MAE,
+ink, and edge diagnostics, explicit unscorable reasons, per-category counts, and the worst five
+regions. Regions are additive and may overlap—for example, cell text remains inside a table region—so
+they are diagnostic lenses rather than a partition or an aggregate quality score.
 
 ## Visual report
 
@@ -317,9 +349,9 @@ For every dimension-compatible page, `index.html` shows:
 - absolute grayscale-difference heatmap;
 - a metric table and the complete page JSON.
 
-The summary lists up to five lowest-ink-F1 pages and five lowest-recall worst tiles. These are
-diagnostic rankings only, not acceptance decisions. HTML has no remote scripts, fonts, or network
-dependencies.
+The summary lists up to five lowest-ink-F1 pages, five lowest-recall worst tiles, and five worst
+semantic regions when evidence is present. These are diagnostic rankings only, not acceptance
+decisions. HTML has no remote scripts, fonts, or network dependencies.
 
 ## Determinism and identity
 
@@ -342,10 +374,10 @@ the output. Repeating a comparison with identical file bytes, command arguments,
 and OS/font environment should therefore produce identical report bytes and asset PNGs even when the
 input parents and output directories differ.
 
-The current CLI computes hashes but does not yet consume a signed fixture manifest. Issue #101 owns
-the ≥20-pair T0/T1 calibration and reviewed-manifest work: source/reference hash, Hancom
-product/build, OS, export method, font-file hashes, and redistribution authority. A sibling `.pdf`
-alone must never be promoted to T0 or T1.
+The current CLI computes hashes and binds semantic evidence to the exact PDF, but it does not consume
+a cryptographically signed fixture manifest. The ≥20-pair T1 calibration stores reviewed source and
+reference hashes, producer/build/OS/export/font metadata, and redistribution authority. A sibling
+`.pdf` alone must never be promoted to T0 or T1.
 
 ## Report-only interpretation
 
@@ -395,7 +427,7 @@ Run the dependency-free synthetic metric and PNG codec suite with:
 python3 scripts/tests/test_pdf_visual_check.py -v
 ```
 
-The suite covers exact identity, bounded translation, clipped-ink penalties, translation overflow,
+The suites cover exact identity, bounded translation, clipped-ink penalties, translation overflow,
 missing small foreground, blank/unscorable semantics, missing-all-ink loss, 2 px edge tolerance,
 white padding without resampling, PNG round-trips, A4 tolerance, and structural mismatches. It also
 exercises valid/different CropBoxes, `-cropbox` page rendering, input/page/pixel/raster/decompression,
@@ -403,29 +435,31 @@ ink/alignment/edge-work, derived-asset, and report-total limits; subprocess outp
 and POSIX file-size caps;
 T0/T1 provenance, path redaction, forced `0700`/`0600` modes under umask `000` and `022`, secure
 symlink rejection, finite box/rotation validation, resource-exhaustion conversion,
-structural-before-raster orchestration, complete unscorable HTML/JSON output, and atomic failure.
+structural-before-raster orchestration, strict SHA-bound semantic-region validation, bounded region
+work, fixed-global-alignment region scoring, complete unscorable HTML/JSON output, and atomic failure.
+The Node suite additionally covers one-command private staging, no-overwrite behavior, source-path
+redaction, symlink rejection, and failed-subprocess cleanup.
 When Poppler and
 `benchmarks/benchmark.pdf` are present, it rasterizes the first page and performs an exact
 self-compare; otherwise that integration case is skipped.
 
-The standard-library suite is wired into `scripts/verify-local.sh` and the required GitHub
-`build-test` job through `unittest discover`. It includes a two-run whole-report determinism check
+Both suites are wired into `scripts/verify-local.sh` and the required GitHub `build-test` job. The
+Python suite includes a two-run whole-report determinism check
 covering the raw byte-identical `report.json`, HTML, and every raw/derived PNG asset without deleting,
 normalizing, or ignoring any clock or path field.
 Synthetic/structural/resource tests need no third-party Python dependency; the one Poppler
 self-compare remains automatically skipped when Poppler or the benchmark fixture is unavailable.
 
-## Known first-slice limits
+## Known limits
 
-- Inputs are PDF files; reference manifests are not yet parsed.
 - Provenance is required and labelled `self_attested`, but no signed manifest authenticates it yet.
-- The script assumes the caller already produced the candidate through `export-pdf`.
-- It does not yet compare own SVG against own PDF from the same `PageLayerTree`.
-- It cannot yet count text/table/image/equation/chart objects or PDF replay/stub events; issue #102
-  owns object accounting and SVG/PDF replay/sink parity.
+- Semantic evidence describes candidate placement, not reference-document object boundaries; metrics
+  therefore answer “how does this candidate region compare at the same location?” rather than doing
+  cross-document object matching.
+- Equations and charts share the `object` category; subtype attribution remains future work.
+- Paragraph regions are block bands. Text inside a table is diagnosed through the containing table
+  region rather than duplicated as an independent text region.
 - It does not mask dynamic regions; broad automatic masking would make missing content easier to hide.
-- It does not address the known PDF `PaintOp::Image.svg` equation/chart stub. Instead, the current
-  image/tile diagnostics make that loss visible while the renderer fix proceeds separately.
 - Poppler version and platform are recorded but not enforced by a baseline manifest yet.
 - A non-POSIX platform cannot stop `pdftoppm` while it is writing an oversized file; it falls back to
   the documented post-write stat check.

--- a/scripts/document-visual-check.mjs
+++ b/scripts/document-visual-check.mjs
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import {
+  chmodSync, existsSync, lstatSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync,
+} from "node:fs";
+import { dirname, extname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repo = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const VALUE_OPTIONS = new Set([
+  "--reference", "--reference-tier", "--reference-product", "--reference-build",
+  "--reference-os", "--font-fingerprint", "--candidate-font-fingerprint", "--reference-note",
+  "--output-dir", "--cli", "--python", "--max-translation-px",
+]);
+
+export function usage() {
+  return `Usage:
+  node scripts/document-visual-check.mjs DOCUMENT.hwp[x] \\
+    --reference REFERENCE.pdf --reference-tier T0|T1|T2|T3 \\
+    --output-dir NEW_DIR [provenance options] [--cli target/debug/auto-hwp]
+
+The command exports DOCUMENT through auto-hwp's own PDF path, emits content-free semantic regions
+from the same placement, and runs the report-only PDF comparator. It never defines a pass threshold.`;
+}
+
+export function parseArgs(argv) {
+  const args = { cli: join(repo, "target/debug/auto-hwp"), python: "python3" };
+  let document = null;
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--help" || arg === "-h") args.help = true;
+    else if (arg.startsWith("--")) {
+      if (!VALUE_OPTIONS.has(arg)) throw new Error(`unknown option: ${arg}`);
+      const value = argv[++index];
+      if (!value || value.startsWith("--")) throw new Error(`${arg} requires a value`);
+      args[arg.slice(2).replaceAll("-", "_")] = value;
+    } else if (document === null) document = arg;
+    else throw new Error(`unexpected positional argument: ${arg}`);
+  }
+  if (args.help) return { ...args, document };
+  for (const required of ["reference", "reference_tier", "output_dir"]) {
+    if (!args[required]) throw new Error(`--${required.replaceAll("_", "-")} is required`);
+  }
+  if (!document) throw new Error("DOCUMENT.hwp[x] is required");
+  if (!new Set(["T0", "T1", "T2", "T3"]).has(args.reference_tier)) {
+    throw new Error("--reference-tier must be T0, T1, T2, or T3");
+  }
+  if (args.max_translation_px !== undefined && !/^[0-3]$/.test(args.max_translation_px)) {
+    throw new Error("--max-translation-px must be 0..3");
+  }
+  return { ...args, document };
+}
+
+function regularFile(path, label) {
+  const stat = lstatSync(path);
+  if (!stat.isFile() || stat.isSymbolicLink()) throw new Error(`${label} must be a regular non-symlink file`);
+}
+
+function command(executable, args, label, timeout = 300_000) {
+  const result = spawnSync(executable, args, {
+    cwd: repo,
+    encoding: "utf8",
+    maxBuffer: 2 * 1024 * 1024,
+    timeout,
+    shell: false,
+  });
+  if (result.error) throw new Error(`${label} could not start: ${result.error.code ?? result.error.message}`);
+  if (result.status !== 0) throw new Error(`${label} failed with exit status ${result.status}; no private subprocess output was copied`);
+}
+
+function privateFile(path) {
+  regularFile(path, "generated artifact");
+  chmodSync(path, 0o600);
+}
+
+export function runVisualCheck(args) {
+  const document = resolve(args.document);
+  const reference = resolve(args.reference);
+  const cli = resolve(args.cli);
+  const outputDir = resolve(args.output_dir);
+  if (![".hwp", ".hwpx"].includes(extname(document).toLowerCase())) throw new Error("DOCUMENT must end in .hwp or .hwpx");
+  if (extname(reference).toLowerCase() !== ".pdf") throw new Error("--reference must end in .pdf");
+  regularFile(document, "document");
+  regularFile(reference, "reference");
+  regularFile(cli, "auto-hwp CLI");
+  if (existsSync(outputDir)) throw new Error("output directory already exists; refusing to overwrite");
+  const outputParent = dirname(outputDir);
+  mkdirSync(outputParent, { recursive: true, mode: 0o700 });
+  const parentStat = lstatSync(outputParent);
+  if (!parentStat.isDirectory() || parentStat.isSymbolicLink()) throw new Error("output parent must be a real directory");
+  const stage = join(outputParent, `.auto-hwp-visual-${process.pid}-${randomBytes(6).toString("hex")}`);
+  mkdirSync(stage, { mode: 0o700 });
+  const candidate = join(stage, "candidate-own.pdf");
+  const regions = join(stage, "candidate-regions.json");
+  const report = join(stage, "report");
+  try {
+    command(cli, ["export-pdf", document, "-o", candidate, "--visual-regions", regions], "own PDF export");
+    privateFile(candidate);
+    privateFile(regions);
+    const compareArgs = [
+      join(repo, "scripts/pdf-visual-check.py"), candidate,
+      "--reference", reference,
+      "--candidate-regions", regions,
+      "--reference-tier", args.reference_tier,
+      "--output-dir", report,
+    ];
+    for (const [key, flag] of [
+      ["reference_product", "--reference-product"],
+      ["reference_build", "--reference-build"],
+      ["reference_os", "--reference-os"],
+      ["font_fingerprint", "--font-fingerprint"],
+      ["candidate_font_fingerprint", "--candidate-font-fingerprint"],
+      ["reference_note", "--reference-note"],
+      ["max_translation_px", "--max-translation-px"],
+    ]) if (args[key] !== undefined) compareArgs.push(flag, args[key]);
+    command(args.python, compareArgs, "PDF visual comparator");
+    const evidence = JSON.parse(readFileSync(regions, "utf8"));
+    const reportJson = JSON.parse(readFileSync(join(report, "report.json"), "utf8"));
+    const summary = {
+      schema_version: 1,
+      mode: "report-only",
+      source_format: extname(document).slice(1).toLowerCase(),
+      candidate_pdf_sha256: evidence.candidate_pdf_sha256,
+      visual_region_schema_version: evidence.schema_version,
+      report_status: reportJson.status,
+      policy_pass: null,
+      artifacts: {
+        candidate_pdf: "candidate-own.pdf",
+        candidate_regions: "candidate-regions.json",
+        report_json: "report/report.json",
+        report_html: "report/index.html",
+      },
+    };
+    writeFileSync(join(stage, "summary.json"), `${JSON.stringify(summary, null, 2)}\n`, { mode: 0o600, flag: "wx" });
+    writeFileSync(
+      join(stage, "index.html"),
+      "<!doctype html><meta charset=\"utf-8\"><title>auto-hwp visual check</title>" +
+        "<h1>auto-hwp visual check - report only</h1><p>No pass/fail threshold is defined.</p>" +
+        "<p><a href=\"report/index.html\">Open the visual report</a></p>",
+      { mode: 0o600, flag: "wx" },
+    );
+    chmodSync(stage, 0o700);
+    if (existsSync(outputDir)) throw new Error("output directory appeared during generation; refusing to replace it");
+    renameSync(stage, outputDir);
+    chmodSync(outputDir, 0o700);
+    return summary;
+  } catch (error) {
+    rmSync(stage, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+if (resolve(process.argv[1] ?? "") === fileURLToPath(import.meta.url)) {
+  try {
+    const args = parseArgs(process.argv.slice(2));
+    if (args.help) console.log(usage());
+    else {
+      const result = runVisualCheck(args);
+      console.log(`document visual check: ${result.report_status} (report-only; pass=null)`);
+      console.log(`html: ${resolve(args.output_dir, "index.html")}`);
+    }
+  } catch (error) {
+    console.error(`document-visual-check: ${error.message}`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/pdf-visual-check.py
+++ b/scripts/pdf-visual-check.py
@@ -39,7 +39,7 @@ except ImportError:  # pragma: no cover - exercised only on non-POSIX Python.
     posix_resource = None  # type: ignore[assignment]
 
 
-SCHEMA_VERSION = 3
+SCHEMA_VERSION = 4
 DPI = 144
 MAX_TRANSLATION_PX = 3
 INK_THRESHOLD = 245
@@ -84,6 +84,13 @@ HARD_MAX_REPORT_ASSET_BYTES = 128 * MIB
 HARD_MAX_REPORT_BYTES = 2 * GIB
 HARD_MAX_SUBPROCESS_OUTPUT_BYTES = 4 * MIB
 HARD_SUBPROCESS_TIMEOUT_SECONDS = 300.0
+
+VISUAL_REGION_SCHEMA_VERSION = 1
+MAX_VISUAL_REGION_MANIFEST_BYTES = 8 * MIB
+MAX_VISUAL_REGIONS_TOTAL = 10_000
+MAX_VISUAL_REGIONS_PER_PAGE = 2_000
+MAX_VISUAL_REGION_PAGE_AREA_MULTIPLIER = 16
+VISUAL_REGION_CATEGORIES = frozenset({"text", "table", "image", "object"})
 
 REFERENCE_TIERS: Mapping[str, str] = {
     "T0": "Licensed Hancom Windows/WebHWP rendering with product, build, and font provenance.",
@@ -369,6 +376,140 @@ def _snapshot_file(source: Path, destination: Path, max_bytes: int) -> int:
     finally:
         os.close(input_fd)
     return total
+
+
+def _reject_json_constant(value: str) -> Any:
+    raise VisualCheckError(f"visual region manifest contains non-finite JSON value: {value}")
+
+
+def _exact_object_keys(value: Any, expected: Set[str], label: str) -> Mapping[str, Any]:
+    if not isinstance(value, dict):
+        raise VisualCheckError(f"{label} must be an object")
+    actual = set(value)
+    if actual != expected:
+        missing = sorted(expected - actual)
+        unknown = sorted(actual - expected)
+        raise VisualCheckError(
+            f"{label} fields differ; missing={missing}, unknown={unknown}"
+        )
+    return value
+
+
+def _finite_number(value: Any, label: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise VisualCheckError(f"{label} must be a finite number")
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise VisualCheckError(f"{label} must be a finite number")
+    return parsed
+
+
+def _load_visual_regions(
+    snapshot: Path,
+    candidate_sha256: str,
+    candidate_info: PdfInfo,
+) -> Dict[str, Any]:
+    try:
+        document = json.loads(
+            snapshot.read_text("utf-8"), parse_constant=_reject_json_constant
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise VisualCheckError(f"visual region manifest is not strict UTF-8 JSON: {error}") from error
+    root = _exact_object_keys(
+        document,
+        {"schema_version", "coordinate_space", "candidate_pdf_sha256", "pages"},
+        "visual region manifest",
+    )
+    if root["schema_version"] != VISUAL_REGION_SCHEMA_VERSION:
+        raise VisualCheckError("visual region manifest schema_version must be 1")
+    if root["coordinate_space"] != "HWPUNIT":
+        raise VisualCheckError("visual region manifest coordinate_space must be HWPUNIT")
+    if root["candidate_pdf_sha256"] != candidate_sha256:
+        raise VisualCheckError("visual region manifest candidate PDF SHA-256 mismatch")
+    pages = root["pages"]
+    if not isinstance(pages, list) or len(pages) != candidate_info.page_count:
+        raise VisualCheckError("visual region manifest page count does not match candidate PDF")
+
+    ids: Set[str] = set()
+    total_regions = 0
+    category_counts = {category: 0 for category in sorted(VISUAL_REGION_CATEGORIES)}
+    for index, (page, pdf_page) in enumerate(zip(pages, candidate_info.pages), start=1):
+        page = _exact_object_keys(
+            page, {"page", "width", "height", "regions"}, f"visual regions page {index}"
+        )
+        if page["page"] != index:
+            raise VisualCheckError("visual region manifest pages must be ordered and one-based")
+        page_width = _finite_number(page["width"], f"visual regions page {index}.width")
+        page_height = _finite_number(page["height"], f"visual regions page {index}.height")
+        if page_width <= 0 or page_height <= 0:
+            raise VisualCheckError("visual region page dimensions must be positive")
+        if (
+            abs(page_width / 100.0 - pdf_page.width_pt) > PDF_BOX_VALIDATION_TOLERANCE_PT
+            or abs(page_height / 100.0 - pdf_page.height_pt) > PDF_BOX_VALIDATION_TOLERANCE_PT
+        ):
+            raise VisualCheckError(
+                f"visual regions page {index} dimensions do not match candidate PDF MediaBox"
+            )
+        regions = page["regions"]
+        if not isinstance(regions, list) or len(regions) > MAX_VISUAL_REGIONS_PER_PAGE:
+            raise VisualCheckError(
+                f"visual regions page {index} exceeds {MAX_VISUAL_REGIONS_PER_PAGE} entries"
+            )
+        total_regions += len(regions)
+        if total_regions > MAX_VISUAL_REGIONS_TOTAL:
+            raise VisualCheckError(
+                f"visual region manifest exceeds {MAX_VISUAL_REGIONS_TOTAL} entries"
+            )
+        page_region_area = 0.0
+        for region_index, region in enumerate(regions):
+            label = f"visual regions page {index}.regions[{region_index}]"
+            region = _exact_object_keys(
+                region, {"id", "category", "x", "y", "w", "h", "clipped"}, label
+            )
+            region_id = region["id"]
+            if not isinstance(region_id, str) or not re.fullmatch(
+                r"(?:text|table|image|object)-[0-9]{4}", region_id
+            ):
+                raise VisualCheckError(f"{label}.id is invalid")
+            global_id = f"{index}:{region_id}"
+            if global_id in ids:
+                raise VisualCheckError(f"duplicate visual region id: {global_id}")
+            ids.add(global_id)
+            category = region["category"]
+            if category not in VISUAL_REGION_CATEGORIES or not region_id.startswith(f"{category}-"):
+                raise VisualCheckError(f"{label}.category is invalid or disagrees with id")
+            if not isinstance(region["clipped"], bool):
+                raise VisualCheckError(f"{label}.clipped must be boolean")
+            x = _finite_number(region["x"], f"{label}.x")
+            y = _finite_number(region["y"], f"{label}.y")
+            width = _finite_number(region["w"], f"{label}.w")
+            height = _finite_number(region["h"], f"{label}.h")
+            epsilon = 1e-6
+            if (
+                x < -epsilon
+                or y < -epsilon
+                or width <= 0
+                or height <= 0
+                or x + width > page_width + epsilon
+                or y + height > page_height + epsilon
+            ):
+                raise VisualCheckError(f"{label} is outside its page or has empty geometry")
+            page_region_area += width * height
+            if (
+                page_region_area
+                > page_width * page_height * MAX_VISUAL_REGION_PAGE_AREA_MULTIPLIER
+            ):
+                raise VisualCheckError(
+                    f"visual regions page {index} overlap area exceeds the bounded scoring budget"
+                )
+            category_counts[category] += 1
+    return {
+        "document": document,
+        "sha256": _sha256(snapshot),
+        "bytes": snapshot.stat().st_size,
+        "total_regions": total_regions,
+        "category_counts": category_counts,
+    }
 
 
 def _command_env() -> Dict[str, str]:
@@ -1733,6 +1874,110 @@ def _heatmap_pixels(reference: GrayImage, candidate: GrayImage) -> bytes:
     return bytes(output)
 
 
+def _crop_image(image: GrayImage, left: int, top: int, right: int, bottom: int) -> GrayImage:
+    if not (0 <= left < right <= image.width and 0 <= top < bottom <= image.height):
+        raise VisualCheckError("semantic region crop is empty or outside the raster canvas")
+    width = right - left
+    pixels = bytearray(width * (bottom - top))
+    target = 0
+    for row in range(top, bottom):
+        start = row * image.width + left
+        pixels[target : target + width] = image.pixels[start : start + width]
+        target += width
+    return GrayImage(width, bottom - top, bytes(pixels))
+
+
+def _score_visual_regions(
+    page_contract: Mapping[str, Any],
+    reference: GrayImage,
+    aligned_candidate: GrayImage,
+    candidate_raw_width: int,
+    candidate_raw_height: int,
+    translation: Mapping[str, int],
+    max_edge_work: int,
+) -> List[Dict[str, Any]]:
+    page_width = float(page_contract["width"])
+    page_height = float(page_contract["height"])
+    dx = int(translation["dx"])
+    dy = int(translation["dy"])
+    results: List[Dict[str, Any]] = []
+    for region in page_contract["regions"]:
+        raw_left = math.floor(float(region["x"]) * candidate_raw_width / page_width)
+        raw_top = math.floor(float(region["y"]) * candidate_raw_height / page_height)
+        raw_right = math.ceil(
+            (float(region["x"]) + float(region["w"]))
+            * candidate_raw_width
+            / page_width
+        )
+        raw_bottom = math.ceil(
+            (float(region["y"]) + float(region["h"]))
+            * candidate_raw_height
+            / page_height
+        )
+        left = max(0, raw_left + dx)
+        top = max(0, raw_top + dy)
+        right = min(reference.width, raw_right + dx)
+        bottom = min(reference.height, raw_bottom + dy)
+        base = {
+            "id": region["id"],
+            "category": region["category"],
+            "source_bounds_hwpunit": {
+                "x": region["x"],
+                "y": region["y"],
+                "w": region["w"],
+                "h": region["h"],
+            },
+            "source_clipped_to_page": region["clipped"],
+            "alignment_clipped": (
+                left != raw_left + dx
+                or top != raw_top + dy
+                or right != raw_right + dx
+                or bottom != raw_bottom + dy
+            ),
+        }
+        if right <= left or bottom <= top:
+            base.update(
+                {
+                    "status": "unscorable",
+                    "reason": "region moved outside the fixed page canvas by global alignment",
+                    "aligned_bounds_px": None,
+                    "metrics": None,
+                }
+            )
+            results.append(base)
+            continue
+        reference_crop = _crop_image(reference, left, top, right, bottom)
+        candidate_crop = _crop_image(aligned_candidate, left, top, right, bottom)
+        _, metrics = _compare_images(
+            reference_crop,
+            candidate_crop,
+            max_translation=0,
+            max_edge_work=max_edge_work,
+        )
+        base.update(
+            {
+                "status": metrics["status"],
+                "reason": None,
+                "aligned_bounds_px": {
+                    "left": left,
+                    "top": top,
+                    "width": right - left,
+                    "height": bottom - top,
+                },
+                "metrics": {
+                    "global_ssim_like": metrics["ssim_like"]["global"],
+                    "local_ssim_like_mean": metrics["ssim_like"]["local"]["mean"],
+                    "union_foreground_mae": metrics["union_foreground_mae"],
+                    "ink": metrics["ink"],
+                    "edge_f1": metrics["edge"]["f1"],
+                    "unscorable_metrics": metrics["unscorable_metrics"],
+                },
+            }
+        )
+        results.append(base)
+    return results
+
+
 def _format_metric(value: Any) -> str:
     if value is None:
         return "unscorable"
@@ -1771,6 +2016,26 @@ def _render_html(report: Mapping[str, Any]) -> str:
               <tr><td>Worst-tile recall</td><td>{_format_metric(None if worst_tile is None else worst_tile['recall'])}</td></tr>
             </table>
             """
+        semantic_regions = page.get("semantic_regions", [])
+        if semantic_regions:
+            region_rows = "".join(
+                "<tr>"
+                f"<td>{html.escape(region['id'])}</td>"
+                f"<td>{html.escape(region['category'])}</td>"
+                f"<td>{html.escape(region['status'])}</td>"
+                f"<td>{_format_metric(None if region.get('metrics') is None else region['metrics']['ink']['f1'])}</td>"
+                f"<td>{_format_metric(None if region.get('metrics') is None else region['metrics']['edge_f1'])}</td>"
+                "</tr>"
+                for region in semantic_regions
+            )
+            region_table = (
+                "<h3>Semantic regions (additive, report-only)</h3>"
+                "<table><tr><th>ID</th><th>Category</th><th>Status</th>"
+                "<th>Ink F1</th><th>Edge F1</th></tr>"
+                f"{region_rows}</table>"
+            )
+        else:
+            region_table = "<p class=muted>No first-party semantic region manifest was provided.</p>"
         artifacts = page.get("artifacts", {})
         image_cards: List[str] = []
         for key, label in (
@@ -1798,6 +2063,7 @@ def _render_html(report: Mapping[str, Any]) -> str:
               <h2>Page {page['page']} - {html.escape(page['status'])}</h2>
               <p>{html.escape(offset_text)}</p>
               {metric_rows}
+              {region_table}
               <div class=images>{''.join(image_cards)}</div>
               <details><summary>Page JSON</summary><pre>{html.escape(json.dumps(page, ensure_ascii=False, indent=2, sort_keys=True))}</pre></details>
             </section>
@@ -1821,6 +2087,7 @@ def _render_html(report: Mapping[str, Any]) -> str:
 
     worst_pages = report.get("summary", {}).get("worst_pages", [])
     worst_tiles = report.get("summary", {}).get("worst_tiles", [])
+    worst_regions = report.get("summary", {}).get("worst_regions", [])
     return f"""<!doctype html>
 <html lang=en>
 <head>
@@ -1872,6 +2139,7 @@ def _render_html(report: Mapping[str, Any]) -> str:
     <h2>Worst-page diagnostics</h2>
     <p>Worst pages: <code>{html.escape(json.dumps(worst_pages, ensure_ascii=False, sort_keys=True))}</code></p>
     <p>Worst tiles: <code>{html.escape(json.dumps(worst_tiles, ensure_ascii=False, sort_keys=True))}</code></p>
+    <p>Worst semantic regions: <code>{html.escape(json.dumps(worst_regions, ensure_ascii=False, sort_keys=True))}</code></p>
   </section>
   {''.join(page_sections)}
 </body>
@@ -1924,6 +2192,50 @@ def _summarize_pages(pages: Sequence[Mapping[str, Any]]) -> Dict[str, Any]:
             )
     tile_entries.sort(key=lambda item: (item["recall"], item["page"]))
 
+    region_entries = []
+    unscorable_regions = 0
+    partially_unscorable_regions = 0
+    category_counts: Dict[str, Dict[str, int]] = {}
+    for page in pages:
+        for region in page.get("semantic_regions", []):
+            category = region["category"]
+            counts = category_counts.setdefault(
+                category,
+                {"total": 0, "scored": 0, "partially_unscorable": 0, "unscorable": 0},
+            )
+            counts["total"] += 1
+            metrics = region.get("metrics")
+            if metrics is None:
+                counts["unscorable"] += 1
+                unscorable_regions += 1
+                continue
+            counts["scored"] += 1
+            if region.get("status") == "partially_unscorable":
+                counts["partially_unscorable"] += 1
+                partially_unscorable_regions += 1
+            region_entries.append(
+                {
+                    "page": page["page"],
+                    "id": region["id"],
+                    "category": category,
+                    "ink_f1": metrics["ink"]["f1"],
+                    "local_ssim_like_mean": metrics["local_ssim_like_mean"],
+                    "edge_f1": metrics["edge_f1"],
+                    "aligned_bounds_px": region["aligned_bounds_px"],
+                }
+            )
+
+    def region_key(region: Mapping[str, Any]) -> Tuple[float, float, int, str]:
+        return (
+            float("inf") if region["ink_f1"] is None else region["ink_f1"],
+            float("inf")
+            if region["local_ssim_like_mean"] is None
+            else region["local_ssim_like_mean"],
+            region["page"],
+            region["id"],
+        )
+    region_entries.sort(key=region_key)
+
     return {
         "total_pages": len(pages),
         "scored_pages": len(scored),
@@ -1931,6 +2243,11 @@ def _summarize_pages(pages: Sequence[Mapping[str, Any]]) -> Dict[str, Any]:
         "partially_unscorable_pages": len(partially_unscorable),
         "worst_pages": worst_pages,
         "worst_tiles": tile_entries[:5],
+        "worst_regions": region_entries[:5],
+        "scored_regions": len(region_entries),
+        "partially_unscorable_regions": partially_unscorable_regions,
+        "unscorable_regions": unscorable_regions,
+        "region_category_counts": category_counts,
     }
 
 
@@ -2234,12 +2551,20 @@ def _run_visual_check_impl(args: argparse.Namespace) -> Dict[str, Any]:
         temporary_path = Path(temporary)
         candidate_snapshot = temporary_path / "candidate.pdf"
         reference_snapshot = temporary_path / "reference.pdf"
+        regions_snapshot = None
         candidate_bytes = _snapshot_file(
             candidate_path, candidate_snapshot, limits.max_input_bytes
         )
         reference_bytes = _snapshot_file(
             reference_path, reference_snapshot, limits.max_input_bytes
         )
+        if args.candidate_regions:
+            regions_snapshot = temporary_path / "candidate-regions.json"
+            _snapshot_file(
+                Path(args.candidate_regions),
+                regions_snapshot,
+                MAX_VISUAL_REGION_MANIFEST_BYTES,
+            )
         return _run_visual_check_from_snapshots(
             args,
             candidate_snapshot,
@@ -2249,6 +2574,7 @@ def _run_visual_check_impl(args: argparse.Namespace) -> Dict[str, Any]:
             candidate_bytes,
             reference_bytes,
             limits,
+            regions_snapshot,
         )
 
 
@@ -2261,6 +2587,7 @@ def _run_visual_check_from_snapshots(
     candidate_bytes: int,
     reference_bytes: int,
     limits: ResourceLimits,
+    regions_snapshot: Optional[Path] = None,
 ) -> Dict[str, Any]:
     candidate_sha = _sha256(candidate_snapshot)
     reference_sha = _sha256(reference_snapshot)
@@ -2274,6 +2601,23 @@ def _run_visual_check_from_snapshots(
     )
     candidate_info = _inspect_pdf(candidate_snapshot, limits)
     reference_info = _inspect_pdf(reference_snapshot, limits)
+    visual_regions = (
+        _load_visual_regions(regions_snapshot, candidate_sha, candidate_info)
+        if regions_snapshot is not None
+        else None
+    )
+    report["inputs"]["candidate"]["visual_regions"] = (
+        {
+            "provided": True,
+            "schema_version": VISUAL_REGION_SCHEMA_VERSION,
+            "sha256": visual_regions["sha256"],
+            "bytes": visual_regions["bytes"],
+            "total_regions": visual_regions["total_regions"],
+            "category_counts": visual_regions["category_counts"],
+        }
+        if visual_regions is not None
+        else {"provided": False}
+    )
     structural = _compare_pdf_structure(candidate_info, reference_info)
     report["structural"] = structural
     report["pages"] = []
@@ -2292,6 +2636,9 @@ def _run_visual_check_from_snapshots(
             "partially_unscorable_pages": 0,
             "worst_pages": [],
             "worst_tiles": [],
+            "worst_regions": [],
+            "scored_regions": 0,
+            "unscorable_regions": 0,
             "pixel_comparison_attempted": False,
         }
         _write_report(output_dir, report, {}, limits)
@@ -2391,6 +2738,24 @@ def _run_visual_check_from_snapshots(
         width_delta = abs(candidate_raw_image.width - reference_raw_image.width)
         height_delta = abs(candidate_raw_image.height - reference_raw_image.height)
         if width_delta > MAX_RASTER_PADDING_PX or height_delta > MAX_RASTER_PADDING_PX:
+            semantic_regions = []
+            if visual_regions is not None:
+                semantic_regions = [
+                    {
+                        "id": region["id"],
+                        "category": region["category"],
+                        "source_bounds_hwpunit": {
+                            key: region[key] for key in ("x", "y", "w", "h")
+                        },
+                        "source_clipped_to_page": region["clipped"],
+                        "alignment_clipped": False,
+                        "status": "unscorable",
+                        "reason": "page raster dimensions are unscorable without forbidden resizing",
+                        "aligned_bounds_px": None,
+                        "metrics": None,
+                    }
+                    for region in visual_regions["document"]["pages"][page_number - 1]["regions"]
+                ]
             report["pages"].append(
                 {
                     "page": page_number,
@@ -2415,6 +2780,7 @@ def _run_visual_check_from_snapshots(
                     },
                     "alignment": None,
                     "metrics": None,
+                    "semantic_regions": semantic_regions,
                     "artifacts": artifacts,
                 }
             )
@@ -2499,6 +2865,17 @@ def _run_visual_check_from_snapshots(
                 "heatmap": f"assets/{heatmap_name}",
             }
         )
+        semantic_regions = []
+        if visual_regions is not None:
+            semantic_regions = _score_visual_regions(
+                visual_regions["document"]["pages"][page_number - 1],
+                reference_image,
+                aligned_candidate,
+                candidate_raw_image.width,
+                candidate_raw_image.height,
+                metrics["alignment"]["candidate_translation_px"],
+                limits.max_edge_work,
+            )
         report["pages"].append(
             {
                 "page": page_number,
@@ -2512,6 +2889,7 @@ def _run_visual_check_from_snapshots(
                 "raster_canvas": raster_canvas,
                 "alignment": metrics["alignment"],
                 "metrics": metrics,
+                "semantic_regions": semantic_regions,
                 "artifacts": artifacts,
             }
         )
@@ -2551,6 +2929,13 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("candidate", help="candidate PDF exported by auto-hwp")
     parser.add_argument("--reference", required=True, help="reference PDF")
+    parser.add_argument(
+        "--candidate-regions",
+        help=(
+            "optional schema-v1 content-free HWPUNIT region manifest emitted from "
+            "the same first-party placement as the candidate PDF"
+        ),
+    )
     parser.add_argument(
         "--reference-tier",
         required=True,

--- a/scripts/tests/document-visual-check.test.mjs
+++ b/scripts/tests/document-visual-check.test.mjs
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import {
+  chmodSync,
+  lstatSync,
+  readdirSync,
+  readFileSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { mkdtempSync } from "node:fs";
+import { parseArgs, runVisualCheck } from "../document-visual-check.mjs";
+
+function executable(path, source) {
+  writeFileSync(path, `#!/usr/bin/env node\n${source}\n`, { mode: 0o700 });
+  chmodSync(path, 0o700);
+}
+
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), "auto-hwp-document-visual-"));
+  const document = join(root, "private-form.hwpx");
+  const reference = join(root, "official.pdf");
+  const cli = join(root, "fake-auto-hwp");
+  const python = join(root, "fake-python");
+  writeFileSync(document, "synthetic document", { mode: 0o600 });
+  writeFileSync(reference, "%PDF-reference", { mode: 0o600 });
+  executable(cli, `
+    const fs = require("node:fs");
+    const args = process.argv.slice(2);
+    const out = args[args.indexOf("-o") + 1];
+    const regions = args[args.indexOf("--visual-regions") + 1];
+    fs.writeFileSync(out, "%PDF-own\\n%%EOF\\n");
+    fs.writeFileSync(regions, JSON.stringify({
+      schema_version: 1, coordinate_space: "HWPUNIT", candidate_pdf_sha256: "${"a".repeat(64)}",
+      pages: [{ page: 1, width: 59500, height: 84200, regions: [] }]
+    }) + "\\n");
+  `);
+  executable(python, `
+    const fs = require("node:fs");
+    const args = process.argv.slice(2);
+    const output = args[args.indexOf("--output-dir") + 1];
+    fs.mkdirSync(output, { mode: 0o700 });
+    fs.writeFileSync(output + "/report.json", JSON.stringify({ status: "scored_report", policy: { pass: null } }));
+    fs.writeFileSync(output + "/index.html", "<!doctype html><title>report</title>");
+  `);
+  return { root, document, reference, cli, python };
+}
+
+test("one command stages private PDF, semantic evidence, and report atomically", () => {
+  const { root, document, reference, cli, python } = fixture();
+  const output = join(root, "result");
+  const result = runVisualCheck({
+    document,
+    reference,
+    reference_tier: "T3",
+    output_dir: output,
+    cli,
+    python,
+  });
+  assert.equal(result.report_status, "scored_report");
+  assert.equal(result.policy_pass, null);
+  assert.equal(lstatSync(output).mode & 0o777, 0o700);
+  for (const relative of ["candidate-own.pdf", "candidate-regions.json", "summary.json", "index.html"]) {
+    assert.equal(lstatSync(join(output, relative)).mode & 0o777, 0o600, relative);
+  }
+  const summaryText = readFileSync(join(output, "summary.json"), "utf8");
+  assert.doesNotMatch(summaryText, /private-form|synthetic document|auto-hwp-document-visual-/);
+  assert.throws(() => runVisualCheck({
+    document, reference, reference_tier: "T3", output_dir: output, cli, python,
+  }), /already exists/);
+});
+
+test("argument and input boundaries fail closed", () => {
+  assert.throws(() => parseArgs(["doc.hwpx"]), /--reference is required/);
+  assert.throws(() => parseArgs([
+    "doc.hwpx", "--reference", "ref.pdf", "--reference-tier", "truth", "--output-dir", "out",
+  ]), /T0, T1, T2, or T3/);
+  const { root, document, reference, cli, python } = fixture();
+  const link = join(root, "document-link.hwpx");
+  symlinkSync(document, link);
+  assert.throws(() => runVisualCheck({
+    document: link,
+    reference,
+    reference_tier: "T3",
+    output_dir: join(root, "result"),
+    cli,
+    python,
+  }), /non-symlink/);
+});
+
+test("a failed subprocess leaves no partial final or staging directory", () => {
+  const { root, document, reference, python } = fixture();
+  const cli = join(root, "failing-auto-hwp");
+  executable(cli, "process.exit(2);");
+  const output = join(root, "result");
+  assert.throws(() => runVisualCheck({
+    document, reference, reference_tier: "T3", output_dir: output, cli, python,
+  }), /exit status 2/);
+  assert.deepEqual(
+    readdirSync(root).filter((name) => name.startsWith(".auto-hwp-visual-")),
+    [],
+  );
+});

--- a/scripts/tests/test_pdf_visual_check.py
+++ b/scripts/tests/test_pdf_visual_check.py
@@ -96,6 +96,150 @@ class MetricTests(unittest.TestCase):
         self.assertEqual(metrics["worst_tile_recall"]["recall"], 1.0)
         self.assertEqual(metrics["unscorable_metrics"], {})
 
+
+class VisualRegionTests(unittest.TestCase):
+    def page_info(self):
+        return pdf_visual_check.PdfInfo(
+            1,
+            (pdf_visual_check.PdfPageInfo(1, (0.0, 0.0, 595.0, 842.0), 0),),
+        )
+
+    def manifest(self, candidate_sha256: str):
+        return {
+            "schema_version": 1,
+            "coordinate_space": "HWPUNIT",
+            "candidate_pdf_sha256": candidate_sha256,
+            "pages": [
+                {
+                    "page": 1,
+                    "width": 59500.0,
+                    "height": 84200.0,
+                    "regions": [
+                        {
+                            "id": "text-0001",
+                            "category": "text",
+                            "x": 1000.0,
+                            "y": 2000.0,
+                            "w": 10000.0,
+                            "h": 3000.0,
+                            "clipped": False,
+                        }
+                    ],
+                }
+            ],
+        }
+
+    def load(self, document, candidate_sha256):
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "regions.json"
+            path.write_text(json.dumps(document), encoding="utf-8")
+            return pdf_visual_check._load_visual_regions(
+                path, candidate_sha256, self.page_info()
+            )
+
+    def test_manifest_is_sha_bound_strict_and_content_free(self):
+        candidate_sha256 = "a" * 64
+        loaded = self.load(self.manifest(candidate_sha256), candidate_sha256)
+        self.assertEqual(loaded["total_regions"], 1)
+        self.assertEqual(loaded["category_counts"]["text"], 1)
+        self.assertNotIn("text", loaded["document"]["pages"][0]["regions"][0])
+
+        for mutation, pattern in (
+            (lambda doc: doc.update({"unknown": True}), "fields differ"),
+            (lambda doc: doc.update({"candidate_pdf_sha256": "b" * 64}), "SHA-256 mismatch"),
+            (lambda doc: doc["pages"][0].update({"width": 59400}), "dimensions do not match"),
+            (lambda doc: doc["pages"][0]["regions"][0].update({"category": "secret"}), "category"),
+            (lambda doc: doc["pages"][0]["regions"][0].update({"x": -1}), "outside its page"),
+            (lambda doc: doc["pages"][0]["regions"][0].update({"w": float("nan")}), "non-finite"),
+        ):
+            with self.subTest(pattern=pattern):
+                document = self.manifest(candidate_sha256)
+                mutation(document)
+                with self.assertRaisesRegex(pdf_visual_check.VisualCheckError, pattern):
+                    self.load(document, candidate_sha256)
+
+    def test_manifest_rejects_overlapping_regions_that_exhaust_scoring_work(self):
+        candidate_sha256 = "a" * 64
+        document = self.manifest(candidate_sha256)
+        document["pages"][0]["regions"] = [
+            {
+                "id": f"text-{index:04d}",
+                "category": "text",
+                "x": 0.0,
+                "y": 0.0,
+                "w": 59500.0,
+                "h": 84200.0,
+                "clipped": False,
+            }
+            for index in range(
+                1, pdf_visual_check.MAX_VISUAL_REGION_PAGE_AREA_MULTIPLIER + 2
+            )
+        ]
+
+        with self.assertRaisesRegex(pdf_visual_check.VisualCheckError, "scoring budget"):
+            self.load(document, candidate_sha256)
+
+    def test_manifest_rejects_page_mismatch_and_duplicate_region_ids(self):
+        candidate_sha256 = "a" * 64
+        no_pages = self.manifest(candidate_sha256)
+        no_pages["pages"] = []
+        with self.assertRaisesRegex(pdf_visual_check.VisualCheckError, "page count"):
+            self.load(no_pages, candidate_sha256)
+
+        duplicate = self.manifest(candidate_sha256)
+        duplicate["pages"][0]["regions"].append(
+            dict(duplicate["pages"][0]["regions"][0])
+        )
+        with self.assertRaisesRegex(pdf_visual_check.VisualCheckError, "duplicate"):
+            self.load(duplicate, candidate_sha256)
+
+    def test_semantic_region_uses_global_alignment_without_a_second_search(self):
+        ink = rectangle(2, 2, 5, 5)
+        reference = gray_image(10, 10, ink)
+        candidate = gray_image(10, 10, ink)
+        page = {
+            "width": 100.0,
+            "height": 100.0,
+            "regions": [
+                {
+                    "id": "table-0001",
+                    "category": "table",
+                    "x": 20.0,
+                    "y": 20.0,
+                    "w": 40.0,
+                    "h": 40.0,
+                    "clipped": False,
+                }
+            ],
+        }
+        regions = pdf_visual_check._score_visual_regions(
+            page, reference, candidate, 10, 10, {"dx": 0, "dy": 0}, 100_000
+        )
+        self.assertEqual(regions[0]["metrics"]["ink"]["f1"], 1.0)
+        self.assertEqual(regions[0]["metrics"]["global_ssim_like"], 1.0)
+
+        missing = pdf_visual_check._score_visual_regions(
+            page,
+            reference,
+            gray_image(10, 10),
+            10,
+            10,
+            {"dx": 0, "dy": 0},
+            100_000,
+        )
+        self.assertEqual(missing[0]["metrics"]["ink"]["f1"], 0.0)
+        self.assertEqual(missing[0]["status"], "partially_unscorable")
+        summary = pdf_visual_check._summarize_pages(
+            [{"page": 1, "metrics": None, "semantic_regions": missing}]
+        )
+        self.assertEqual(summary["scored_regions"], 1)
+        self.assertEqual(summary["partially_unscorable_regions"], 1)
+        self.assertEqual(
+            summary["region_category_counts"]["table"]["partially_unscorable"], 1
+        )
+
+
+class MetricRegressionTests(unittest.TestCase):
     def test_bounded_translation_is_detected_and_reported(self):
         reference = gray_image(16, 16, rectangle(2, 2, 5, 5))
         candidate = gray_image(16, 16, rectangle(4, 3, 7, 6))

--- a/scripts/verify-local.sh
+++ b/scripts/verify-local.sh
@@ -21,6 +21,8 @@ echo "═══ tests (workspace) ═══"
 cargo test --workspace
 echo "═══ PDF visual oracle (standard-library unittest) ═══"
 python3 -m unittest discover -s scripts/tests -p 'test_pdf_visual_check.py'
+node --check scripts/document-visual-check.mjs
+node --test scripts/tests/document-visual-check.test.mjs
 echo "═══ tests (hwp-rhwp features) ═══"
 cargo test -p hwp-rhwp --features "rhwp shaper"
 


### PR DESCRIPTION
Closes #213
Refs #93

## Summary
- export the own-engine PDF and SHA-bound content-free text/table/image/object regions from one exact placement
- add a strict schema-v4 comparator lane with independent region metrics, explicit unscorable states, and worst-five diagnostics
- add an atomic private HWP/HWPX-to-report command plus hostile resource, schema, symlink, overwrite, and cleanup tests
- keep the visual oracle report-only: threshold/pass remains null and existing page/tile gates are unchanged

## Validation
- focused Rust export/render/CLI tests and checks
- Python visual suite: 55 passed
- Node runner suite: 3 passed
- scripts/verify-local.sh: green
- scripts/verify-local.sh --full: all Rust, gates, wasm, JS build, and 1,012 Vitest tests green; sandbox port EPERM only
- same full-build Playwright E2E outside the port sandbox: 85 passed, 3 intentional skips
- canonical layout gate remains 8/18/24 and 98.9%+
- pinned external/rhwp remains clean at f137b4c9