### PR TITLE
docs: record deterministic-font PDF fidelity evidence

### DIFF
--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,6 +3,32 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
+- 갱신: 2026-08-25 · Codex(sol) — **#217 deterministic-font fidelity 재측정 완료 · 진단 PR 직전**.
+  public canonical 8쪽 HWP/PDF를 OFL registry로 독립 process 2회 실행해 candidate PDF SHA
+  `2ee86296…`와 registry fingerprint `39841f73…`, 8쪽·102영역(70 text/32 table)이 exact 반복됐다.
+  3,143 glyph는 모두 정직한 fallback이며 path/text/font bytes/source hash는 보고서에 없다. 무등록 대비
+  worst-page ink F1은 **0.218434→0.221304**, page delta는 **-0.008762~+0.002870**, table 평균
+  **-0.000277**, numeric text 평균 **+0.000277**뿐이고 8쪽 content-bbox height delta는 전부 불변이다.
+  text 70 중 F1 0이 **52**, candidate-empty/reference-nonempty가 **25**로 남아 주원인은 font registry가
+  아니다. 시각 확인과 기존 `hwp5_empty_run_layout`의 content-free 경계가 official 하단 쪽번호 대
+  production rhwp lift의 누락을 재확인했다. own candidate는 매쪽 decoration glyph 정확히 3개이며 이를
+  제거할 때 body glyph/block/table/cell/rect/line/image가 exact다. threshold/translation/oracle/T3/
+  `pass=null` 무변경, rhwp `f137b4c9` pinned/무수정. **다음:** 문서 diff·quick 감사→commit/push→
+  PR `Closes #217`·CI green 자율 병합→owned `Section.page_number`를 production HWP5 경로에 fail-closed로
+  연결하는 구현 child를 issue-first 착수한다.
+
+- 갱신: 2026-08-25 · Codex(sol) — **PR #216 병합 · #217 deterministic-font fidelity 재측정 착수**.
+  #215 exact head `715a8eb`는 issue-link **3s**·licenses **11m17s**·build-test **11m18s** green,
+  MERGEABLE, review/general/inline 댓글 0으로 protected main `49c809db`에 squash 병합됐다. #215는
+  close되고 원격 branch도 삭제했다. strict font registry, layout/PDF face lockstep, CLI/wasm/Tauri,
+  OFL 6-face fixture와 content-free realization이 main 정본이다. 다음 P0를 #93 child #217로 등재하고
+  exact main의 `codex/issue-217-font-fidelity`를 만들었다. 목표는 canonical 공개 8쪽 HWP/PDF를 새
+  registry로 독립 process 2회 재측정해 #213 전후 page/tile/semantic-region 변화를 분리하고, 가장 큰
+  잔여 text/table 결함을 content-free 또는 synthetic 최소 경계로 고정하는 것이다. threshold,
+  translation, oracle, T3 reference, `policy.pass=null`은 불변이며 proprietary font/rhwp 수정은 금지.
+  rhwp는 `f137b4c9` pinned/무수정. **다음:** exact CLI 빌드→benchmark.hwp/benchmark.pdf를 OFL registry로
+  두 번 atomic visual-check→SHA/fingerprint/구조·region diff→선두 잔여 원인을 분류한다.
+
 - 갱신: 2026-08-25 · Codex(sol) — **#215 deterministic licensed font registry 구현·full green · PR 직전**.
   strict schema v1 registry가 family/style·face 수/개별/총 bytes·TTF/OTF magic·실제 face parse·SHA-256을
   검증하고, 경로/본문/font bytes 없는 deterministic fingerprint와 exact/fallback/unavailable realization을

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,12 @@
 
 ---
 
+## 2026-08-25 (Codex sol) · #217 deterministic-font fidelity remeasurement
+- public 8-page HWP/PDF + OFL registry를 독립 2회 실행해 PDF SHA/fingerprint/102 regions exact 반복.
+- font 전후 worst-page 0.218434→0.221304; text F1=0 52/70·candidate-empty 25로 주원인 아님을 증명.
+- official 쪽번호 대 rhwp lift 누락을 기존 own-parser 3 glyph/page content-free regression에 연결.
+- 다음: docs PR/CI/merge→owned page-number decoration production 연결 child.
+
 ## 2026-08-25 (Codex sol) · #215 deterministic font registry
 - strict bounded font manifest/realization report와 layout·PDF 동일 face-hash 선택을 공유 코어에 구현.
 - CLI·wasm·Tauri 등록/화면/PDF/print와 #213 visual-check fingerprint를 연결, OFL 6-face fixture 추가.

