### PR TITLE
fix(hwp5): enrich owned page-number metadata

### DIFF
--- a/crates/hwp-core/src/lib.rs
+++ b/crates/hwp-core/src/lib.rs
@@ -30,10 +30,15 @@ impl Engine {
                 enrich_equations(&mut d);
                 d
             }
-            SourceFormat::Hwp5 | SourceFormat::Hwp3 => {
-                // Bootstrap path: rhwp parses binary HWP (when wired).
-                RhwpEngine::new().parse(bytes, fmt)?
+            SourceFormat::Hwp5 => {
+                // Bootstrap body decode remains on governed rhwp. A strict first-party parse may
+                // enrich only page-number metadata that rhwp omitted; unsupported/conflicting input
+                // is an atomic no-op, never a hidden parser cutover.
+                let mut d = RhwpEngine::new().parse(bytes, fmt)?;
+                enrich_hwp5_owned_page_numbers(bytes, &mut d);
+                d
             }
+            SourceFormat::Hwp3 => RhwpEngine::new().parse(bytes, fmt)?,
             SourceFormat::Docx => hwp_foreign::read_docx(bytes)?,
             SourceFormat::Pdf => hwp_foreign::read_pdf(bytes)?,
             SourceFormat::Unknown => return Err(Error::UnknownFormat),
@@ -48,6 +53,39 @@ impl Engine {
     pub fn detect(bytes: &[u8]) -> SourceFormat {
         hwp_ingest::detect(bytes)
     }
+}
+
+/// Merge the one bounded HWP5 decoration already owned by the strict parser. The candidate parse
+/// must succeed for the whole document, and this helper validates every section before mutating any
+/// section so a topology mismatch or typed conflict cannot leave a partially enriched document.
+fn enrich_hwp5_owned_page_numbers(bytes: &[u8], target: &mut SemanticDoc) {
+    let Ok(owned) = hwp_hwp5::OwnHwp5Parser::new().parse(bytes) else {
+        return;
+    };
+    merge_owned_page_numbers(target, &owned);
+}
+
+fn merge_owned_page_numbers(target: &mut SemanticDoc, owned: &SemanticDoc) -> bool {
+    if target.sections.len() != owned.sections.len()
+        || !target
+            .sections
+            .iter()
+            .zip(&owned.sections)
+            .all(
+                |(target, owned)| match (target.page_number, owned.page_number) {
+                    (Some(current), Some(candidate)) => current == candidate,
+                    _ => true,
+                },
+            )
+    {
+        return false;
+    }
+    for (target, owned) in target.sections.iter_mut().zip(&owned.sections) {
+        if target.page_number.is_none() {
+            target.page_number = owned.page_number;
+        }
+    }
+    true
 }
 
 /// Run only the first-party HWP5 parser lane. This entry point is intentionally separate from
@@ -100,6 +138,7 @@ pub fn hwp5_own_parser_eligibility(bytes: &[u8]) -> Result<hwp_hwp5::OwnParserEl
 #[cfg(all(test, feature = "rhwp"))]
 mod hwp5_candidate_tests {
     use super::*;
+    use std::num::NonZeroU16;
 
     fn benchmark() -> Vec<u8> {
         std::fs::read(concat!(
@@ -115,6 +154,71 @@ mod hwp5_candidate_tests {
         assert_eq!(doc.origin, Some(SourceFormat::Hwp5));
         assert_eq!(doc.sections.len(), 1);
         assert!(!doc.sections[0].blocks.is_empty());
+    }
+
+    fn number(start: u16, position: PageNumberPosition) -> PageNumberDecoration {
+        PageNumberDecoration {
+            start: NonZeroU16::new(start).unwrap(),
+            format: PageNumberFormat::Digit,
+            position,
+            prefix: None,
+            suffix: None,
+            dash: Some('-'),
+        }
+    }
+
+    fn sections(numbers: &[Option<PageNumberDecoration>]) -> SemanticDoc {
+        SemanticDoc {
+            sections: numbers
+                .iter()
+                .map(|page_number| Section {
+                    page_number: *page_number,
+                    ..Section::default()
+                })
+                .collect(),
+            ..SemanticDoc::default()
+        }
+    }
+
+    #[test]
+    fn page_number_merge_is_atomic_for_topology_partial_and_typed_conflicts() {
+        let first = number(1, PageNumberPosition::BottomCenter);
+        let second = number(2, PageNumberPosition::BottomCenter);
+        let conflicting = number(1, PageNumberPosition::TopCenter);
+
+        let mut topology = sections(&[None]);
+        assert!(!merge_owned_page_numbers(
+            &mut topology,
+            &sections(&[Some(first), Some(second)])
+        ));
+        assert!(topology.sections[0].page_number.is_none());
+
+        let mut partial = sections(&[None, Some(conflicting)]);
+        assert!(!merge_owned_page_numbers(
+            &mut partial,
+            &sections(&[Some(first), Some(second)])
+        ));
+        assert!(partial.sections[0].page_number.is_none());
+        assert_eq!(partial.sections[1].page_number, Some(conflicting));
+
+        let mut compatible = sections(&[None, Some(second)]);
+        assert!(merge_owned_page_numbers(
+            &mut compatible,
+            &sections(&[Some(first), Some(second)])
+        ));
+        assert_eq!(compatible.sections[0].page_number, Some(first));
+        assert_eq!(compatible.sections[1].page_number, Some(second));
+    }
+
+    #[test]
+    fn production_hwp5_open_enriches_the_strictly_owned_page_number() {
+        let doc = Engine::open(&benchmark()).expect("production HWP5 open succeeds");
+        assert_eq!(doc.sections.len(), 1);
+        assert_eq!(
+            doc.sections[0].page_number,
+            open_hwp5_own(&benchmark()).unwrap().sections[0].page_number
+        );
+        assert!(doc.sections[0].page_number.is_some());
     }
 
     #[test]

--- a/crates/hwp-core/tests/hwp5_empty_run_layout.rs
+++ b/crates/hwp-core/tests/hwp5_empty_run_layout.rs
@@ -2,6 +2,8 @@
 
 use hwp_core::{hwp5_own_parser_eligibility, open_hwp5_own, Engine};
 use hwp_model::document::{Block, Inline, Paragraph, SemanticDoc};
+use hwp_model::prelude::{DocumentParser, SourceFormat};
+use hwp_rhwp::RhwpEngine;
 use hwp_typeset::{compare_placed_docs, place_doc, ApproxFontMetrics, PlacedDoc};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -157,7 +159,8 @@ fn benchmark_empty_run_deltas_are_content_free_and_layout_classified() {
     ))
     .unwrap();
     let candidate = open_hwp5_own(&bytes).unwrap();
-    let oracle = Engine::open(&bytes).unwrap();
+    let oracle = RhwpEngine::new().parse(&bytes, SourceFormat::Hwp5).unwrap();
+    let production = Engine::open(&bytes).unwrap();
     let candidate_paragraphs = paragraphs(&candidate);
     let oracle_paragraphs = paragraphs(&oracle);
     assert_eq!(candidate_paragraphs.len(), oracle_paragraphs.len());
@@ -231,6 +234,7 @@ fn benchmark_empty_run_deltas_are_content_free_and_layout_classified() {
 
     let candidate_placed = place_doc(&candidate, &ApproxFontMetrics);
     let oracle_placed = place_doc(&oracle, &ApproxFontMetrics);
+    let production_placed = place_doc(&production, &ApproxFontMetrics);
     let typed_delta = compare_placed_docs(&candidate_placed, &oracle_placed);
     assert_eq!(candidate_placed.pages.len(), 8);
     assert_eq!(candidate_placed.pages.len(), oracle_placed.pages.len());
@@ -277,6 +281,18 @@ fn benchmark_empty_run_deltas_are_content_free_and_layout_classified() {
     }));
     assert!(typed_delta.pages.iter().all(|page| {
         page.body_glyphs.is_exact()
+            && page.blocks.is_exact()
+            && page.tables.is_exact()
+            && page.cells.is_exact()
+            && page.rects.is_exact()
+            && page.lines.is_exact()
+            && page.images.is_exact()
+    }));
+    let production_delta = compare_placed_docs(&candidate_placed, &production_placed);
+    assert!(production_delta.pages.iter().all(|page| {
+        page.page_box.is_exact()
+            && page.decoration_glyphs.is_exact()
+            && page.body_glyphs.is_exact()
             && page.blocks.is_exact()
             && page.tables.is_exact()
             && page.cells.is_exact()

--- a/crates/hwp-export/tests/hwp5_empty_run_pdf_parity.rs
+++ b/crates/hwp-export/tests/hwp5_empty_run_pdf_parity.rs
@@ -36,15 +36,16 @@ fn page_decoration_mask_agrees_with_pdf_replay_counts() {
     ))
     .unwrap();
     let candidate = open_hwp5_own(&bytes).unwrap();
-    let oracle = Engine::open(&bytes).unwrap();
+    let production = Engine::open(&bytes).unwrap();
     let mut candidate_without_page_number = candidate.clone();
     for section in &mut candidate_without_page_number.sections {
         section.page_number = None;
     }
     let candidate_masks = render_doc_diagnostic_masks(&candidate, &ApproxFontMetrics);
-    let oracle_masks = render_doc_diagnostic_masks(&oracle, &ApproxFontMetrics);
+    let production_masks = render_doc_diagnostic_masks(&production, &ApproxFontMetrics);
     let candidate_pdf = export_pdf(&candidate, &ApproxFontMetrics, &PdfOptions::default()).unwrap();
-    let oracle_pdf = export_pdf(&oracle, &ApproxFontMetrics, &PdfOptions::default()).unwrap();
+    let production_pdf =
+        export_pdf(&production, &ApproxFontMetrics, &PdfOptions::default()).unwrap();
     let body_pdf = export_pdf(
         &candidate_without_page_number,
         &ApproxFontMetrics,
@@ -53,38 +54,40 @@ fn page_decoration_mask_agrees_with_pdf_replay_counts() {
     .unwrap();
 
     assert_eq!(candidate_pdf.pages, 8);
-    assert_eq!(candidate_pdf.pages, oracle_pdf.pages);
-    for (((candidate_page, oracle_page), candidate_mask), oracle_mask) in candidate_pdf
+    assert_eq!(candidate_pdf.pages, production_pdf.pages);
+    for (((candidate_page, production_page), candidate_mask), production_mask) in candidate_pdf
         .replay
         .iter()
-        .zip(&oracle_pdf.replay)
+        .zip(&production_pdf.replay)
         .zip(&candidate_masks)
-        .zip(&oracle_masks)
+        .zip(&production_masks)
     {
         let candidate_decoration = candidate_mask
             .categories
             .iter()
             .filter(|category| **category == DiagnosticPaintCategory::PageDecoration)
             .count();
-        let oracle_decoration = oracle_mask
+        let production_decoration = production_mask
             .categories
             .iter()
             .filter(|category| **category == DiagnosticPaintCategory::PageDecoration)
             .count();
-        assert_eq!(candidate_decoration, oracle_decoration + 3);
-        assert_eq!(candidate_page.text.produced, oracle_page.text.produced + 3);
-        assert_eq!(candidate_page.text.replayed, oracle_page.text.replayed + 3);
-        assert_eq!(candidate_page.text.stubbed, oracle_page.text.stubbed);
-        assert_eq!(candidate_page.table_geometry, oracle_page.table_geometry);
-        assert_eq!(candidate_page.image, oracle_page.image);
-        assert_eq!(candidate_page.equation, oracle_page.equation);
-        assert_eq!(candidate_page.chart, oracle_page.chart);
+        assert_eq!(candidate_decoration, production_decoration);
+        assert_eq!(candidate_page.text, production_page.text);
+        assert_eq!(
+            candidate_page.table_geometry,
+            production_page.table_geometry
+        );
+        assert_eq!(candidate_page.image, production_page.image);
+        assert_eq!(candidate_page.equation, production_page.equation);
+        assert_eq!(candidate_page.chart, production_page.chart);
     }
     assert!(
-        body_pdf.bytes == oracle_pdf.bytes
-            && body_pdf.pages == oracle_pdf.pages
-            && body_pdf.replay == oracle_pdf.replay
-            && body_pdf.diagnostics == oracle_pdf.diagnostics,
-        "removing the first-party page number leaves the PDF byte-exact"
+        candidate_pdf.bytes == production_pdf.bytes
+            && candidate_pdf.pages == production_pdf.pages
+            && candidate_pdf.replay == production_pdf.replay
+            && candidate_pdf.diagnostics == production_pdf.diagnostics,
+        "production PDF must retain the strictly owned page-number decoration"
     );
+    assert_ne!(body_pdf.bytes, production_pdf.bytes);
 }

--- a/crates/hwp-render/tests/hwp5_empty_run_svg_parity.rs
+++ b/crates/hwp-render/tests/hwp5_empty_run_svg_parity.rs
@@ -10,19 +10,19 @@ fn empty_run_evidence_normalization_is_svg_exact() {
     ))
     .unwrap();
     let candidate = open_hwp5_own(&bytes).unwrap();
-    let oracle = Engine::open(&bytes).unwrap();
+    let production = Engine::open(&bytes).unwrap();
     let mut normalized = candidate.clone();
     normalize_hwp5_empty_runs_for_layout_evidence(&mut normalized);
 
     let candidate_svg = render_doc_svg(&candidate, &ApproxFontMetrics);
     let normalized_svg = render_doc_svg(&normalized, &ApproxFontMetrics);
-    let oracle_svg = render_doc_svg(&oracle, &ApproxFontMetrics);
+    let production_svg = render_doc_svg(&production, &ApproxFontMetrics);
     assert!(
         candidate_svg == normalized_svg,
         "empty-run normalization must be SVG-exact without printing source content"
     );
     assert!(
-        candidate_svg != oracle_svg,
-        "remaining parser render parity must stay fail-closed"
+        candidate_svg == production_svg,
+        "production SVG must retain the strictly owned page-number decoration"
     );
 }

--- a/crates/hwp-render/tests/hwp5_geometry_layers.rs
+++ b/crates/hwp-render/tests/hwp5_geometry_layers.rs
@@ -32,28 +32,28 @@ fn masked_svg(tree: &PageLayerTree, categories: &[DiagnosticPaintCategory]) -> S
 fn benchmark_masks_prove_page_number_ownership_and_isolate_body_pages() {
     let bytes = fixture();
     let candidate = open_hwp5_own(&bytes).unwrap();
-    let oracle = Engine::open(&bytes).unwrap();
+    let production = Engine::open(&bytes).unwrap();
     let candidate_masks = render_doc_diagnostic_masks(&candidate, &ApproxFontMetrics);
-    let oracle_masks = render_doc_diagnostic_masks(&oracle, &ApproxFontMetrics);
+    let production_masks = render_doc_diagnostic_masks(&production, &ApproxFontMetrics);
     assert_eq!(candidate_masks.len(), 8);
-    assert_eq!(candidate_masks.len(), oracle_masks.len());
+    assert_eq!(candidate_masks.len(), production_masks.len());
 
-    for (candidate_mask, oracle_mask) in candidate_masks.iter().zip(&oracle_masks) {
+    for (candidate_mask, production_mask) in candidate_masks.iter().zip(&production_masks) {
         let candidate_decoration = candidate_mask
             .categories
             .iter()
             .filter(|category| **category == DiagnosticPaintCategory::PageDecoration)
             .count();
-        let oracle_decoration = oracle_mask
+        let production_decoration = production_mask
             .categories
             .iter()
             .filter(|category| **category == DiagnosticPaintCategory::PageDecoration)
             .count();
-        assert_eq!(candidate_decoration, oracle_decoration + 3);
+        assert_eq!(candidate_decoration, production_decoration);
         assert!(!candidate_mask
             .categories
             .contains(&DiagnosticPaintCategory::BoundaryCrossing));
-        assert!(!oracle_mask
+        assert!(!production_mask
             .categories
             .contains(&DiagnosticPaintCategory::BoundaryCrossing));
     }
@@ -78,23 +78,23 @@ fn benchmark_masks_prove_page_number_ownership_and_isolate_body_pages() {
         );
     }
 
-    let oracle_trees = render_doc_trees(&oracle, &ApproxFontMetrics);
+    let production_trees = render_doc_trees(&production, &ApproxFontMetrics);
     let differing_body_pages: Vec<_> = candidate_trees
         .iter()
         .zip(&candidate_masks)
-        .zip(&oracle_trees)
-        .zip(&oracle_masks)
+        .zip(&production_trees)
+        .zip(&production_masks)
         .enumerate()
         .filter_map(
-            |(page, (((candidate_tree, candidate_mask), oracle_tree), oracle_mask))| {
+            |(page, (((candidate_tree, candidate_mask), production_tree), production_mask))| {
                 (masked_svg(candidate_tree, &candidate_mask.categories)
-                    != masked_svg(oracle_tree, &oracle_mask.categories))
+                    != masked_svg(production_tree, &production_mask.categories))
                 .then_some(page)
             },
         )
         .collect();
     assert!(
         differing_body_pages.is_empty(),
-        "all body SVG pages are exact; the only remaining paint delta is owned page numbering"
+        "all production body SVG pages remain exact after page-number enrichment"
     );
 }

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,6 +3,20 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
+- 갱신: 2026-08-25 · Codex(sol) — **#219 owned page-number enrichment 구현·시각 계측·full green · PR 직전**.
+  production HWP5는 governed rhwp base decode를 유지하고, strict first-party parser가 whole-document
+  parse에 성공하며 section topology·기존 typed decoration과 모두 호환될 때만
+  `Section.page_number`를 validation-before-mutation으로 atomic 보강한다. parse 실패, section mismatch,
+  partial/conflict는 전체 no-op이고 HWP3/HWPX·generic eligibility·`external/rhwp`(`f137b4c9`)는 불변이다.
+  focused core/render/export 11 tests와 CLI build green; production SVG/PDF는 first-party candidate와
+  쪽당 3 decoration glyph까지 exact다. canonical T3 visual은 8쪽·102영역 유지, PDF SHA `25524c3d…`,
+  content-bbox height delta가 기존 `-59..-952px`에서 **`-2..+5px`**로 수렴했다. page ink F1은 장식이
+  작아 `-0.000074..+0.000332` 범위만 움직였고 typography/color 잔여는 미해결이다. threshold/oracle/
+  `pass=null` 무변경. `verify-local --full`의 Rust/rhwp/wasm/JS/Vitest 1,012 tests는 green이고,
+  샌드박스 밖 Chromium은 **83 pass·3 intentional skip·2 retry-pass**(기존 타이밍 계열)다.
+  **다음:** final diff/privacy/vendor 감사→commit/push/PR `Closes #219`→필수 CI·댓글 감사·자율 병합→
+  #93/#94/#114 동기화 후 다음 조판 fidelity child를 issue-first 선정.
+
 - 갱신: 2026-08-25 · Codex(sol) — **#217 deterministic-font fidelity 재측정 완료 · 진단 PR 직전**.
   public canonical 8쪽 HWP/PDF를 OFL registry로 독립 process 2회 실행해 candidate PDF SHA
   `2ee86296…`와 registry fingerprint `39841f73…`, 8쪽·102영역(70 text/32 table)이 exact 반복됐다.

--- a/docs/HWP5-NATIVE-PARSER.md
+++ b/docs/HWP5-NATIVE-PARSER.md
@@ -6,7 +6,8 @@ the paragraph support-pool boundary, and issue #160 owns DocInfo styles plus con
 header refusal reasons; issue #161 adds strict column definitions and the shared multi-column layout
 contract. Issues #168–#196 then advanced one content-free control/table boundary at a time through
 strict exact subsets. The bounded public benchmark now parses to the end in the first-party-only lane.
-None of these slices changes production parsing.
+Issue #219 connects one already-proven decoration to production as a fail-closed enrichment; it is
+not a generic parser cutover.
 
 ## What is owned now
 
@@ -63,7 +64,11 @@ rejected instead of being interpreted as records.
 
 ## Parser modes
 
-- `Engine::open`: unchanged production route. Binary HWP still uses the governed rhwp bootstrap.
+- `Engine::open`: binary HWP5 still uses the governed rhwp bootstrap for the base `SemanticDoc`.
+  After that succeeds, the strict first-party parser may enrich only `Section.page_number`, and only
+  when the complete owned parse succeeds, section topology is identical, and every pre-existing
+  typed page-number value is compatible. Validation precedes mutation, so parse failure, topology
+  mismatch, or any conflict is an atomic no-op. HWP3 remains the unmodified rhwp route.
 - `open_hwp5_own`: explicit first-party-only route. It returns a `SemanticDoc` only for the owned
   text, single-sided page setup, strict column subset, page numbering, and explicitly enumerated
   table subsets. These include exact merged/full-grid forms, bounded depth-1 nested tables, multiple
@@ -148,13 +153,20 @@ is 143 HWPUNIT, whose half produced the former 71.5-HWPUNIT centered-glyph shift
 bits 0–1/2 are kept as page-break/repeat-header semantics rather than being mistaken for HWPX
 `noAdjust`; HWP5 stored row heights remain floors, while only the HWPX parser may request exact clipping.
 
-After those corrections, all eight pages are exact against the rhwp oracle for body glyphs, blocks,
+After those corrections, all eight pages are exact against the raw rhwp oracle for body glyphs, blocks,
 tables, cells, rectangles, lines, images, and body-only SVG. The first-party page-number decoration is
 still intentionally present only in the candidate (three glyphs per page). Removing only that owned
 decoration makes PDF bytes, page count, replay counters, and diagnostics exact against the rhwp PDF.
 This is strong evidence for the one bounded benchmark, not generic HWP5 coverage: production remains
 on rhwp, `external/rhwp` remains immutable, and eligibility remains false until the parser-wide corpus
 and cutover gates below are satisfied.
+
+#219 then promoted only that typed page-number fact into `Engine::open`. The base HWP5 document is
+still decoded by rhwp; a complete strict first-party parse acts as the fail-closed evidence source.
+On the canonical eight-page benchmark, production SVG and PDF now match the first-party candidate,
+including three page-number glyphs per page. HWP3, HWPX, the generic cutover eligibility result, and
+vendored rhwp are unchanged. This bounded enrichment does not imply that unsupported first-party
+documents can bypass rhwp.
 
 ## Cutover rule
 

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,12 @@
 
 ---
 
+## 2026-08-25 (Codex sol) · #219 fail-closed HWP5 page-number enrichment
+- rhwp base decode 뒤 whole-document strict parse·typed/topology 호환 때만 `Section.page_number` atomic 보강.
+- production SVG/PDF=own candidate; T3 8쪽 bbox height delta `-59..-952px`→`-2..+5px`, oracle 불변.
+- full green: 8/18/24+98.9%, AI120, Vitest1,012, Chromium83 pass/3 skip/2 retry-pass; rhwp 무수정.
+- 다음: commit/push/PR/CI/merge→#93/#94/#114 동기화→다음 조판 fidelity child.
+
 ## 2026-08-25 (Codex sol) · #217 deterministic-font fidelity remeasurement
 - public 8-page HWP/PDF + OFL registry를 독립 2회 실행해 PDF SHA/fingerprint/102 regions exact 반복.
 - font 전후 worst-page 0.218434→0.221304; text F1=0 52/70·candidate-empty 25로 주원인 아님을 증명.

--- a/docs/PDF-VISUAL-ORACLE.md
+++ b/docs/PDF-VISUAL-ORACLE.md
@@ -444,6 +444,22 @@ line/image evidence exact. The next bounded implementation should connect that o
 the production path fail-closed; it must not modify rhwp, claim OFL fallback as exact, or relax the
 visual oracle.
 
+### Fail-closed page-number enrichment remeasurement (2026-08-25, #219)
+
+The bounded #219 enrichment restored the owned bottom-center page number while retaining rhwp as the
+base HWP5 decoder. The canonical run remained 8 pages and 102 semantic regions, and produced candidate
+PDF SHA-256 `25524c3dfc15e19498fb5623e74bc38f16ba9e751dba7470ef441406cdb9e5bd`.
+Aggregate page ink F1 moved only slightly because the decoration is small: pages 1–8 changed from
+`0.819208, 0.853208, 0.791151, 0.318353, 0.252517, 0.358842, 0.290394, 0.221304` to
+`0.819227, 0.853170, 0.791077, 0.318685, 0.252800, 0.358870, 0.290371, 0.221422`.
+
+The structural signal is decisive: content-bbox height deltas collapsed from
+`-100, -559, -59, -952, -639, -610, -91, -143` pixels to
+`+2, +5, -2, +2, +1, -1, +1, +1`. Direct inspection confirms that the candidate now paints the
+bottom-center page number at the reference location. This closes the missing-decoration defect, not
+the broader typography/color fidelity gap; the T3 reference, thresholds, translation bounds, and
+report-only `pass=null` policy remain unchanged.
+
 ## Tests
 
 Run the dependency-free synthetic metric and PNG codec suite with:

--- a/docs/RHWP-FORK-GOVERNANCE.md
+++ b/docs/RHWP-FORK-GOVERNANCE.md
@@ -12,7 +12,8 @@
 |---|---|---|
 | HWPX parse/write·무손실 round-trip | `hwp-hwpx` | 자체 엔진 |
 | live 조판·SVG·PDF·편집 op-bus | `hwp-typeset`→`hwp-render`/`hwp-export`→`hwp-ops` | 자체 엔진 |
-| HWP5/HWP3 bytes→SemanticDoc | `hwp-rhwp`→`external/rhwp` | 교체 대상 hard dependency (#107, #94) |
+| HWP5 bytes→SemanticDoc | `hwp-rhwp` base + strict owned page-number enrichment | 교체 중 hard dependency (#107, #94, #219) |
+| HWP3 bytes→SemanticDoc | `hwp-rhwp`→`external/rhwp` | 교체 대상 hard dependency (#107, #94) |
 | 원본 SVG/lineseg/glyph 비교 | 명시적 `source:"original"`·오라클 API | read-only 보조 경로 |
 | 수식/차트 SVG enrichment | `hwp-rhwp` helper가 derived cache만 채움 | 좁은 교체 대상 |
 
@@ -44,6 +45,8 @@ HWPX를 rhwp에 다시 넣어 생산 렌더·저장하지 않는다. rhwp 직렬
 
 F0(#87/#151)은 이 문서·검증기·코드 경계를 소유한다. F1(#107)은 자체 HWP5 container/record
 경계를 `hwp-hwp5`로 구현했다(`docs/HWP5-NATIVE-PARSER.md`). production decode는 아직 rhwp이며,
+#219는 whole-document strict parse와 section/typed-value 호환이 모두 성립할 때만
+`Section.page_number`를 production 결과에 atomic 보강한다. 이는 generic cutover가 아니며,
 #94가 DocInfo/text/object semantic slice와 corpus parity를 순차 승격한다. 자체 전용 API는 미지원
 slice에서 fail-closed하고 production route로 fallback하지 않는다. 한 기능씩 corpus와
 lineseg/페이지/PDF 시각 오라클을 통과시킨 뒤에만 rhwp 호출을 제거한다.


### PR DESCRIPTION
## Summary
- keep governed rhwp as the HWP5 base decoder and enrich only strictly owned `Section.page_number`
- require a complete first-party parse plus section-topology and typed-value compatibility before mutation
- lock production SVG/PDF parity with the first-party candidate and record the canonical T3 visual result

## Safety boundary
- parse failure, section mismatch, or any typed conflict is an atomic no-op
- HWP3, HWPX, generic own-parser eligibility, oracle thresholds, and `external/rhwp` are unchanged
- no user document, generated wasm asset, path, text, or credential is committed

## Verification
- focused core/render/export tests: green
- `scripts/verify-local.sh --full`: Rust/rhwp/wasm/JS/Vitest green; canonical 8/18/24 and 98.9%+ gate green
- Chromium: 83 passed, 3 intentional skips, 2 retry-pass timing flakes
- canonical visual check: 8 pages / 102 regions; content-bbox height delta improved from -59..-952 px to -2..+5 px; report-only policy unchanged

Closes #219
