### PR TITLE
feat: deterministic licensed font registry and realization diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,6 +332,7 @@ dependencies = [
  "quick-xml 0.37.5",
  "serde",
  "serde_json",
+ "sha2",
  "zip 2.4.2",
 ]
 
@@ -2234,6 +2235,8 @@ dependencies = [
  "hwp-typeset",
  "serde",
  "serde_json",
+ "sha2",
+ "ttf-parser",
 ]
 
 [[package]]

--- a/corpus/font-registry/ofl-registry-v1.json
+++ b/corpus/font-registry/ofl-registry-v1.json
@@ -1,0 +1,52 @@
+{
+  "schema_version": 1,
+  "limits": {
+    "max_faces": 8,
+    "max_face_bytes": 8388608,
+    "max_total_bytes": 33554432
+  },
+  "faces": [
+    {
+      "family": "Nanum Gothic",
+      "style": "regular",
+      "path": "../../assets/fonts/NanumGothic-Regular.ttf",
+      "sha256": "76f45ef4a6bcff344c837c95a7dcc26e017e38b5846d5ae0cdcb5b86be2e2d31",
+      "face_index": 0
+    },
+    {
+      "family": "Nanum Gothic",
+      "style": "bold",
+      "path": "../../assets/fonts/NanumGothic-Bold.ttf",
+      "sha256": "f96298f9fb18e364d2370f4c3ce948ac67a2b61af992d7234bc15c42b033c674",
+      "face_index": 0
+    },
+    {
+      "family": "Nanum Myeongjo",
+      "style": "regular",
+      "path": "../../assets/fonts/NanumMyeongjo-Regular.ttf",
+      "sha256": "7ed9e8653a8ed04285d51dc343ffea6eb3d9c73afc27383ea8929ee4ffd03205",
+      "face_index": 0
+    },
+    {
+      "family": "Nanum Myeongjo",
+      "style": "bold",
+      "path": "../../assets/fonts/NanumMyeongjo-Bold.ttf",
+      "sha256": "bc9ed8e60d93fe6db054b8fb988481b625f2eef8cb2317ad0e9834681b8fe3f3",
+      "face_index": 0
+    },
+    {
+      "family": "나눔고딕",
+      "style": "regular",
+      "path": "../../assets/fonts/NanumGothic-Regular.ttf",
+      "sha256": "76f45ef4a6bcff344c837c95a7dcc26e017e38b5846d5ae0cdcb5b86be2e2d31",
+      "face_index": 0
+    },
+    {
+      "family": "나눔고딕",
+      "style": "bold",
+      "path": "../../assets/fonts/NanumGothic-Bold.ttf",
+      "sha256": "f96298f9fb18e364d2370f4c3ce948ac67a2b61af992d7234bc15c42b033c674",
+      "face_index": 0
+    }
+  ]
+}

--- a/crates/auto-hwp-cli/Cargo.toml
+++ b/crates/auto-hwp-cli/Cargo.toml
@@ -48,6 +48,7 @@ serde = { workspace = true }
 # 벌크 채움(issue 073): 편집 레인은 웹과 동일한 hwp-mcp Intent 경로를 쓴다(검증·거부 규칙 한 벌).
 hwp-mcp = { workspace = true }
 serde_json = { workspace = true }
+sha2 = { workspace = true }
 zip = { workspace = true }
 # 073/#40 xlsx 명단: workspace zip + quick-xml only (no calamine, no native runtime).
 quick-xml = { workspace = true }