--- a/docs/PDF-VISUAL-ORACLE.md
+++ b/docs/PDF-VISUAL-ORACLE.md
@@ -419,6 +419,31 @@ and paginator fixes. Both are now structurally comparable, so pixel metrics are 
 silently assigning structural failures a score. Both still have worst-tile recall `0.0`; restoring
 page count and orientation is therefore a prerequisite, not evidence of complete visual fidelity.
 
+### Deterministic-font remeasurement (2026-08-25, #217)
+
+The canonical public 8-page HWP/PDF pair was rerun in two independent processes with the #215 public
+Nanum OFL registry. Both runs produced the same candidate PDF SHA-256
+`2ee862963eceb8c3c31e2a05d8ee915b3e3ad61778a4b541e9aae005fc2d0ad9`, registry fingerprint
+`sha256:39841f738d60ca1822789c92bbc30d134969910589584b3766a4d9365b3742a9`, 8 pages, and 102
+semantic regions (70 text, 32 table). All 3,143 non-whitespace glyph requests were reported as
+OFL fallback rather than exact realization; no path, text, font bytes, or source hash entered the
+report.
+
+The registry changed the worst-page ink F1 from `0.218434` to `0.221304`. Per-page changes ranged
+from `-0.008762` to `+0.002870`; mean table-region ink F1 changed by `-0.000277` and mean numeric
+text-region ink F1 by `+0.000277`. All eight content-bbox height deltas were unchanged. Fifty-two of
+70 text regions remained at ink F1 `0.0`, including 25 where the candidate region had no ink while
+the same aligned reference band did. This is a useful negative result: deterministic substitution
+made the export reproducible and diagnosable, but did not explain the dominant fidelity gap.
+
+Direct inspection isolates one already-owned non-font defect: the official PDF paints a bottom-center
+page-number decoration while the production rhwp semantic lift omits it. The existing content-free
+`hwp5_empty_run_layout` regression proves the first-party HWP5 candidate owns exactly three decoration
+glyphs per page and that removing only `Section.page_number` leaves body glyph/block/table/cell/rect/
+line/image evidence exact. The next bounded implementation should connect that owned decoration to
+the production path fail-closed; it must not modify rhwp, claim OFL fallback as exact, or relax the
+visual oracle.
+
 ## Tests
 
 Run the dependency-free synthetic metric and PNG codec suite with:


### PR DESCRIPTION
Closes #217

## Outcome
- reruns the canonical public 8-page HWP/PDF comparison twice with the #215 OFL registry
- records byte-identical candidate PDF SHA, identical registry fingerprint, and unchanged 8-page / 102-region structure
- quantifies the small font-substitution deltas without changing any oracle policy
- classifies the dominant remaining signal as non-font and connects the missing page-number decoration to the existing content-free first-party HWP5 regression

## Evidence
- candidate PDF SHA exact across independent processes: 2ee862963eceb8c3c31e2a05d8ee915b3e3ad61778a4b541e9aae005fc2d0ad9
- registry fingerprint: sha256:39841f738d60ca1822789c92bbc30d134969910589584b3766a4d9365b3742a9
- 3,143 glyph requests, all honestly reported as fallback
- worst-page ink F1 0.218434 to 0.221304; per-page delta -0.008762 to +0.002870
- table mean delta -0.000277; numeric text mean delta +0.000277
- 52 of 70 text regions remain F1 0; 25 candidate-empty/reference-nonempty
- existing hwp5_empty_run_layout regression passed and proves three first-party decoration glyphs per page with body evidence exact

## Boundaries
- report-only, policy.pass remains null
- T3 reference, alignment bounds, thresholds, scoring logic, and oracle data unchanged
- no proprietary font, user text, source hash, private path, raw font bytes, rhwp edit, or production cutover