--- a/crates/auto-hwp-cli/src/font_registry.rs
+++ b/crates/auto-hwp-cli/src/font_registry.rs
@@ -1,0 +1,176 @@
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use hwp_session::font_registry::{
+    FontFaceInput, FontRealizationReport, FontRegistry, FontRegistryLimits, FontStyle,
+};
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Manifest {
+    schema_version: u32,
+    #[serde(default)]
+    limits: ManifestLimits,
+    faces: Vec<ManifestFace>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ManifestLimits {
+    max_faces: Option<usize>,
+    max_face_bytes: Option<usize>,
+    max_total_bytes: Option<usize>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ManifestFace {
+    family: String,
+    style: FontStyle,
+    path: PathBuf,
+    sha256: String,
+    #[serde(default)]
+    face_index: u32,
+}
+
+pub fn load(path: &Path) -> Result<FontRegistry, String> {
+    require_regular_non_symlink(path, "font registry manifest")?;
+    let bytes = std::fs::read(path).map_err(|error| format!("read font registry: {error}"))?;
+    if bytes.len() > 1024 * 1024 {
+        return Err("font registry manifest exceeds 1 MiB".into());
+    }
+    let manifest: Manifest = serde_json::from_slice(&bytes)
+        .map_err(|error| format!("invalid font registry: {error}"))?;
+    if manifest.schema_version != 1 {
+        return Err("font registry schema_version must be 1".into());
+    }
+    let defaults = FontRegistryLimits::default();
+    let limits = FontRegistryLimits {
+        max_faces: manifest.limits.max_faces.unwrap_or(defaults.max_faces),
+        max_face_bytes: manifest
+            .limits
+            .max_face_bytes
+            .unwrap_or(defaults.max_face_bytes),
+        max_total_bytes: manifest
+            .limits
+            .max_total_bytes
+            .unwrap_or(defaults.max_total_bytes),
+    };
+    if limits.max_faces == 0 || limits.max_face_bytes == 0 || limits.max_total_bytes == 0 {
+        return Err("font registry limits must be positive".into());
+    }
+    let base = path.parent().unwrap_or_else(|| Path::new("."));
+    let mut inputs = Vec::with_capacity(manifest.faces.len());
+    for face in manifest.faces {
+        let face_path = if face.path.is_absolute() {
+            face.path
+        } else {
+            base.join(face.path)
+        };
+        require_regular_non_symlink(&face_path, "font face")?;
+        let bytes =
+            std::fs::read(&face_path).map_err(|error| format!("read font face: {error}"))?;
+        let actual = hex_sha256(&bytes);
+        if !valid_sha256(&face.sha256) || !actual.eq_ignore_ascii_case(&face.sha256) {
+            return Err("font face SHA-256 mismatch".into());
+        }
+        inputs.push(FontFaceInput {
+            family: face.family,
+            style: face.style,
+            bytes,
+            face_index: face.face_index,
+        });
+    }
+    FontRegistry::new(inputs, limits)
+}
+
+pub fn write_report_new(path: &Path, report: &FontRealizationReport) -> Result<(), String> {
+    let mut bytes = serde_json::to_vec_pretty(report)
+        .map_err(|error| format!("serialize font realization report: {error}"))?;
+    bytes.push(b'\n');
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options
+        .open(path)
+        .map_err(|error| format!("create font realization report: {error}"))?;
+    file.write_all(&bytes)
+        .map_err(|error| format!("write font realization report: {error}"))
+}
+
+fn require_regular_non_symlink(path: &Path, label: &str) -> Result<(), String> {
+    let metadata =
+        std::fs::symlink_metadata(path).map_err(|error| format!("inspect {label}: {error}"))?;
+    if metadata.file_type().is_symlink() || !metadata.file_type().is_file() {
+        return Err(format!("{label} must be a regular non-symlink file"));
+    }
+    Ok(())
+}
+
+fn valid_sha256(value: &str) -> bool {
+    value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn hex_sha256(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let digest = Sha256::digest(bytes);
+    let mut out = String::with_capacity(64);
+    for byte in digest {
+        out.push(HEX[(byte >> 4) as usize] as char);
+        out.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn manifest_rejects_unknown_fields_and_non_integral_indices() {
+        let unknown = br#"{"schema_version":1,"faces":[],"surprise":true}"#;
+        assert!(serde_json::from_slice::<Manifest>(unknown).is_err());
+        let face_unknown = br#"{"schema_version":1,"faces":[{"family":"A","style":"regular","path":"a.ttf","sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","extra":1}]}"#;
+        assert!(serde_json::from_slice::<Manifest>(face_unknown).is_err());
+        let fractional = br#"{"schema_version":1,"faces":[{"family":"A","style":"regular","path":"a.ttf","sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","face_index":0.5}]}"#;
+        assert!(serde_json::from_slice::<Manifest>(fractional).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn loader_rejects_a_symlink_font_before_reading_it() {
+        use std::os::unix::fs::symlink;
+        use std::time::{SystemTime, UNIX_EPOCH};
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "auto-hwp-font-registry-{}-{nonce}",
+            std::process::id()
+        ));
+        std::fs::create_dir(&dir).unwrap();
+        let real = dir.join("real.ttf");
+        let link = dir.join("linked.ttf");
+        let manifest = dir.join("registry.json");
+        std::fs::write(&real, [0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0]).unwrap();
+        symlink(&real, &link).unwrap();
+        std::fs::write(
+            &manifest,
+            format!(
+                "{{\"schema_version\":1,\"faces\":[{{\"family\":\"A\",\"style\":\"regular\",\"path\":\"{}\",\"sha256\":\"{}\"}}]}}",
+                link.display(),
+                "0".repeat(64)
+            ),
+        )
+        .unwrap();
+        assert!(load(&manifest).unwrap_err().contains("non-symlink"));
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+}

--- a/crates/auto-hwp-cli/src/main.rs
+++ b/crates/auto-hwp-cli/src/main.rs
@@ -6,6 +6,8 @@ use std::process::ExitCode;
 use clap::{Parser, Subcommand};
 
 mod fill;
+#[cfg(feature = "pdf")]
+mod font_registry;
 mod inspect_layout;
 mod layout_score;
 mod xlsx_roster;
@@ -218,6 +220,13 @@ enum Cmd {
         /// used for this PDF. The sidecar is candidate-SHA-bound and never contains document text.
         #[arg(long)]
         visual_regions: Option<PathBuf>,
+        /// Strict schema-v1 local font registry manifest. Files are explicit, SHA-256 pinned,
+        /// regular non-symlink TTF/OTF inputs; no system-directory scan occurs.
+        #[arg(long)]
+        font_registry: Option<PathBuf>,
+        /// Write a content-free/path-free font realization report (requires --font-registry).
+        #[arg(long)]
+        font_report: Option<PathBuf>,
     },
     /// PIVOT M0: apply ONE CSS-only AI-routing op (CssSetDecl) to a project dir, proving
     /// content/design separation — only styles/document.css is re-written; the .jsx are untouched.
@@ -356,7 +365,15 @@ fn run() -> Result<(), String> {
             file,
             out,
             visual_regions,
-        } => export_pdf(&file, &out, visual_regions.as_deref())?,
+            font_registry,
+            font_report,
+        } => export_pdf(
+            &file,
+            &out,
+            visual_regions.as_deref(),
+            font_registry.as_deref(),
+            font_report.as_deref(),
+        )?,
         Cmd::EditOp {
             proj,
             node,
@@ -781,7 +798,30 @@ fn export_html(file: &PathBuf, out: &Path) -> Result<(), String> {
 /// PHASE P4: export to PDF from OUR OWN layout (paint IR → krilla, Korean font subsetting). The PDF
 /// matches own-render because both replay the same paint IR. Needs `--features pdf`.
 #[cfg(feature = "pdf")]
-fn export_pdf(file: &PathBuf, out: &Path, visual_regions: Option<&Path>) -> Result<(), String> {
+fn export_pdf(
+    file: &PathBuf,
+    out: &Path,
+    visual_regions: Option<&Path>,
+    font_registry: Option<&Path>,
+    font_report: Option<&Path>,
+) -> Result<(), String> {
+    if font_report.is_some() && font_registry.is_none() {
+        return Err("--font-report requires --font-registry".into());
+    }
+    if let Some(path) = font_report {
+        if path == out || visual_regions.is_some_and(|regions| regions == path) {
+            return Err("--font-report must not reuse another export output path".into());
+        }
+        if path
+            .try_exists()
+            .map_err(|error| format!("inspect {}: {error}", path.display()))?
+        {
+            return Err(format!(
+                "font report output already exists; refusing to overwrite {}",
+                path.display()
+            ));
+        }
+    }
     if let Some(path) = visual_regions {
         if path == out {
             return Err("--visual-regions must not be the PDF output path".into());
@@ -800,7 +840,16 @@ fn export_pdf(file: &PathBuf, out: &Path, visual_regions: Option<&Path>) -> Resu
     // Engine::open handles both: .hwpx parse (default build) + .hwp lift (needs --features rhwp).
     let doc = hwp_core::Engine::open(&bytes).map_err(|e| e.to_string())?;
     let title = file.file_stem().map(|s| s.to_string_lossy().into_owned());
-    let result = hwp_session::emit_pdf(&doc, title)?;
+    let registry = font_registry.map(font_registry::load).transpose()?;
+    let injected = registry
+        .as_ref()
+        .map(|registry| registry.injected_faces())
+        .unwrap_or_default();
+    let result = if registry.is_some() {
+        hwp_session::emit_pdf_with_fonts(&doc, title, &injected)?
+    } else {
+        hwp_session::emit_pdf(&doc, title)?
+    };
     let evidence = visual_regions
         .map(|_| {
             let mut bytes = serde_json::to_vec_pretty(&result.visual_evidence)
@@ -826,6 +875,9 @@ fn export_pdf(file: &PathBuf, out: &Path, visual_regions: Option<&Path>) -> Resu
             .write_all(&bytes)
             .map_err(|error| format!("write {}: {error}", path.display()))?;
     }
+    if let (Some(path), Some(registry)) = (font_report, registry.as_ref()) {
+        font_registry::write_report_new(path, &registry.realization_report(&doc))?;
+    }
     match &result.font_path {
         Some(p) => println!(
             "wrote {} ({} pages, {} KB) — Korean font embedded from {p}",
@@ -847,7 +899,13 @@ fn export_pdf(file: &PathBuf, out: &Path, visual_regions: Option<&Path>) -> Resu
 /// INTERIM (no `pdf` feature): explain the build flag + the headless-print fallback. We do NOT
 /// silently produce a wrong/empty file — the user gets an actionable message.
 #[cfg(not(feature = "pdf"))]
-fn export_pdf(file: &PathBuf, _out: &Path, _visual_regions: Option<&Path>) -> Result<(), String> {
+fn export_pdf(
+    file: &PathBuf,
+    _out: &Path,
+    _visual_regions: Option<&Path>,
+    _font_registry: Option<&Path>,
+    _font_report: Option<&Path>,
+) -> Result<(), String> {
     let _ = file;
     Err("export-pdf needs a build with `--features pdf` (krilla PDF backend + Korean font embedding).\n\
          Interim fallback without that feature: `auto-hwp export-html <doc> -o doc.html` then print the \

--- a/crates/hwp-export/src/pdf.rs
+++ b/crates/hwp-export/src/pdf.rs
@@ -1198,30 +1198,35 @@ fn paint_glyph(
                     .map(|(_, face)| face)
             };
             let explicit = font.and_then(|n| {
-                if bold {
-                    explicit_face(&format!("{} Bold", n.trim())).or_else(|| explicit_face(n))
-                } else {
-                    explicit_face(n)
-                }
+                let n = n.trim();
+                let styled = match (bold, italic) {
+                    (true, true) => explicit_face(&format!("{n} Bold Italic"))
+                        .or_else(|| explicit_face(&format!("{n} Italic Bold")))
+                        .map(|face| (face, true)),
+                    (true, false) => explicit_face(&format!("{n} Bold")).map(|face| (face, false)),
+                    (false, true) => explicit_face(&format!("{n} Italic")).map(|face| (face, true)),
+                    (false, false) => None,
+                };
+                styled.or_else(|| explicit_face(n).map(|face| (face, false)))
             });
-            let face = if let Some(face) = explicit {
-                face
+            let (face, realized_italic) = if let Some((face, realized_italic)) = explicit {
+                (face, realized_italic)
             } else if is_serif {
                 if bold {
-                    f.serif_bold.as_ref().or(f.serif.as_ref()).unwrap()
+                    (f.serif_bold.as_ref().or(f.serif.as_ref()).unwrap(), false)
                 } else {
-                    f.serif.as_ref().unwrap()
+                    (f.serif.as_ref().unwrap(), false)
                 }
             } else if bold {
-                f.bold.as_ref().unwrap_or(&f.font)
+                (f.bold.as_ref().unwrap_or(&f.font), false)
             } else {
-                &f.font
+                (&f.font, false)
             };
             let (bx, by) = (pt(x), pt(y));
             // Italic: NanumGothic has no italic face, so synthesize an oblique by shearing the glyph
             // about its baseline (x' = x - SLANT*y + SLANT*baseline) — ascenders lean right, the
             // baseline origin stays put. Matches the webview's font-style:italic synthesis.
-            if italic {
+            if italic && !realized_italic {
                 const SLANT: f32 = 0.21; // ≈ 12°, the conventional faux-italic angle
                 surface.push_transform(&krilla::geom::Transform::from_row(
                     1.0,
@@ -1241,7 +1246,7 @@ fn paint_glyph(
                 false,
                 TextDirection::Auto,
             );
-            if italic {
+            if italic && !realized_italic {
                 surface.pop();
             }
         }

--- a/crates/hwp-session/Cargo.toml
+++ b/crates/hwp-session/Cargo.toml
@@ -33,5 +33,7 @@ hwp-typeset = { workspace = true }
 hwp-render = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+sha2 = { workspace = true }
+ttf-parser = "0.25"
 # Decode chat-attached images (base64) before stashing — pure-Rust, wasm-safe (used only under `fs`).
 base64 = "0.21"

--- a/crates/hwp-session/src/font_registry.rs
+++ b/crates/hwp-session/src/font_registry.rs
@@ -1,0 +1,506 @@
+//! Deterministic host-fed font registry and path/text-free realization evidence.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use hwp_model::document::{Block, Inline, Paragraph};
+use hwp_model::font_class::{classify, FontCategory};
+use hwp_model::prelude::{ScriptClass, SemanticDoc};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+pub const DEFAULT_MAX_FACES: usize = 32;
+pub const DEFAULT_MAX_FACE_BYTES: usize = 24 * 1024 * 1024;
+pub const DEFAULT_MAX_TOTAL_BYTES: usize = 128 * 1024 * 1024;
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "kebab-case")]
+pub enum FontStyle {
+    Regular,
+    Bold,
+    Italic,
+    BoldItalic,
+}
+
+impl FontStyle {
+    pub fn from_flags(bold: bool, italic: bool) -> Self {
+        match (bold, italic) {
+            (false, false) => Self::Regular,
+            (true, false) => Self::Bold,
+            (false, true) => Self::Italic,
+            (true, true) => Self::BoldItalic,
+        }
+    }
+
+    fn decorated_family(self, family: &str) -> String {
+        match self {
+            Self::Regular => family.to_string(),
+            Self::Bold => format!("{family} Bold"),
+            Self::Italic => format!("{family} Italic"),
+            Self::BoldItalic => format!("{family} Bold Italic"),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct FontRegistryLimits {
+    pub max_faces: usize,
+    pub max_face_bytes: usize,
+    pub max_total_bytes: usize,
+}
+
+impl Default for FontRegistryLimits {
+    fn default() -> Self {
+        Self {
+            max_faces: DEFAULT_MAX_FACES,
+            max_face_bytes: DEFAULT_MAX_FACE_BYTES,
+            max_total_bytes: DEFAULT_MAX_TOTAL_BYTES,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct FontFaceInput {
+    pub family: String,
+    pub style: FontStyle,
+    pub bytes: Vec<u8>,
+    pub face_index: u32,
+}
+
+impl FontFaceInput {
+    /// Convert the legacy `(family label, bytes)` web injection seam into the typed contract. Style
+    /// suffixes are normalized so `Family` + `Family Bold` become one family with two distinct faces.
+    pub fn from_legacy_label(family: String, bytes: Vec<u8>) -> Self {
+        let (family, style) = split_legacy_style(&family);
+        Self {
+            family,
+            style,
+            bytes,
+            face_index: 0,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct RegisteredFace {
+    family: String,
+    normalized_family: String,
+    style: FontStyle,
+    bytes: Vec<u8>,
+    sha256: String,
+    category: FontCategory,
+}
+
+#[derive(Clone, Debug)]
+pub struct FontRegistry {
+    faces: Vec<RegisteredFace>,
+    fingerprint: String,
+}
+
+impl FontRegistry {
+    pub fn new(inputs: Vec<FontFaceInput>, limits: FontRegistryLimits) -> Result<Self, String> {
+        if inputs.is_empty() {
+            return Err("font registry must contain at least one face".into());
+        }
+        if inputs.len() > limits.max_faces {
+            return Err(format!(
+                "font registry face limit exceeded ({})",
+                limits.max_faces
+            ));
+        }
+        let mut total = 0usize;
+        let mut seen = BTreeSet::new();
+        let mut faces = Vec::with_capacity(inputs.len());
+        for input in inputs {
+            let family = input.family.trim();
+            if family.is_empty() || family.len() > 128 || family.chars().any(char::is_control) {
+                return Err("font family must be 1..128 non-control characters".into());
+            }
+            if input.face_index != 0 {
+                return Err("only finite face_index 0 is supported".into());
+            }
+            if input.bytes.len() > limits.max_face_bytes {
+                return Err(format!(
+                    "font face byte limit exceeded ({})",
+                    limits.max_face_bytes
+                ));
+            }
+            total = total
+                .checked_add(input.bytes.len())
+                .ok_or_else(|| "font registry byte total overflow".to_string())?;
+            if total > limits.max_total_bytes {
+                return Err(format!(
+                    "font registry total byte limit exceeded ({})",
+                    limits.max_total_bytes
+                ));
+            }
+            validate_single_face(&input.bytes)?;
+            let normalized_family = normalize_family(family);
+            if !seen.insert((normalized_family.clone(), input.style)) {
+                return Err("duplicate font family/style".into());
+            }
+            faces.push(RegisteredFace {
+                family: family.to_string(),
+                normalized_family,
+                style: input.style,
+                sha256: hex_sha256(&input.bytes),
+                category: classify(family),
+                bytes: input.bytes,
+            });
+        }
+        faces.sort_by(|a, b| {
+            (&a.normalized_family, a.style, &a.sha256).cmp(&(
+                &b.normalized_family,
+                b.style,
+                &b.sha256,
+            ))
+        });
+        let mut digest = Sha256::new();
+        digest.update(b"auto-hwp-font-registry-v1\0");
+        for face in &faces {
+            digest.update(face.normalized_family.as_bytes());
+            digest.update([face.style as u8]);
+            digest.update(face.sha256.as_bytes());
+        }
+        let fingerprint = format!("sha256:{}", hex_bytes(&digest.finalize()));
+        Ok(Self { faces, fingerprint })
+    }
+
+    pub fn fingerprint(&self) -> &str {
+        &self.fingerprint
+    }
+
+    pub fn injected_faces(&self) -> Vec<(String, Vec<u8>)> {
+        self.faces
+            .iter()
+            .map(|face| {
+                (
+                    face.style.decorated_family(&face.family),
+                    face.bytes.clone(),
+                )
+            })
+            .collect()
+    }
+
+    pub fn realization_report(&self, doc: &SemanticDoc) -> FontRealizationReport {
+        type Key = (String, FontStyle, RealizationStatus, Option<String>);
+        let mut aggregate: BTreeMap<Key, u64> = BTreeMap::new();
+        for section in &doc.sections {
+            visit_blocks(&section.blocks, &mut |paragraph| {
+                for run in &paragraph.runs {
+                    let shape = doc.char_shapes.get(run.char_shape);
+                    let style = FontStyle::from_flags(
+                        shape.is_some_and(|value| value.bold),
+                        shape.is_some_and(|value| value.italic),
+                    );
+                    for inline in &run.content {
+                        let Inline::Text(text) = inline else { continue };
+                        for ch in text.chars().filter(|ch| !ch.is_whitespace()) {
+                            let requested = shape.and_then(|value| {
+                                value
+                                    .fonts
+                                    .get(script_slot(ch) as usize)
+                                    .and_then(|name| name.as_deref())
+                                    .or(value.font_family.as_deref())
+                                    .map(str::trim)
+                                    .filter(|name| !name.is_empty())
+                            });
+                            let category = requested.map(classify).unwrap_or(FontCategory::Other);
+                            let selected = self.select(requested, category, style);
+                            let (status, hash) = match selected {
+                                Some((face, true)) => {
+                                    (RealizationStatus::Exact, Some(face.sha256.clone()))
+                                }
+                                Some((face, false)) => {
+                                    (RealizationStatus::Fallback, Some(face.sha256.clone()))
+                                }
+                                None => (RealizationStatus::Unavailable, None),
+                            };
+                            *aggregate
+                                .entry((category_name(category).to_string(), style, status, hash))
+                                .or_default() += 1;
+                        }
+                    }
+                }
+            });
+        }
+        FontRealizationReport {
+            schema_version: 1,
+            registry_fingerprint: self.fingerprint.clone(),
+            face_count: self.faces.len(),
+            lanes: aggregate
+                .into_iter()
+                .map(
+                    |((requested_category, style, status, selected_face_sha256), glyph_count)| {
+                        FontRealizationLane {
+                            requested_category,
+                            style,
+                            status,
+                            selected_face_sha256,
+                            glyph_count,
+                        }
+                    },
+                )
+                .collect(),
+        }
+    }
+
+    fn select(
+        &self,
+        requested: Option<&str>,
+        category: FontCategory,
+        style: FontStyle,
+    ) -> Option<(&RegisteredFace, bool)> {
+        if let Some(requested) = requested {
+            let family = normalize_family(requested);
+            if let Some(face) = self
+                .faces
+                .iter()
+                .find(|face| face.normalized_family == family && face.style == style)
+            {
+                return Some((face, true));
+            }
+            if let Some(face) = self
+                .faces
+                .iter()
+                .find(|face| face.normalized_family == family && face.style == FontStyle::Regular)
+            {
+                return Some((face, false));
+            }
+        }
+        let fallback_category = match category {
+            FontCategory::Other => FontCategory::Gothic,
+            value => value,
+        };
+        let fallback = self
+            .faces
+            .iter()
+            .find(|face| face.category == fallback_category && face.style == style)
+            .or_else(|| {
+                self.faces.iter().find(|face| {
+                    face.category == fallback_category && face.style == FontStyle::Regular
+                })
+            });
+        fallback
+            .or_else(|| requested.is_none().then(|| self.faces.first()).flatten())
+            .map(|face| (face, false))
+    }
+}
+
+#[derive(Clone, Copy, Debug, Serialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "snake_case")]
+pub enum RealizationStatus {
+    Exact,
+    Fallback,
+    Unavailable,
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+pub struct FontRealizationReport {
+    pub schema_version: u32,
+    pub registry_fingerprint: String,
+    pub face_count: usize,
+    pub lanes: Vec<FontRealizationLane>,
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+pub struct FontRealizationLane {
+    pub requested_category: String,
+    pub style: FontStyle,
+    pub status: RealizationStatus,
+    pub selected_face_sha256: Option<String>,
+    pub glyph_count: u64,
+}
+
+fn visit_blocks(blocks: &[Block], visit: &mut impl FnMut(&Paragraph)) {
+    for block in blocks {
+        match block {
+            Block::Paragraph(paragraph) => {
+                visit(paragraph);
+                for run in &paragraph.runs {
+                    for inline in &run.content {
+                        if let Inline::Note(note) = inline {
+                            visit_blocks(&note.body, visit);
+                        }
+                    }
+                }
+            }
+            Block::Table(table) => {
+                if let Some(caption) = &table.caption {
+                    visit_blocks(&caption.blocks, visit);
+                }
+                for cell in &table.cells {
+                    visit_blocks(&cell.blocks, visit);
+                }
+            }
+        }
+    }
+}
+
+fn validate_single_face(bytes: &[u8]) -> Result<(), String> {
+    if bytes.starts_with(b"ttcf") {
+        return Err("font collections (TTC/OTC) are unsupported".into());
+    }
+    if bytes.len() < 12
+        || !(bytes.starts_with(&[0, 1, 0, 0])
+            || bytes.starts_with(b"OTTO")
+            || bytes.starts_with(b"true")
+            || bytes.starts_with(b"typ1"))
+    {
+        return Err("unsupported or malformed single-face TTF/OTF".into());
+    }
+    ttf_parser::Face::parse(bytes, 0)
+        .map_err(|_| "unsupported or malformed single-face TTF/OTF".to_string())?;
+    Ok(())
+}
+
+fn normalize_family(family: &str) -> String {
+    family
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_lowercase()
+}
+
+fn split_legacy_style(family: &str) -> (String, FontStyle) {
+    let mut words: Vec<&str> = family.split_whitespace().collect();
+    let mut bold = false;
+    let mut italic = false;
+    while let Some(word) = words.last() {
+        match word.to_ascii_lowercase().as_str() {
+            "bold" | "boldface" => bold = true,
+            "italic" | "oblique" => italic = true,
+            "regular" => {}
+            _ => break,
+        }
+        words.pop();
+    }
+    (words.join(" "), FontStyle::from_flags(bold, italic))
+}
+
+fn hex_sha256(bytes: &[u8]) -> String {
+    hex_bytes(&Sha256::digest(bytes))
+}
+
+fn hex_bytes(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        out.push(HEX[(byte >> 4) as usize] as char);
+        out.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    out
+}
+
+fn category_name(category: FontCategory) -> &'static str {
+    match category {
+        FontCategory::Serif => "serif",
+        FontCategory::Gothic => "gothic",
+        FontCategory::Other => "other",
+    }
+}
+
+fn script_slot(ch: char) -> ScriptClass {
+    match ch as u32 {
+        0x1100..=0x11FF | 0x3130..=0x318F | 0xA960..=0xA97F | 0xAC00..=0xD7A3 | 0xD7B0..=0xD7FF => {
+            ScriptClass::Hangul
+        }
+        0x2E80..=0x2FDF | 0x3400..=0x4DBF | 0x4E00..=0x9FFF | 0xF900..=0xFAFF => ScriptClass::Hanja,
+        0x3040..=0x30FF => ScriptClass::Japanese,
+        0x0000..=0x024F => ScriptClass::Latin,
+        _ => ScriptClass::Other,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn gothic() -> Vec<u8> {
+        std::fs::read(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../assets/fonts/NanumGothic-Regular.ttf"
+        ))
+        .unwrap()
+    }
+
+    fn face(family: &str, style: FontStyle) -> FontFaceInput {
+        FontFaceInput {
+            family: family.to_string(),
+            style,
+            bytes: gothic(),
+            face_index: 0,
+        }
+    }
+
+    #[test]
+    fn registry_is_order_independent_and_rejects_duplicate_style() {
+        let a = FontRegistry::new(
+            vec![
+                face("Nanum Gothic", FontStyle::Regular),
+                face("Nanum Myeongjo", FontStyle::Bold),
+            ],
+            FontRegistryLimits::default(),
+        )
+        .unwrap();
+        let b = FontRegistry::new(
+            vec![
+                face("Nanum Myeongjo", FontStyle::Bold),
+                face("Nanum Gothic", FontStyle::Regular),
+            ],
+            FontRegistryLimits::default(),
+        )
+        .unwrap();
+        assert_eq!(a.fingerprint(), b.fingerprint());
+        assert!(FontRegistry::new(
+            vec![
+                face(" Nanum   Gothic ", FontStyle::Regular),
+                face("nanum gothic", FontStyle::Regular),
+            ],
+            FontRegistryLimits::default(),
+        )
+        .unwrap_err()
+        .contains("duplicate"));
+    }
+
+    #[test]
+    fn registry_rejects_collections_indices_and_resource_overruns() {
+        let mut collection = face("A", FontStyle::Regular);
+        collection.bytes = b"ttcf00000000".to_vec();
+        assert!(FontRegistry::new(vec![collection], FontRegistryLimits::default()).is_err());
+        let mut indexed = face("A", FontStyle::Regular);
+        indexed.face_index = 1;
+        assert!(FontRegistry::new(vec![indexed], FontRegistryLimits::default()).is_err());
+        assert!(FontRegistry::new(
+            vec![face("A", FontStyle::Regular)],
+            FontRegistryLimits {
+                max_faces: 1,
+                max_face_bytes: 12,
+                max_total_bytes: 12,
+            },
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn realization_is_exact_only_when_family_and_style_both_match() {
+        let registry = FontRegistry::new(
+            vec![face("Nanum Gothic", FontStyle::Regular)],
+            FontRegistryLimits::default(),
+        )
+        .unwrap();
+        assert!(registry
+            .select(
+                Some("Nanum Gothic"),
+                FontCategory::Gothic,
+                FontStyle::Regular,
+            )
+            .is_some_and(|(_, exact)| exact));
+        assert!(registry
+            .select(
+                Some("Nanum Gothic"),
+                FontCategory::Gothic,
+                FontStyle::Italic,
+            )
+            .is_some_and(|(_, exact)| !exact));
+    }
+}

--- a/crates/hwp-session/src/lib.rs
+++ b/crates/hwp-session/src/lib.rs
@@ -26,6 +26,8 @@
 use hwp_model::prelude::SemanticDoc;
 use serde_json::{json, Value};
 
+pub mod font_registry;
+
 /// The positioned, paginated document produced by [`place`] — re-exported so a caller (the wasm
 /// `HwpDoc` layout cache, issue 025) can name and store it without depending on `hwp-typeset` directly.
 pub use hwp_typeset::PlacedDoc;
@@ -66,12 +68,10 @@ pub fn own_render_fonts() -> Box<dyn hwp_model::prelude::FontMetricsProvider> {
 pub fn own_render_fonts_with(
     injected: &[(String, Vec<u8>)],
 ) -> Box<dyn hwp_model::prelude::FontMetricsProvider> {
-    match injected.iter().find(|(_, b)| !b.is_empty()) {
-        Some((_family, bytes)) => Box::new(WithFamilies {
-            inner: Box::new(hwp_typeset::RealFontMetrics::from_bytes(bytes)),
-            families: injected.iter().map(|(f, _)| f.clone()).collect(),
-        }),
-        None => own_render_fonts(),
+    if injected.iter().any(|(_, bytes)| !bytes.is_empty()) {
+        Box::new(hwp_typeset::RealFontMetrics::from_registry(injected))
+    } else {
+        own_render_fonts()
     }
 }
 #[cfg(not(feature = "shaper"))]
@@ -96,11 +96,13 @@ pub fn own_render_fonts_with(
 /// (e.g. "Pretendard") bypasses the 058 class substitute and keeps its own name (the screen
 /// `@font-face` and the PDF per-family embed pick it up). Metrics delegate untouched (V5 게이트 불변); the
 /// zero-injection path never builds this, so golden bytes are unchanged.
+#[cfg(not(feature = "shaper"))]
 struct WithFamilies {
     inner: Box<dyn hwp_model::prelude::FontMetricsProvider>,
     families: Vec<String>,
 }
 
+#[cfg(not(feature = "shaper"))]
 impl hwp_model::prelude::FontMetricsProvider for WithFamilies {
     fn advance_width(
         &self,
@@ -3044,6 +3046,103 @@ mod tests {
             .bytes,
             "빈 주입 = discover 경로, 바이트 동일"
         );
+    }
+
+    /// Issue 215 RED: a requested family must choose the same face for placement regardless of
+    /// registration order. Before the registry fix, `own_render_fonts_with` measured every run with
+    /// the first injected face, while the PDF embedder could select the requested second face.
+    #[cfg(feature = "shaper")]
+    #[test]
+    fn injected_metrics_follow_the_requested_family_not_the_first_face() {
+        let Ok(gothic) = std::fs::read(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../assets/fonts/NanumGothic-Regular.ttf"
+        )) else {
+            return;
+        };
+        let Ok(myeongjo) = std::fs::read(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../assets/fonts/NanumMyeongjo-Regular.ttf"
+        )) else {
+            return;
+        };
+        let mut doc = body_para_doc("MWMW narrow iii", 20_000);
+        doc.char_shapes[0].font_family = Some("Nanum Myeongjo".to_string());
+
+        let requested_only = place(&doc, &[("Nanum Myeongjo".to_string(), myeongjo.clone())]);
+        let requested_second = place(
+            &doc,
+            &[
+                ("Nanum Gothic".to_string(), gothic),
+                ("Nanum Myeongjo".to_string(), myeongjo),
+            ],
+        );
+        let xs = |placed: &PlacedDoc| {
+            placed.pages[0]
+                .glyphs
+                .iter()
+                .map(|glyph| glyph.x)
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(
+            xs(&requested_second),
+            xs(&requested_only),
+            "the requested family must drive layout metrics even when registered second"
+        );
+    }
+
+    #[cfg(all(feature = "shaper", feature = "pdf"))]
+    #[test]
+    fn exact_registry_face_is_reported_and_exports_stable_pdf_bytes() {
+        use crate::font_registry::{
+            FontFaceInput, FontRegistry, FontRegistryLimits, FontStyle, RealizationStatus,
+        };
+        let Ok(gothic) = std::fs::read(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../assets/fonts/NanumGothic-Regular.ttf"
+        )) else {
+            return;
+        };
+        let Ok(myeongjo) = std::fs::read(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../assets/fonts/NanumMyeongjo-Regular.ttf"
+        )) else {
+            return;
+        };
+        let registry = FontRegistry::new(
+            vec![
+                FontFaceInput {
+                    family: "Nanum Gothic".into(),
+                    style: FontStyle::Regular,
+                    bytes: gothic,
+                    face_index: 0,
+                },
+                FontFaceInput {
+                    family: "Nanum Myeongjo".into(),
+                    style: FontStyle::Regular,
+                    bytes: myeongjo,
+                    face_index: 0,
+                },
+            ],
+            FontRegistryLimits::default(),
+        )
+        .unwrap();
+        let mut doc = body_para_doc("exact family proof", 20_000);
+        doc.char_shapes[0].font_family = Some("Nanum Myeongjo".into());
+        let report = registry.realization_report(&doc);
+        assert_eq!(report.lanes.len(), 1);
+        assert_eq!(report.lanes[0].status, RealizationStatus::Exact);
+        assert_eq!(
+            report.lanes[0]
+                .selected_face_sha256
+                .as_deref()
+                .map(str::len),
+            Some(64)
+        );
+        let faces = registry.injected_faces();
+        let first = emit_pdf_with_fonts(&doc, None, &faces).unwrap();
+        let second = emit_pdf_with_fonts(&doc, None, &faces).unwrap();
+        assert_eq!(first.bytes, second.bytes);
     }
 
     #[test]

--- a/crates/hwp-typeset/src/lib.rs
+++ b/crates/hwp-typeset/src/lib.rs
@@ -1634,7 +1634,6 @@ pub fn layout_paragraph(
     let mut chars: Vec<(char, i32)> = Vec::new();
     let mut advs: Vec<f64> = Vec::new();
     let mut object_heights: Vec<f64> = Vec::new();
-    let font = plain_font();
     for run in &p.runs {
         let cs = doc.char_shapes.get(run.char_shape);
         let size = cs.map(|c| c.height).filter(|&h| h > 0).unwrap_or(1000);
@@ -1643,6 +1642,7 @@ pub fn layout_paragraph(
                 Inline::Text(t) => {
                     for ch in t.chars() {
                         let sch = subst_glyph(ch);
+                        let font = resolved_font_key(cs, sch, fonts);
                         chars.push((sch, size));
                         advs.push(scaled_advance(sch, size, cs, &font, fonts));
                         object_heights.push(0.0);
@@ -1879,6 +1879,41 @@ pub(crate) fn script_slot(ch: char) -> ScriptClass {
         0x3040..=0x30FF => ScriptClass::Japanese,
         0x0000..=0x024F => ScriptClass::Latin,
         _ => ScriptClass::Other,
+    }
+}
+
+/// Resolve one glyph to the same display family/style that the placer and PDF exporter use. An
+/// explicitly registered document family wins; otherwise the deterministic OFL substitute name is
+/// carried in the key so a matching injected serif/sans face can drive both metrics and realization.
+pub(crate) fn resolved_font_key(
+    cs: Option<&CharShape>,
+    ch: char,
+    fonts: &dyn FontMetricsProvider,
+) -> FontKey {
+    let Some(cs) = cs else { return plain_font() };
+    let slot = script_slot(ch);
+    let requested = cs
+        .fonts
+        .get(slot as usize)
+        .and_then(|name| name.as_deref())
+        .or(cs.font_family.as_deref())
+        .map(str::trim)
+        .filter(|name| !name.is_empty());
+    let family = requested
+        .and_then(|name| {
+            if fonts.has_family(name) {
+                Some(name.to_string())
+            } else {
+                let panose = cs.font_panose.get(slot as usize).and_then(Option::as_ref);
+                hwp_model::font_class::substitute_family_with_panose(name, panose)
+                    .map(str::to_string)
+            }
+        })
+        .unwrap_or_default();
+    FontKey {
+        family,
+        bold: cs.bold,
+        italic: cs.italic,
     }
 }
 

--- a/crates/hwp-typeset/src/place.rs
+++ b/crates/hwp-typeset/src/place.rs
@@ -3016,6 +3016,9 @@ struct GlyphInfo {
     /// Requested font family (CharShape.font_family) — display only (the SVG/text font-family); advances
     /// still use the default metrics, so a font change re-DISPLAYS without reflowing.
     font: Option<String>,
+    /// Exact metric selection key. This is resolved once with the same family substitution as the
+    /// display face, keeping the line breaker and positioned glyph advances in lockstep.
+    metric_font: FontKey,
     /// 장평 (width scale, default 1.0) + 자간 (letter gap as a fraction of the EM, default 0.0), resolved
     /// from the run's char shape per the glyph's script. The DRAWN advance must apply these so glyphs
     /// sit where the line-breaker (which now scales advances) computed — else a compressed run renders
@@ -3042,12 +3045,7 @@ impl ParagraphAtom {
     fn advance(&self, fonts: &dyn FontMetricsProvider) -> f64 {
         match self {
             Self::Glyph(glyph) => {
-                let plain = FontKey {
-                    family: String::new(),
-                    bold: false,
-                    italic: false,
-                };
-                fonts.advance_width(&plain, glyph.ch, glyph.size as i32) * glyph.ratio
+                fonts.advance_width(&glyph.metric_font, glyph.ch, glyph.size as i32) * glyph.ratio
                     + glyph.spacing_em * glyph.size
             }
             Self::Object {
@@ -3140,6 +3138,7 @@ fn paragraph_atoms(
                         let cluster = crate::old_hangul_cluster(ch);
                         let sch = crate::subst_glyph(ch);
                         let slot = crate::script_slot(sch);
+                        let metric_font = crate::resolved_font_key(cs, sch, fonts);
                         let (ratio, spacing_em) = cs
                             .map(|c| {
                                 let r = match *c.ratio.get(slot) {
@@ -3159,6 +3158,7 @@ fn paragraph_atoms(
                             bold,
                             italic,
                             font: display_font(cs, slot, fonts),
+                            metric_font,
                             ratio,
                             spacing_em,
                             cluster,

--- a/crates/hwp-typeset/src/shaper.rs
+++ b/crates/hwp-typeset/src/shaper.rs
@@ -16,6 +16,8 @@ use hwp_model::prelude::*;
 
 use crate::is_full_width;
 
+type AdvanceCacheKey = (String, bool, bool, char, i32);
+
 /// System font candidates probed at runtime, Korean-capable first. The first that parses wins; if
 /// none is present we fall back to the per-script approximation (so this never panics headless/CI).
 /// We deliberately prefer a FULL-EM Korean face (AppleGothic packs Hangul at exactly 1 EM, like
@@ -165,8 +167,19 @@ pub struct RealFontMetrics {
     /// Proportional Latin/serif face for Latin/digit/punctuation. `None` → route Latin to `font`
     /// (the old single-face behavior), so a machine without a Latin face is never worse than before.
     latin: Option<LoadedFont>,
-    /// (char, size_hwpunit) → advance HWPUNIT. RefCell: the trait method is `&self`.
-    cache: RefCell<HashMap<(char, i32), f64>>,
+    /// Explicit host-provided faces. Unlike the legacy first-face mapping, these are selected by the
+    /// requested family/style so layout and PDF realization cannot silently disagree.
+    registered: Vec<RegisteredFace>,
+    /// (normalized family, bold, italic, char, size_hwpunit) → advance HWPUNIT.
+    cache: RefCell<HashMap<AdvanceCacheKey, f64>>,
+}
+
+struct RegisteredFace {
+    family: String,
+    category: hwp_model::font_class::FontCategory,
+    bold: bool,
+    italic: bool,
+    font: LoadedFont,
 }
 
 impl Default for RealFontMetrics {
@@ -182,6 +195,7 @@ impl RealFontMetrics {
         RealFontMetrics {
             font: LoadedFont::discover(),
             latin: LoadedFont::discover_from(LATIN_FONT_CANDIDATES),
+            registered: Vec::new(),
             cache: RefCell::new(HashMap::new()),
         }
     }
@@ -195,14 +209,35 @@ impl RealFontMetrics {
     /// same bytes → identical advances). Bytes that don't parse fall back to the per-script
     /// approximation (never panics). TTF/OTF single-face only (face index 0); a TTC isn't accepted.
     pub fn from_bytes(bytes: &[u8]) -> RealFontMetrics {
-        let font = LoadedFont::from_bytes(
-            bytes.to_vec().into_boxed_slice(),
-            0,
-            "<injected>".to_string(),
-        );
+        Self::from_registry(&[(String::new(), bytes.to_vec())])
+    }
+
+    /// Build deterministic metrics from all caller-provided faces. Invalid/empty faces are ignored;
+    /// registration order is only the final default when neither an exact family nor a matching
+    /// serif/sans category exists.
+    pub fn from_registry(faces: &[(String, Vec<u8>)]) -> RealFontMetrics {
+        let registered = faces
+            .iter()
+            .filter_map(|(family, bytes)| {
+                let font = LoadedFont::from_bytes(
+                    bytes.clone().into_boxed_slice(),
+                    0,
+                    "<injected>".to_string(),
+                )?;
+                let lower = family.to_lowercase();
+                Some(RegisteredFace {
+                    family: normalized_family(family),
+                    category: hwp_model::font_class::classify(family),
+                    bold: lower.contains("bold") || lower.contains("boldface"),
+                    italic: lower.contains("italic") || lower.contains("oblique"),
+                    font,
+                })
+            })
+            .collect();
         RealFontMetrics {
-            font,
+            font: None,
             latin: None,
+            registered,
             cache: RefCell::new(HashMap::new()),
         }
     }
@@ -210,12 +245,15 @@ impl RealFontMetrics {
     /// True when a real font backs the metrics (a Korean-capable face was found). False = the
     /// approximate fallback is active (no font on this machine / CI).
     pub fn is_real(&self) -> bool {
-        self.font.is_some()
+        self.font.is_some() || !self.registered.is_empty()
     }
 
     /// Path of the loaded font, or `None` when falling back to approximate metrics. Diagnostics.
     pub fn font_path(&self) -> Option<&str> {
-        self.font.as_ref().map(|f| f.path.as_str())
+        self.font
+            .as_ref()
+            .or_else(|| self.registered.first().map(|face| &face.font))
+            .map(|f| f.path.as_str())
     }
 
     /// Path of the loaded proportional Latin face, or `None` when Latin routes to the Korean face
@@ -246,42 +284,95 @@ impl RealFontMetrics {
     }
 
     /// Base advance (no 자간/장평) in HWPUNIT — the [`FontMetricsProvider`] contract value.
-    fn base_advance(&self, ch: char, size_hwpunit: i32) -> f64 {
+    fn base_advance(&self, key: &FontKey, ch: char, size_hwpunit: i32) -> f64 {
         let em = size_hwpunit.max(1) as f64;
-        let key = (ch, size_hwpunit);
-        if let Some(&v) = self.cache.borrow().get(&key) {
+        let cache_key = (
+            normalized_family(&key.family),
+            key.bold,
+            key.italic,
+            ch,
+            size_hwpunit,
+        );
+        if let Some(&v) = self.cache.borrow().get(&cache_key) {
             return v;
         }
-        let adv = match &self.font {
-            // Full-width glyphs (Hangul/CJK/fullwidth, 전각) snap to the 1-EM grid: Hancom spaces
-            // them on the EM grid regardless of the font's own (often tighter) advance, so snapping
-            // keeps our line breaks aligned with Hancom's.
-            Some(_) if is_full_width(ch) => em,
-            // Proportional glyphs (Latin/digit/punct) get the REAL HarfBuzz-shaped advance from the
-            // PROPORTIONAL LATIN face when present (Times/Helvetica/Liberation) — the Korean face
-            // packs Latin too wide (overflows narrow cells). The Latin face falls back to the Korean
-            // face, then the per-script approximation, so an absent glyph never collapses to zero.
-            Some(kor) => {
-                let latin = self.latin.as_ref().unwrap_or(kor);
-                let raw = latin.raw_advance(ch);
+        let selected = self.registered_face(key);
+        let adv = if let Some(face) = selected {
+            if is_full_width(ch) {
+                em
+            } else {
+                let raw = face.raw_advance(ch);
                 if raw > 0.0 {
-                    raw / latin.units_per_em * em
-                } else if self.latin.is_some() {
-                    // Glyph absent in the Latin face — try the Korean face before approximating.
-                    let kraw = kor.raw_advance(ch);
-                    if kraw > 0.0 {
-                        kraw / kor.units_per_em * em
-                    } else {
-                        approx_advance(ch, em)
-                    }
+                    raw / face.units_per_em * em
                 } else {
                     approx_advance(ch, em)
                 }
             }
-            None => approx_advance(ch, em),
+        } else {
+            match &self.font {
+                // Full-width glyphs (Hangul/CJK/fullwidth, 전각) snap to the 1-EM grid: Hancom spaces
+                // them on the EM grid regardless of the font's own (often tighter) advance, so snapping
+                // keeps our line breaks aligned with Hancom's.
+                Some(_) if is_full_width(ch) => em,
+                // Proportional glyphs (Latin/digit/punct) get the REAL HarfBuzz-shaped advance from the
+                // PROPORTIONAL LATIN face when present (Times/Helvetica/Liberation) — the Korean face
+                // packs Latin too wide (overflows narrow cells). The Latin face falls back to the Korean
+                // face, then the per-script approximation, so an absent glyph never collapses to zero.
+                Some(kor) => {
+                    let latin = self.latin.as_ref().unwrap_or(kor);
+                    let raw = latin.raw_advance(ch);
+                    if raw > 0.0 {
+                        raw / latin.units_per_em * em
+                    } else if self.latin.is_some() {
+                        // Glyph absent in the Latin face — try the Korean face before approximating.
+                        let kraw = kor.raw_advance(ch);
+                        if kraw > 0.0 {
+                            kraw / kor.units_per_em * em
+                        } else {
+                            approx_advance(ch, em)
+                        }
+                    } else {
+                        approx_advance(ch, em)
+                    }
+                }
+                None => approx_advance(ch, em),
+            }
         };
-        self.cache.borrow_mut().insert(key, adv);
+        self.cache.borrow_mut().insert(cache_key, adv);
         adv
+    }
+
+    fn registered_face(&self, key: &FontKey) -> Option<&LoadedFont> {
+        if self.registered.is_empty() {
+            return None;
+        }
+        let family = normalized_family(&key.family);
+        let exact = |face: &&RegisteredFace| face.family == family;
+        self.registered
+            .iter()
+            .filter(exact)
+            .find(|face| face.bold == key.bold && face.italic == key.italic)
+            .or_else(|| {
+                self.registered
+                    .iter()
+                    .filter(exact)
+                    .find(|face| !face.bold && !face.italic)
+            })
+            .or_else(|| self.registered.iter().find(|face| face.family == family))
+            .or_else(|| {
+                let category = hwp_model::font_class::classify(&key.family);
+                self.registered.iter().find(|face| {
+                    face.category == category && face.bold == key.bold && face.italic == key.italic
+                })
+            })
+            .or_else(|| {
+                let category = hwp_model::font_class::classify(&key.family);
+                self.registered
+                    .iter()
+                    .find(|face| face.category == category && !face.bold && !face.italic)
+            })
+            .or_else(|| self.registered.first())
+            .map(|face| &face.font)
     }
 
     /// Advance in HWPUNIT with 자간/장평 from the [`CharShape`] applied (the layout engine's job per
@@ -289,7 +380,15 @@ impl RealFontMetrics {
     /// per-glyph gap as a fraction of the EM. `script` picks the per-script slot; default = Hangul.
     pub fn advance_scaled(&self, ch: char, size_hwpunit: i32, cs: &CharShape) -> f64 {
         let script = script_of(ch);
-        let base = self.base_advance(ch, size_hwpunit);
+        let base = self.base_advance(
+            &FontKey {
+                family: String::new(),
+                bold: cs.bold,
+                italic: cs.italic,
+            },
+            ch,
+            size_hwpunit,
+        );
         // 0 = unset → 100% (no scaling); otherwise clamp to HWP's 50–200% range. Remap BEFORE the
         // clamp so a default (0) shape is full-width, not clamped up to the 50% floor.
         let ratio = match *cs.ratio.get(script) {
@@ -338,8 +437,8 @@ fn script_of(ch: char) -> ScriptClass {
 }
 
 impl FontMetricsProvider for RealFontMetrics {
-    fn advance_width(&self, _font: &FontKey, ch: char, size_hwpunit: i32) -> f64 {
-        self.base_advance(ch, size_hwpunit)
+    fn advance_width(&self, font: &FontKey, ch: char, size_hwpunit: i32) -> f64 {
+        self.base_advance(font, ch, size_hwpunit)
     }
 
     /// Real line height from the Korean face's vertical metrics (ascent + descent + line_gap),
@@ -356,6 +455,24 @@ impl FontMetricsProvider for RealFontMetrics {
         // a Fixed/Minimum-spacing floor can be reintroduced per-type later if needed.)
         size_hwpunit.max(1) as f64
     }
+
+    fn has_family(&self, family: &str) -> bool {
+        let family = normalized_family(family);
+        self.registered.iter().any(|face| face.family == family)
+    }
+}
+
+fn normalized_family(family: &str) -> String {
+    let mut words: Vec<_> = family.split_whitespace().collect();
+    while words.last().is_some_and(|word| {
+        matches!(
+            word.to_ascii_lowercase().as_str(),
+            "regular" | "bold" | "italic" | "oblique" | "boldface"
+        )
+    }) {
+        words.pop();
+    }
+    words.join(" ").to_lowercase()
 }
 
 #[cfg(test)]
@@ -397,6 +514,7 @@ mod tests {
         let m = RealFontMetrics {
             font: None,
             latin: None,
+            registered: Vec::new(),
             cache: RefCell::new(HashMap::new()),
         };
         let f = FontKey {

--- a/crates/hwp-viewer/src/lib.rs
+++ b/crates/hwp-viewer/src/lib.rs
@@ -24,6 +24,7 @@ use tauri::{Emitter, Manager};
 /// `Arc` so the heavy commands can clone a handle out of `State` and move it into a
 /// `spawn_blocking` worker, keeping the parse/serialize/render off the async/IPC thread.
 pub type SharedSession = Arc<Mutex<hwp_mcp::Session>>;
+pub type SharedFonts = Arc<Mutex<Vec<(String, Vec<u8>)>>>;
 pub(crate) type SharedDesktopState = Arc<Mutex<desktop_state::DesktopDocumentState>>;
 pub(crate) type SharedRecentDocuments = Arc<Mutex<()>>;
 
@@ -356,6 +357,35 @@ fn allow_desktop_close(desktop: tauri::State<'_, SharedDesktopState>) -> Result<
     Ok(())
 }
 
+/// Register/replace one explicit host-provided face using the same bounded contract as wasm. The
+/// bytes remain process-local; no system directory is scanned and no path crosses the webview IPC.
+#[tauri::command]
+fn register_font(
+    family: String,
+    bytes: Vec<u8>,
+    fonts: tauri::State<'_, SharedFonts>,
+) -> Result<(), String> {
+    use hwp_session::font_registry::{FontFaceInput, FontRegistry, FontRegistryLimits};
+    let mut fonts = fonts.lock().map_err(|_| "font registry poisoned")?;
+    let mut prospective = fonts.clone();
+    match prospective
+        .iter_mut()
+        .find(|(registered, _)| registered.trim().eq_ignore_ascii_case(family.trim()))
+    {
+        Some(slot) => *slot = (family.clone(), bytes.clone()),
+        None => prospective.push((family.clone(), bytes.clone())),
+    }
+    FontRegistry::new(
+        prospective
+            .iter()
+            .map(|(family, bytes)| FontFaceInput::from_legacy_label(family.clone(), bytes.clone()))
+            .collect(),
+        FontRegistryLimits::default(),
+    )?;
+    *fonts = prospective;
+    Ok(())
+}
+
 #[tauri::command]
 async fn render_page(page: u32, sess: tauri::State<'_, SharedSession>) -> Result<String, String> {
     let sess = sess.inner().clone();
@@ -396,12 +426,15 @@ async fn render_doc_html(sess: tauri::State<'_, SharedSession>) -> Result<String
 async fn render_own_page(
     page: u32,
     sess: tauri::State<'_, SharedSession>,
+    fonts: tauri::State<'_, SharedFonts>,
 ) -> Result<String, String> {
     let sess = sess.inner().clone();
+    let fonts = fonts.inner().clone();
     tauri::async_runtime::spawn_blocking(move || {
         let s = sess.lock().map_err(|_| "session poisoned")?;
+        let fonts = fonts.lock().map_err(|_| "font registry poisoned")?;
         let doc = s.doc.as_ref().ok_or("no document open")?.doc();
-        let svgs = hwp_session::render_svg(doc);
+        let svgs = hwp_session::render_svg_with(doc, &fonts);
         svgs.get(page as usize)
             .cloned()
             .ok_or_else(|| format!("page {page} out of range (0..{})", svgs.len()))
@@ -413,15 +446,20 @@ async fn render_own_page(
 /// Page count of the LIVE document as paginated by OUR OWN engine (may differ from `doc_page_count`,
 /// which uses the rhwp paginator) — drives the "자체 렌더" virtualized page list. 0 if no document.
 #[tauri::command]
-async fn own_page_count(sess: tauri::State<'_, SharedSession>) -> Result<u32, String> {
+async fn own_page_count(
+    sess: tauri::State<'_, SharedSession>,
+    fonts: tauri::State<'_, SharedFonts>,
+) -> Result<u32, String> {
     let sess = sess.inner().clone();
+    let fonts = fonts.inner().clone();
     tauri::async_runtime::spawn_blocking(move || {
         let s = sess.lock().map_err(|_| "session poisoned")?;
+        let fonts = fonts.lock().map_err(|_| "font registry poisoned")?;
         let doc = match s.doc.as_ref() {
             Some(d) => d.doc(),
             None => return Ok(0),
         };
-        Ok(hwp_session::render_svg(doc).len() as u32)
+        Ok(hwp_session::render_svg_with(doc, &fonts).len() as u32)
     })
     .await
     .map_err(|e| e.to_string())?
@@ -545,15 +583,22 @@ async fn export_doc_html(
 async fn export_doc_pdf(
     path: String,
     sess: tauri::State<'_, SharedSession>,
+    fonts: tauri::State<'_, SharedFonts>,
 ) -> Result<String, String> {
     let sess = sess.inner().clone();
+    let fonts = fonts.inner().clone();
     tauri::async_runtime::spawn_blocking(move || {
         let s = sess.lock().map_err(|_| "session poisoned")?;
+        let fonts = fonts.lock().map_err(|_| "font registry poisoned")?;
         let doc = s.doc.as_ref().ok_or("no document open")?.doc();
         let title = std::path::Path::new(&path)
             .file_stem()
             .map(|t| t.to_string_lossy().into_owned());
-        let result = hwp_session::emit_pdf(doc, title)?;
+        let result = if fonts.is_empty() {
+            hwp_session::emit_pdf(doc, title)?
+        } else {
+            hwp_session::emit_pdf_with_fonts(doc, title, &fonts)?
+        };
         std::fs::write(&path, &result.bytes).map_err(|e| format!("write {path}: {e}"))?;
         let font = match &result.font_path {
             Some(_) => "한글 글꼴 임베드됨",
@@ -1992,12 +2037,21 @@ async fn export_hwpx_bytes(sess: tauri::State<'_, SharedSession>) -> Result<Vec<
 /// place_doc → paint IR → krilla path). Needs `--features pdf`; without it a clear error (below).
 #[cfg(feature = "pdf")]
 #[tauri::command]
-async fn export_pdf_bytes(sess: tauri::State<'_, SharedSession>) -> Result<Vec<u8>, String> {
+async fn export_pdf_bytes(
+    sess: tauri::State<'_, SharedSession>,
+    fonts: tauri::State<'_, SharedFonts>,
+) -> Result<Vec<u8>, String> {
     let sess = sess.inner().clone();
+    let fonts = fonts.inner().clone();
     tauri::async_runtime::spawn_blocking(move || {
         let s = sess.lock().map_err(|_| "session poisoned")?;
+        let fonts = fonts.lock().map_err(|_| "font registry poisoned")?;
         let doc = s.doc.as_ref().ok_or("no document open")?.doc();
-        Ok(hwp_session::emit_pdf(doc, None)?.bytes)
+        if fonts.is_empty() {
+            Ok(hwp_session::emit_pdf(doc, None)?.bytes)
+        } else {
+            Ok(hwp_session::emit_pdf_with_fonts(doc, None, &fonts)?.bytes)
+        }
     })
     .await
     .map_err(|e| e.to_string())?
@@ -2023,12 +2077,19 @@ async fn export_pdf_bytes(_sess: tauri::State<'_, SharedSession>) -> Result<Vec<
 async fn print_doc_pdf(
     app: tauri::AppHandle,
     sess: tauri::State<'_, SharedSession>,
+    fonts: tauri::State<'_, SharedFonts>,
 ) -> Result<native_print::NativePrintResult, String> {
     let sess = sess.inner().clone();
+    let fonts = fonts.inner().clone();
     let export = tauri::async_runtime::spawn_blocking(move || {
         let s = sess.lock().map_err(|_| "session poisoned")?;
+        let fonts = fonts.lock().map_err(|_| "font registry poisoned")?;
         let doc = s.doc.as_ref().ok_or("no document open")?.doc();
-        hwp_session::emit_pdf(doc, None)
+        if fonts.is_empty() {
+            hwp_session::emit_pdf(doc, None)
+        } else {
+            hwp_session::emit_pdf_with_fonts(doc, None, &fonts)
+        }
     })
     .await
     .map_err(|e| e.to_string())??;
@@ -2095,6 +2156,7 @@ pub fn run() {
     let app = builder
         .plugin(tauri_plugin_dialog::init())
         .manage(SharedSession::default())
+        .manage(SharedFonts::default())
         .manage(SharedDesktopState::default())
         .manage(SharedRecentDocuments::default())
         .manage(open_request::OpenRequestQueue::default())
@@ -2143,6 +2205,7 @@ pub fn run() {
             render_page,
             render_doc_html,
             render_own_page,
+            register_font,
             own_page_count,
             doc_page_count,
             doc_outline,

--- a/crates/hwp-wasm/src/lib.rs
+++ b/crates/hwp-wasm/src/lib.rs
@@ -767,18 +767,35 @@ impl HwpDoc {
     /// deterministic Approx fallback (backward compatible) and `export_pdf` throws `font_missing`.
     #[wasm_bindgen(js_name = registerFont)]
     pub fn register_font(&mut self, family: String, bytes: Vec<u8>) -> Result<(), JsValue> {
-        if bytes.starts_with(b"ttcf") {
-            return Err(js_err(
-                "ttc_unsupported",
-                "TTC(글꼴 컬렉션)는 지원하지 않습니다 — 단일 TTF/OTF 파일을 선택하세요 (krilla 서브셋 제약)",
-            ));
+        use hwp_session::font_registry::{FontFaceInput, FontRegistry, FontRegistryLimits};
+        let mut prospective = self.fonts.clone();
+        match prospective
+            .iter_mut()
+            .find(|(registered, _)| registered.trim().eq_ignore_ascii_case(family.trim()))
+        {
+            Some(slot) => *slot = (family.clone(), bytes.clone()),
+            None => prospective.push((family.clone(), bytes.clone())),
         }
+        FontRegistry::new(
+            prospective
+                .iter()
+                .map(|(family, bytes)| {
+                    FontFaceInput::from_legacy_label(family.clone(), bytes.clone())
+                })
+                .collect(),
+            FontRegistryLimits::default(),
+        )
+        .map_err(|message| js_err("invalid_font_registry", &message))?;
         // Upsert by family (issue 058): replace this family's bytes in place if present (so re-picking a
         // face takes effect immediately), else append (so a serif substitute coexists with the gothic
         // body — the first-registered body still backs metrics). Invalidate the revision-keyed SVG cache
         // — the new metrics re-paginate, and a stale cache would make the screen disagree with the PDF
         // (issue §함정: 캐시 무효화).
-        match self.fonts.iter_mut().find(|(f, _)| *f == family) {
+        match self
+            .fonts
+            .iter_mut()
+            .find(|(registered, _)| registered.trim().eq_ignore_ascii_case(family.trim()))
+        {
             Some(slot) => slot.1 = bytes,
             None => self.fonts.push((family, bytes)),
         }

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,6 +3,37 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
+- 갱신: 2026-08-25 · Codex(sol) — **#215 deterministic licensed font registry 구현·full green · PR 직전**.
+  strict schema v1 registry가 family/style·face 수/개별/총 bytes·TTF/OTF magic·실제 face parse·SHA-256을
+  검증하고, 경로/본문/font bytes 없는 deterministic fingerprint와 exact/fallback/unavailable realization을
+  낸다. RealFontMetrics의 줄바꿈과 place_doc, PDF embed가 같은 normalized family/style/face hash를
+  선택하며 regular/bold/italic/bold-italic 실면을 지원한다. CLI `--font-registry`/`--font-report`, wasm의
+  bounded atomic register, Tauri의 실제 register command와 screen/PDF/print 주입을 같은 계약으로 묶었다.
+  OFL Nanum Gothic/Myeongjo 6-face 공개 manifest의 footnote 보고서는 13 glyph exact + 1,391 glyph
+  category fallback을 정직하게 기록했고, visual-check는 candidate fingerprint를 자동 전달한다.
+  서로 다른 process의 PDF SHA가 `d461528f…`로 exact, 5쪽·41 semantic region 비교 가능 영역은 전부
+  1.0이다(빈 ink는 기존 규칙대로 partially-unscorable). focused/full은 workspace·PDF visual **55**·
+  document visual **4**·AI **20문서/120작업 100%**·canonical **8/18/24+98.9%**·corpus **84**·oracle
+  **82**·HWPX body exact **89.5%/±1 98.2%**·wasm **8,016,704B**·Vitest **1,012**·Chromium
+  **83 pass/3 intentional skip/2 retry-pass**, licenses와 PDF-feature clippy green이다. 첫 E2E 실패 둘은
+  재시도 2.8/3.0초 통과한 기존 flaky이며 코드 회귀 0. rhwp `f137b4c9`는 pinned/무수정.
+  **다음:** diff/privacy·generated audit→commit/push→PR `Closes #215`→exact-head CI/comments green
+  자율 병합→desktop overlay geometry까지 registry를 전파하는 bounded follow-up 또는 #94 HWP5 cutover
+  corpus 증거 중 roadmap 우선순위를 재평가해 issue-first 진행.
+
+- 갱신: 2026-08-25 · Codex(sol) — **PR #214 병합 · #215 deterministic font registry 착수**.
+  #213 exact head `50bd1bf`는 issue-link **3s**·licenses **2m41s**·build-test **9m41s** green,
+  CLEAN/MERGEABLE, review/general 댓글 0으로 protected main `e990f619`에 squash 병합됐다. #213은
+  close되고 원격 branch도 삭제했다. #93/#114에는 원문 없이 8쪽·102영역(70 text/32 table), worst-page
+  ink F1 **0.218434**, 여러 text region **0.0**, reference PDF font object **126** 대 candidate realized
+  face **3**을 동기화했다. threshold/pass는 null이고 기존 page/tile/region oracle은 무변경이다.
+  이 신호를 first-party child #215로 등재하고 exact main의 `codex/issue-215-font-registry`를 만들었다.
+  목표는 명시적으로 제공된 합법 font bytes만 쓰는 strict registry, layout/PDF 동일 face hash lockstep,
+  OFL substitute의 정직한 fallback 표시와 path/text/raw-byte 없는 realization report다. proprietary font
+  vendoring·network lookup·system scan·substitute exact 주장 금지. rhwp는 `f137b4c9` pinned/무수정.
+  **다음:** 기존 RealFontMetrics/EmbedFont/injected web·desktop font flow를 지도화→한 family/style이 layout와
+  PDF에서 서로 다른 face를 고르는 RED→versioned bounded registry DTO와 resolver를 공유 코어에 최소 구현.
+
 - 갱신: 2026-08-25 · Codex(sol) — **#213 one-command semantic PDF visual check full green · PR 직전**.
   `render_doc_trees_with_placement` 한 번의 first-party placement에서 own PDF와 SHA-bound content-free
   text/table/image/object 영역을 함께 만들고, strict schema/쪽·MediaBox/유한·범위·중복·symlink·8MiB·

--- a/docs/FONT-REGISTRY.md
+++ b/docs/FONT-REGISTRY.md
@@ -1,0 +1,30 @@
+# Deterministic font registry (schema v1)
+
+The own renderer and PDF exporter accept the same explicit font bytes. Deterministic mode does not
+scan system directories, fetch fonts, upload document fonts, or redistribute proprietary Hancom/HCR/
+Malgun/Human faces. A user may supply a lawfully obtained local face; the repository fixture uses
+only the bundled Nanum OFL assets.
+
+Use the public six-face regular/bold/gothic/serif alias fixture:
+
+```bash
+auto-hwp export-pdf corpus/hwpx/footnote-01.hwpx \
+  --font-registry corpus/font-registry/ofl-registry-v1.json \
+  --font-report font-realization.json -o out.pdf
+```
+
+The manifest is strict JSON: `schema_version` must be `1`; unknown fields fail. Every face declares
+`family`, `style` (`regular`, `bold`, `italic`, or `bold-italic`), a local `path`, a pinned lowercase or
+uppercase `sha256`, and optional integer `face_index` (currently only `0`). The shell rejects symlinks,
+non-regular files, collections, malformed/unsupported containers, duplicate normalized family/style,
+hash mismatch, and configured face/per-face/total byte limit violations before opening the document or
+writing export artifacts.
+
+The report contains only a registry fingerprint, face count, requested typographic category/style,
+`exact`/`fallback`/`unavailable` status, selected face SHA-256, and glyph count. It contains no document
+text, family name, font/document path, or raw bytes. `fallback` is an explicit OFL substitution, never
+an exact-fidelity claim. A missing lane is zero usage; an `unavailable` lane means requested glyphs had
+no realizable face.
+
+`scripts/document-visual-check.mjs --font-registry …` forwards the generated registry fingerprint to
+the #213 report automatically and rejects a conflicting manual candidate fingerprint.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,18 @@
 
 ---
 
+## 2026-08-25 (Codex sol) · #215 deterministic font registry
+- strict bounded font manifest/realization report와 layout·PDF 동일 face-hash 선택을 공유 코어에 구현.
+- CLI·wasm·Tauri 등록/화면/PDF/print와 #213 visual-check fingerprint를 연결, OFL 6-face fixture 추가.
+- full green: 8/18/24+98.9%, oracle82, AI120, Vitest1,012, Chromium83 pass/3 skip/2 retry-pass.
+- 다음: audit→commit/push→`Closes #215` PR/CI/merge→desktop geometry/HWP5 cutover 우선순위 재평가.
+
+## 2026-08-25 (Codex sol) · PR #214 merge / #215 start
+- #214 exact-head CI 3종 green·댓글 0 확인 후 main `e990f619` 병합, #213 close/branch 정리.
+- #93/#114에 102 semantic region·font object 126:3 신호를 content-free로 동기화.
+- #215를 strict licensed font registry + layout/PDF face lockstep child로 등재·착수.
+- 다음: 기존 font injection/resolution 지도화→mismatched-face RED→공유 bounded registry 구현.
+
 ## 2026-08-25 (Codex sol) · #213 semantic PDF visual check
 - HWP/HWPX→own PDF→SHA-bound text/table/image/object metrics를 한 atomic 명령으로 연결.
 - strict manifest·resource/privacy hostile 경계와 worst 5 region JSON/HTML, CI 계약을 추가.

--- a/packages/react/src/TauriAdapter.ts
+++ b/packages/react/src/TauriAdapter.ts
@@ -51,9 +51,8 @@ export interface TauriAdapterOptions {
 /// Two seams are DESKTOP-SPECIFIC (host chrome), documented not hidden:
 ///   • `open(bytes)` vs. the app's path-based `open_doc` — bridged by `resolveOpenPath` (a native file
 ///     dialog wraps opening; the workspace's `<input type=file>` is a web convenience).
-///   • `registerFont` is a no-op + `hasFont()` is always true — the desktop renders with its native /
-///     bundled font stack (no per-call byte injection like the fontless browser); PDF export subsets a
-///     discovered Korean face natively. (Byte-injected own-render metrics on desktop = a 044 follow-up.)
+///   • `registerFont` forwards explicit bytes into the same bounded registry used by wasm; the native
+///     bundled stack remains the zero-registration fallback. PDF export and own-render share the bytes.
 export class TauriAdapter implements EngineAdapter {
   private invoke: Invoke;
   private resolveOpenPath?: (bytes: Uint8Array, name?: string) => Promise<string>;
@@ -342,10 +341,8 @@ export class TauriAdapter implements EngineAdapter {
     return true;
   }
 
-  async registerFont(_family: string, _bytes: Uint8Array): Promise<void> {
-    // The desktop build renders with its native / bundled font stack; there is no per-call byte
-    // injection command (unlike the fontless browser). Documented no-op — see the class header.
-    // Params match the EngineAdapter contract (and WasmAdapter) even though nothing is injected.
+  async registerFont(family: string, bytes: Uint8Array): Promise<void> {
+    await this.invoke<void>("register_font", { family, bytes: Array.from(bytes) });
   }
 
   hasFont(): boolean {

--- a/packages/react/src/__tests__/desktopParity.contract.test.ts
+++ b/packages/react/src/__tests__/desktopParity.contract.test.ts
@@ -111,12 +111,12 @@ describe("desktop adapter contract (issue #64 D0)", () => {
     }
   });
 
-  it("the 25 direct TauriAdapter invoke commands are registered in generate_handler", () => {
+  it("the 26 direct TauriAdapter invoke commands are registered in generate_handler", () => {
     const handler = generateHandlerCommands(readRepo("crates/hwp-viewer/src/lib.rs"));
     const commands = tauriDirectCommands(tauriSrc);
-    expect(commands).toHaveLength(25);
+    expect(commands).toHaveLength(26);
     const unique = new Set(commands);
-    expect(unique.size).toBe(25);
+    expect(unique.size).toBe(26);
     for (const cmd of unique) {
       expect(handler.has(cmd), `${cmd} is invoked by TauriAdapter but not in generate_handler![]`).toBe(true);
     }

--- a/packages/react/src/__tests__/tauriAdapter.test.ts
+++ b/packages/react/src/__tests__/tauriAdapter.test.ts
@@ -266,12 +266,15 @@ describe("TauriAdapter — run reads + edit intents (issue 043)", () => {
 });
 
 describe("TauriAdapter — fonts + export (issue 043)", () => {
-  it("registerFont is a no-op and hasFont is always true (native font stack)", async () => {
-    const { invoke, calls } = mockInvoke({});
+  it("registerFont forwards explicit bytes while native fallback remains available", async () => {
+    const { invoke, calls } = mockInvoke({ register_font: undefined });
     const a = new TauriAdapter({ invoke });
     await expect(a.registerFont("Noto", new Uint8Array([1]))).resolves.toBeUndefined();
     expect(a.hasFont()).toBe(true);
-    expect(calls).toEqual([]); // no command issued for font registration on the desktop
+    expect(calls).toEqual([{
+      cmd: "register_font",
+      args: { family: "Noto", bytes: [1] },
+    }]);
   });
 
   it("exportHtml maps to render_doc_html (string)", async () => {

--- a/scripts/document-visual-check.mjs
+++ b/scripts/document-visual-check.mjs
@@ -11,7 +11,7 @@ const repo = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const VALUE_OPTIONS = new Set([
   "--reference", "--reference-tier", "--reference-product", "--reference-build",
   "--reference-os", "--font-fingerprint", "--candidate-font-fingerprint", "--reference-note",
-  "--output-dir", "--cli", "--python", "--max-translation-px",
+  "--output-dir", "--cli", "--python", "--max-translation-px", "--font-registry",
 ]);
 
 export function usage() {
@@ -93,11 +93,31 @@ export function runVisualCheck(args) {
   mkdirSync(stage, { mode: 0o700 });
   const candidate = join(stage, "candidate-own.pdf");
   const regions = join(stage, "candidate-regions.json");
+  const fontReport = join(stage, "candidate-font-realization.json");
   const report = join(stage, "report");
   try {
-    command(cli, ["export-pdf", document, "-o", candidate, "--visual-regions", regions], "own PDF export");
+    const exportArgs = ["export-pdf", document, "-o", candidate, "--visual-regions", regions];
+    if (args.font_registry !== undefined) {
+      const registry = resolve(args.font_registry);
+      regularFile(registry, "font registry");
+      exportArgs.push("--font-registry", registry, "--font-report", fontReport);
+    }
+    command(cli, exportArgs, "own PDF export");
     privateFile(candidate);
     privateFile(regions);
+    let registryFingerprint;
+    if (args.font_registry !== undefined) {
+      privateFile(fontReport);
+      const realization = JSON.parse(readFileSync(fontReport, "utf8"));
+      registryFingerprint = realization.registry_fingerprint;
+      if (typeof registryFingerprint !== "string" || !registryFingerprint.startsWith("sha256:")) {
+        throw new Error("font realization report has no valid registry fingerprint");
+      }
+      if (args.candidate_font_fingerprint !== undefined
+          && args.candidate_font_fingerprint !== registryFingerprint) {
+        throw new Error("--candidate-font-fingerprint disagrees with --font-registry");
+      }
+    }
     const compareArgs = [
       join(repo, "scripts/pdf-visual-check.py"), candidate,
       "--reference", reference,
@@ -105,6 +125,8 @@ export function runVisualCheck(args) {
       "--reference-tier", args.reference_tier,
       "--output-dir", report,
     ];
+    const compareValues = { ...args };
+    if (registryFingerprint !== undefined) compareValues.candidate_font_fingerprint = registryFingerprint;
     for (const [key, flag] of [
       ["reference_product", "--reference-product"],
       ["reference_build", "--reference-build"],
@@ -113,7 +135,7 @@ export function runVisualCheck(args) {
       ["candidate_font_fingerprint", "--candidate-font-fingerprint"],
       ["reference_note", "--reference-note"],
       ["max_translation_px", "--max-translation-px"],
-    ]) if (args[key] !== undefined) compareArgs.push(flag, args[key]);
+    ]) if (compareValues[key] !== undefined) compareArgs.push(flag, compareValues[key]);
     command(args.python, compareArgs, "PDF visual comparator");
     const evidence = JSON.parse(readFileSync(regions, "utf8"));
     const reportJson = JSON.parse(readFileSync(join(report, "report.json"), "utf8"));
@@ -123,11 +145,15 @@ export function runVisualCheck(args) {
       source_format: extname(document).slice(1).toLowerCase(),
       candidate_pdf_sha256: evidence.candidate_pdf_sha256,
       visual_region_schema_version: evidence.schema_version,
+      candidate_font_fingerprint: registryFingerprint ?? args.candidate_font_fingerprint ?? null,
       report_status: reportJson.status,
       policy_pass: null,
       artifacts: {
         candidate_pdf: "candidate-own.pdf",
         candidate_regions: "candidate-regions.json",
+        ...(registryFingerprint === undefined ? {} : {
+          candidate_font_realization: "candidate-font-realization.json",
+        }),
         report_json: "report/report.json",
         report_html: "report/index.html",
       },

--- a/scripts/tests/document-visual-check.test.mjs
+++ b/scripts/tests/document-visual-check.test.mjs
@@ -36,6 +36,10 @@ function fixture() {
       schema_version: 1, coordinate_space: "HWPUNIT", candidate_pdf_sha256: "${"a".repeat(64)}",
       pages: [{ page: 1, width: 59500, height: 84200, regions: [] }]
     }) + "\\n");
+    const fontReportIndex = args.indexOf("--font-report");
+    if (fontReportIndex >= 0) fs.writeFileSync(args[fontReportIndex + 1], JSON.stringify({
+      schema_version: 1, registry_fingerprint: "sha256:${"b".repeat(64)}", face_count: 1, lanes: []
+    }) + "\\n");
   `);
   executable(python, `
     const fs = require("node:fs");
@@ -102,4 +106,18 @@ test("a failed subprocess leaves no partial final or staging directory", () => {
     readdirSync(root).filter((name) => name.startsWith(".auto-hwp-visual-")),
     [],
   );
+});
+
+test("a registry fingerprint is forwarded and retained without paths", () => {
+  const { root, document, reference, cli, python } = fixture();
+  const registry = join(root, "fonts.json");
+  writeFileSync(registry, "{}", { mode: 0o600 });
+  const output = join(root, "result");
+  const result = runVisualCheck({
+    document, reference, reference_tier: "T3", output_dir: output, cli, python,
+    font_registry: registry,
+  });
+  assert.equal(result.candidate_font_fingerprint, `sha256:${"b".repeat(64)}`);
+  assert.equal(lstatSync(join(output, "candidate-font-realization.json")).mode & 0o777, 0o600);
+  assert.doesNotMatch(readFileSync(join(output, "summary.json"), "utf8"), /auto-hwp-document-visual-/);
 });


### PR DESCRIPTION
Closes #215

## Outcome
- adds a strict, bounded schema-v1 registry for explicitly supplied licensed TTF/OTF faces with SHA-256 pinning and deterministic registry fingerprints
- makes line breaking, placement, own-render, and PDF embedding resolve the same normalized family/style face
- adds content-free/path-free exact, fallback, and unavailable realization diagnostics; a family match with a missing style is reported as fallback
- wires the contract through export-pdf, wasm, Tauri, and the semantic PDF visual checker
- adds a public six-face Nanum OFL registry fixture and operator documentation

## Safety and boundaries
- no system font scan, network lookup, proprietary font vendoring, user text, font bytes, or local paths in reports
- malformed fonts, TTC/OTC, symlinks, hash mismatch, duplicates, unknown fields, and resource overruns fail closed
- rhwp remains pinned at f137b4c9 and unmodified; it is not used as the renderer
- oracle scoring logic, tolerances, and truth baselines are unchanged

## Verification
- canonical layout gates: 8/18/24 pages and 98.9%+
- public corpus: 84/84; oracle: 82 documents
- AI suite: 20 documents / 120 tasks, hard gates 100%
- PDF visual unit suite: 55; document visual runner: 4
- HWPX body exact 89.5%, within-one-page 98.2%
- wasm 8,016,704 bytes; licenses green
- Vitest 1,012 passed
- Playwright: 83 passed, 3 intentional skips, 2 retry-pass flakes, exit 0
- PDF-feature clippy and fmt green
- same-process registry PDF bytes stable; separate-process candidate SHA d461528f… exact and all comparable semantic regions scored 1.0