### PR TITLE
test(pdf): make semantic text regions paint-backed

### DIFF
--- a/crates/hwp-export/src/pdf.rs
+++ b/crates/hwp-export/src/pdf.rs
@@ -18,7 +18,7 @@
 //! PDF points (1pt = 1/72in), top-left origin, y-down — the SAME orientation — so we only scale by
 //! `HWPUNIT_PER_PT` (1in = 7200 HWPUNIT = 72pt ⇒ 100 HWPUNIT/pt). No y-flip needed.
 
-use hwp_model::document::{LineStyle, SemanticDoc};
+use hwp_model::document::{Block, Inline, LineStyle, Paragraph, SemanticDoc};
 use hwp_model::font_class::{classify, FontCategory};
 use hwp_model::layout::{PageLayerTree, PaintOp};
 use hwp_model::prelude::FontMetricsProvider;
@@ -259,6 +259,9 @@ pub struct PdfPageVisualEvidence {
     pub page: usize,
     pub width: f64,
     pub height: f64,
+    /// Paragraph page-fragments that intentionally paint no text. They are content-free evidence,
+    /// not missing-ink regions, and therefore never enter pixel scoring.
+    pub intentional_blank_text_regions: usize,
     pub regions: Vec<PdfVisualRegion>,
 }
 
@@ -266,6 +269,10 @@ pub struct PdfPageVisualEvidence {
 pub struct PdfVisualRegion {
     pub id: String,
     pub category: &'static str,
+    /// Text regions are `painted` when the exact placement contains a glyph in the block band, or
+    /// `expected-missing` when source-visible text produced no glyph there. Non-text regions use
+    /// `not-applicable`. This exposes a layout evidence failure without leaking text or addresses.
+    pub paint_status: &'static str,
     pub x: f64,
     pub y: f64,
     pub w: f64,
@@ -293,10 +300,11 @@ fn push_visual_region(
     counters: &mut [usize; 4],
     category_index: usize,
     category: &'static str,
-    page_width: f64,
-    page_height: f64,
+    paint_status: &'static str,
+    page_size: (f64, f64),
     raw: (f64, f64, f64, f64),
 ) -> Result<(), String> {
+    let (page_width, page_height) = page_size;
     let (x, y, w, h) = raw;
     if ![page_width, page_height, x, y, w, h]
         .into_iter()
@@ -320,6 +328,7 @@ fn push_visual_region(
     regions.push(PdfVisualRegion {
         id: format!("{category}-{:04}", counters[category_index]),
         category,
+        paint_status,
         x: left,
         y: top,
         w: right - left,
@@ -329,26 +338,69 @@ fn push_visual_region(
     Ok(())
 }
 
+fn paragraph_expects_text_paint(paragraph: &Paragraph) -> bool {
+    paragraph.runs.iter().any(|run| {
+        run.content.iter().any(|inline| {
+            matches!(inline, Inline::Text(text) if text.chars().any(|ch| !matches!(ch, ' ' | '\t' | '\n')))
+        })
+    })
+}
+
+fn block_band_contains_glyph(
+    page: &hwp_typeset::PlacedPage,
+    block: &hwp_typeset::PlacedBlock,
+) -> bool {
+    let right = block.x + block.w;
+    let bottom = block.y + block.h;
+    page.glyphs.iter().any(|glyph| {
+        glyph.x >= block.x
+            && glyph.x <= right
+            && glyph.baseline >= block.y
+            && glyph.baseline <= bottom
+    })
+}
+
 fn visual_evidence(
     placed: &PlacedDoc,
+    doc: &SemanticDoc,
     candidate_pdf_sha256: String,
 ) -> Result<PdfVisualEvidence, String> {
     let mut pages = Vec::with_capacity(placed.pages.len());
     for (page_index, page) in placed.pages.iter().enumerate() {
         let mut regions = Vec::new();
         let mut counters = [0usize; 4];
+        let mut intentional_blank_text_regions = 0usize;
         for block in page
             .blocks
             .iter()
             .filter(|block| block.kind == BlockKind::Paragraph)
         {
+            let paragraph = doc
+                .sections
+                .get(block.section)
+                .and_then(|section| section.blocks.get(block.block))
+                .and_then(|block| match block {
+                    Block::Paragraph(paragraph) => Some(paragraph),
+                    Block::Table(_) => None,
+                })
+                .ok_or_else(|| "pdf.visual_evidence.paragraph_provenance_mismatch".to_string())?;
+            if !paragraph_expects_text_paint(paragraph) {
+                counters[0] += 1;
+                intentional_blank_text_regions += 1;
+                continue;
+            }
+            let paint_status = if block_band_contains_glyph(page, block) {
+                "painted"
+            } else {
+                "expected-missing"
+            };
             push_visual_region(
                 &mut regions,
                 &mut counters,
                 0,
                 "text",
-                page.width,
-                page.height,
+                paint_status,
+                (page.width, page.height),
                 (block.x, block.y, block.w, block.h),
             )?;
         }
@@ -358,8 +410,8 @@ fn visual_evidence(
                 &mut counters,
                 1,
                 "table",
-                page.width,
-                page.height,
+                "not-applicable",
+                (page.width, page.height),
                 (table.x, table.y, table.w, table.h),
             )?;
         }
@@ -374,8 +426,8 @@ fn visual_evidence(
                 &mut counters,
                 category_index,
                 category,
-                page.width,
-                page.height,
+                "not-applicable",
+                (page.width, page.height),
                 (image.x, image.y, image.w, image.h),
             )?;
         }
@@ -383,11 +435,12 @@ fn visual_evidence(
             page: page_index + 1,
             width: page.width,
             height: page.height,
+            intentional_blank_text_regions,
             regions,
         });
     }
     Ok(PdfVisualEvidence {
-        schema_version: 1,
+        schema_version: 2,
         coordinate_space: "HWPUNIT",
         candidate_pdf_sha256,
         pages,
@@ -518,7 +571,7 @@ pub fn export_pdf_with_fonts(
         .finish()
         .map_err(|e| format!("krilla finish: {e:?}"))?;
     let candidate_pdf_sha256 = format!("{:x}", Sha256::digest(&bytes));
-    let visual_evidence = visual_evidence(&placed, candidate_pdf_sha256)?;
+    let visual_evidence = visual_evidence(&placed, doc, candidate_pdf_sha256)?;
     Ok(PdfExport {
         pages: trees.len(),
         bytes,
@@ -1264,6 +1317,7 @@ mod tests {
     use super::*;
     use hwp_model::prelude::*;
     use hwp_typeset::ApproxFontMetrics;
+    use std::num::NonZeroU16;
 
     fn para(text: &str) -> Paragraph {
         Paragraph {
@@ -1306,7 +1360,7 @@ mod tests {
             "non-trivial PDF size, got {}",
             out.bytes.len()
         );
-        assert_eq!(out.visual_evidence.schema_version, 1);
+        assert_eq!(out.visual_evidence.schema_version, 2);
         assert_eq!(out.visual_evidence.coordinate_space, "HWPUNIT");
         assert_eq!(out.visual_evidence.pages.len(), out.pages);
         assert_eq!(
@@ -1315,6 +1369,14 @@ mod tests {
         );
         let regions = &out.visual_evidence.pages[0].regions;
         assert!(regions.iter().any(|region| region.category == "text"));
+        assert!(regions
+            .iter()
+            .filter(|region| region.category == "text")
+            .all(|region| region.paint_status == "painted"));
+        assert_eq!(
+            out.visual_evidence.pages[0].intentional_blank_text_regions,
+            0
+        );
         assert!(regions.iter().all(|region| {
             region.x >= 0.0
                 && region.y >= 0.0
@@ -1323,6 +1385,129 @@ mod tests {
                 && region.x + region.w <= out.visual_evidence.pages[0].width
                 && region.y + region.h <= out.visual_evidence.pages[0].height
         }));
+    }
+
+    #[test]
+    fn visual_evidence_separates_blank_bands_from_painted_text_with_stable_ordinals() {
+        let table = Table {
+            rows: 1,
+            cols: 1,
+            cells: vec![Cell {
+                blocks: vec![Block::Paragraph(para("table cell text"))],
+                ..Default::default()
+            }],
+            col_widths: vec![8_000],
+            ..Default::default()
+        };
+        let doc = doc_with(vec![
+            Block::Paragraph(para(" \t\n")),
+            Block::Paragraph(para("painted body")),
+            Block::Table(table),
+        ]);
+
+        let out = export_pdf(&doc, &ApproxFontMetrics, &PdfOptions::default()).unwrap();
+        let page = &out.visual_evidence.pages[0];
+        assert_eq!(page.intentional_blank_text_regions, 1);
+        let text_regions = page
+            .regions
+            .iter()
+            .filter(|region| region.category == "text")
+            .collect::<Vec<_>>();
+        assert_eq!(text_regions.len(), 1);
+        assert_eq!(text_regions[0].id, "text-0002");
+        assert_eq!(text_regions[0].paint_status, "painted");
+        assert_eq!(
+            page.regions
+                .iter()
+                .filter(|region| region.category == "table")
+                .count(),
+            1,
+            "table-cell glyphs remain represented by the table region, not a body text region"
+        );
+    }
+
+    #[test]
+    fn blank_body_is_not_misclassified_by_a_page_number_decoration() {
+        let mut doc = doc_with(vec![Block::Paragraph(para("\t \n"))]);
+        doc.sections[0].page_number = Some(PageNumberDecoration {
+            start: NonZeroU16::MIN,
+            format: PageNumberFormat::Digit,
+            position: PageNumberPosition::BottomCenter,
+            prefix: None,
+            suffix: None,
+            dash: Some('-'),
+        });
+
+        let out = export_pdf(&doc, &ApproxFontMetrics, &PdfOptions::default()).unwrap();
+        let page = &out.visual_evidence.pages[0];
+        assert_eq!(page.intentional_blank_text_regions, 1);
+        assert!(page.regions.iter().all(|region| region.category != "text"));
+    }
+
+    #[test]
+    fn page_fragment_paint_status_uses_only_glyphs_inside_that_band() {
+        let block = hwp_typeset::PlacedBlock {
+            x: 100.0,
+            y: 200.0,
+            w: 400.0,
+            h: 100.0,
+            section: 0,
+            block: 0,
+            kind: BlockKind::Paragraph,
+        };
+        let glyph = |x, baseline| hwp_typeset::PlacedGlyph {
+            x,
+            baseline,
+            ch: '가',
+            size: 100.0,
+            color: Color::default(),
+            underline: false,
+            bold: false,
+            italic: false,
+            font: None,
+            cluster: None,
+        };
+        let first_fragment = hwp_typeset::PlacedPage {
+            glyphs: vec![glyph(120.0, 250.0)],
+            ..Default::default()
+        };
+        let continuation_without_text = hwp_typeset::PlacedPage {
+            glyphs: vec![glyph(120.0, 350.0)],
+            ..Default::default()
+        };
+
+        assert!(block_band_contains_glyph(&first_fragment, &block));
+        assert!(!block_band_contains_glyph(
+            &continuation_without_text,
+            &block
+        ));
+    }
+
+    #[test]
+    fn clipped_visual_region_keeps_paint_status_and_bounded_geometry() {
+        let mut regions = Vec::new();
+        let mut counters = [0usize; 4];
+
+        push_visual_region(
+            &mut regions,
+            &mut counters,
+            0,
+            "text",
+            "painted",
+            (100.0, 200.0),
+            (-10.0, 180.0, 50.0, 40.0),
+        )
+        .unwrap();
+
+        assert_eq!(regions.len(), 1);
+        let region = &regions[0];
+        assert_eq!(region.id, "text-0001");
+        assert_eq!(region.paint_status, "painted");
+        assert_eq!(
+            (region.x, region.y, region.w, region.h),
+            (0.0, 180.0, 40.0, 20.0)
+        );
+        assert!(region.clipped);
     }
 
     #[test]

--- a/crates/hwp-export/src/pdf.rs
+++ b/crates/hwp-export/src/pdf.rs
@@ -360,6 +360,20 @@ fn block_band_contains_glyph(
     })
 }
 
+fn paragraph_paint_status(
+    paragraph: &Paragraph,
+    page: &hwp_typeset::PlacedPage,
+    block: &hwp_typeset::PlacedBlock,
+) -> Option<&'static str> {
+    if block_band_contains_glyph(page, block) {
+        Some("painted")
+    } else if paragraph_expects_text_paint(paragraph) {
+        Some("expected-missing")
+    } else {
+        None
+    }
+}
+
 fn visual_evidence(
     placed: &PlacedDoc,
     doc: &SemanticDoc,
@@ -384,15 +398,10 @@ fn visual_evidence(
                     Block::Table(_) => None,
                 })
                 .ok_or_else(|| "pdf.visual_evidence.paragraph_provenance_mismatch".to_string())?;
-            if !paragraph_expects_text_paint(paragraph) {
+            let Some(paint_status) = paragraph_paint_status(paragraph, page, block) else {
                 counters[0] += 1;
                 intentional_blank_text_regions += 1;
                 continue;
-            }
-            let paint_status = if block_band_contains_glyph(page, block) {
-                "painted"
-            } else {
-                "expected-missing"
             };
             push_visual_region(
                 &mut regions,
@@ -1481,6 +1490,19 @@ mod tests {
             &continuation_without_text,
             &block
         ));
+        assert_eq!(
+            paragraph_paint_status(&para(" \t\n"), &first_fragment, &block),
+            Some("painted"),
+            "a marker or generated glyph paints even when the source text run is blank"
+        );
+        assert_eq!(
+            paragraph_paint_status(&para("visible"), &continuation_without_text, &block),
+            Some("expected-missing")
+        );
+        assert_eq!(
+            paragraph_paint_status(&para(" \t\n"), &continuation_without_text, &block),
+            None
+        );
     }
 
     #[test]

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,6 +3,21 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
+- 갱신: 2026-08-25 · Codex(sol) — **PR #220 병합 · #221 paint-backed text-region evidence 구현·재측정 완료**.
+  #219 exact head `be39cae`는 교체 CI의 issue-link **3s**·licenses **2m51s**·build-test **11m1s**
+  green, CLEAN/MERGEABLE, 댓글/review 0으로 protected main `ffce59dd`에 squash 병합됐다. #219는
+  close되고 원격 branch도 삭제했으며 #93/#94/#114에 content-free 결과를 동기화했다. 후속 P0 #221을
+  등재하고 exact main의 `codex/issue-221-paint-backed-regions`를 만들었다. visual-region schema v2가
+  source-visible boolean과 exact placed glyph를 결합해 `painted`/`expected-missing`을 강제하고 intentional
+  blank page-fragment를 별도 집계한다. canonical은 기존 broad text 70개를 blank **42** + painted **28**로
+  분리했고 painted 전부 candidate ink>0, expected-missing 0이다. PDF SHA `25524c3d…` exact로 조판/export
+  바이트 불변. 남은 28 중 reference-empty 12(11개 candidate 22px, 1개 2,406px)와 양쪽 ink지만 F1=0인
+  영역이 실제 누적 수직 위치 drift를 가리킨다. focused Rust 4 + Python 55 + Node 4, hwp-export 45,
+  full Rust/rhwp/AI120/8·18·24+98.9%/공공문서·오라클/JS build/Vitest1,012 모두 green. Chromium은
+  **84 pass·3 intentional skip·1 retry-pass**(image toast timing flake; 재시도 3.0s)다.
+  **다음:** commit/push→`Closes #221` PR/CI/merge→#93/#114 동기화→첫 divergent vertical increment를
+  고정하는 단일축 child. threshold/T3/`pass=null`·HWP/HWPX/rhwp/generated assets는 불변이다.
+
 - 갱신: 2026-08-25 · Codex(sol) — **#219 owned page-number enrichment 구현·시각 계측·full green · PR 직전**.
   production HWP5는 governed rhwp base decode를 유지하고, strict first-party parser가 whole-document
   parse에 성공하며 section topology·기존 typed decoration과 모두 호환될 때만

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,12 @@
 
 ---
 
+## 2026-08-25 (Codex sol) · #221 paint-backed visual regions
+- visual schema v2가 blank 42개를 제외하고 painted text 28개·expected-missing 0을 증명했다.
+- candidate PDF SHA는 #219와 exact; reference-empty 12개가 누적 수직 drift 축을 가리킨다.
+- full green: 8/18/24+98.9%, AI120, Vitest1,012, Chromium84 pass/3 skip/1 retry-pass; rhwp 무수정.
+- 다음: commit/push/PR/CI/merge→#93/#114 동기화→첫 divergent vertical increment 단일축 child.
+
 ## 2026-08-25 (Codex sol) · #219 fail-closed HWP5 page-number enrichment
 - rhwp base decode 뒤 whole-document strict parse·typed/topology 호환 때만 `Section.page_number` atomic 보강.
 - production SVG/PDF=own candidate; T3 8쪽 bbox height delta `-59..-952px`→`-2..+5px`, oracle 불변.

--- a/docs/PDF-VISUAL-ORACLE.md
+++ b/docs/PDF-VISUAL-ORACLE.md
@@ -327,10 +327,12 @@ four content-free categories: paint-backed paragraph bands (`text`), placed tabl
 present; source text, paths, binary identifiers, and font paths are absent.
 
 For paragraph bands, source-visible text is reduced to a boolean and checked against the exact placed
-glyph stream. Intentional blank page-fragments are counted separately and never enter pixel ranking.
-Visible paragraphs are marked `painted` or `expected-missing`; the latter is an explicit unscorable
-placement failure. Non-text regions use `not-applicable`. A painted region that rasterizes without
-candidate ink remains partially unscorable with an explicit metric reason rather than being hidden.
+glyph stream. Any glyph inside the band wins as `painted`, including a generated marker on a
+text-empty paragraph. Without a glyph, source-visible paragraphs become `expected-missing`; only a
+band with neither source-visible text nor a placed glyph is an intentional blank. Intentional blank
+page-fragments are counted separately and never enter pixel ranking. `expected-missing` is an explicit
+unscorable placement failure. Non-text regions use `not-applicable`. A painted region that rasterizes
+without candidate ink remains partially unscorable with an explicit metric reason rather than being hidden.
 
 The manifest must be strict UTF-8 JSON with exactly the known fields, ordered one-based pages, finite
 positive in-page geometry, unique per-page IDs, matching MediaBox dimensions, and an exact SHA-256

--- a/docs/PDF-VISUAL-ORACLE.md
+++ b/docs/PDF-VISUAL-ORACLE.md
@@ -321,10 +321,16 @@ otherwise white, globally similar page.
 
 ### Semantic regions
 
-When `--candidate-regions` is supplied, the exporter evidence divides the candidate placement into
-four content-free categories: paragraph bands (`text`), placed table boxes (`table`), raster images
+When `--candidate-regions` is supplied, visual-region schema v2 divides the candidate placement into
+four content-free categories: paint-backed paragraph bands (`text`), placed table boxes (`table`), raster images
 (`image`), and SVG-backed equations/charts/other objects (`object`). IDs and HWPUNIT geometry are
 present; source text, paths, binary identifiers, and font paths are absent.
+
+For paragraph bands, source-visible text is reduced to a boolean and checked against the exact placed
+glyph stream. Intentional blank page-fragments are counted separately and never enter pixel ranking.
+Visible paragraphs are marked `painted` or `expected-missing`; the latter is an explicit unscorable
+placement failure. Non-text regions use `not-applicable`. A painted region that rasterizes without
+candidate ink remains partially unscorable with an explicit metric reason rather than being hidden.
 
 The manifest must be strict UTF-8 JSON with exactly the known fields, ordered one-based pages, finite
 positive in-page geometry, unique per-page IDs, matching MediaBox dimensions, and an exact SHA-256
@@ -459,6 +465,23 @@ The structural signal is decisive: content-bbox height deltas collapsed from
 bottom-center page number at the reference location. This closes the missing-decoration defect, not
 the broader typography/color fidelity gap; the T3 reference, thresholds, translation bounds, and
 report-only `pass=null` policy remain unchanged.
+
+### Paint-backed text-region remeasurement (2026-08-25, #221)
+
+Visual-region schema v2 reran the exact #219 candidate PDF without changing its SHA-256
+`25524c3dfc15e19498fb5623e74bc38f16ba9e751dba7470ef441406cdb9e5bd`, proving that this evidence
+change does not alter placement or export bytes. Of the former 70 broad paragraph bands, 42 are now
+classified as intentional blanks and excluded from pixel ranking. All remaining 28 text regions are
+`painted`, all 28 contain candidate ink, and none is `expected-missing`.
+
+Twelve of those 28 painted regions remain partially unscorable because the globally aligned
+reference band contains no ink. Eleven contain only 22 candidate pixels and one contains 2,406,
+while additional scored text regions have zero overlap despite ink on both sides. Together with
+direct page inspection, this replaces the earlier ambiguous “candidate missing text” signal with a
+bounded cumulative vertical-position drift: lower-page candidate symbols/headings occupy bands where
+the reference content has already moved. The next rendering child should isolate the first divergent
+vertical increment; font weight/category remains a separate axis. T3 authority, translation bounds,
+thresholds, and `pass=null` remain unchanged.
 
 ## Tests
 

--- a/scripts/pdf-visual-check.py
+++ b/scripts/pdf-visual-check.py
@@ -85,7 +85,7 @@ HARD_MAX_REPORT_BYTES = 2 * GIB
 HARD_MAX_SUBPROCESS_OUTPUT_BYTES = 4 * MIB
 HARD_SUBPROCESS_TIMEOUT_SECONDS = 300.0
 
-VISUAL_REGION_SCHEMA_VERSION = 1
+VISUAL_REGION_SCHEMA_VERSION = 2
 MAX_VISUAL_REGION_MANIFEST_BYTES = 8 * MIB
 MAX_VISUAL_REGIONS_TOTAL = 10_000
 MAX_VISUAL_REGIONS_PER_PAGE = 2_000
@@ -421,7 +421,9 @@ def _load_visual_regions(
         "visual region manifest",
     )
     if root["schema_version"] != VISUAL_REGION_SCHEMA_VERSION:
-        raise VisualCheckError("visual region manifest schema_version must be 1")
+        raise VisualCheckError(
+            f"visual region manifest schema_version must be {VISUAL_REGION_SCHEMA_VERSION}"
+        )
     if root["coordinate_space"] != "HWPUNIT":
         raise VisualCheckError("visual region manifest coordinate_space must be HWPUNIT")
     if root["candidate_pdf_sha256"] != candidate_sha256:
@@ -432,13 +434,27 @@ def _load_visual_regions(
 
     ids: Set[str] = set()
     total_regions = 0
+    intentional_blank_text_regions = 0
     category_counts = {category: 0 for category in sorted(VISUAL_REGION_CATEGORIES)}
     for index, (page, pdf_page) in enumerate(zip(pages, candidate_info.pages), start=1):
         page = _exact_object_keys(
-            page, {"page", "width", "height", "regions"}, f"visual regions page {index}"
+            page,
+            {"page", "width", "height", "intentional_blank_text_regions", "regions"},
+            f"visual regions page {index}",
         )
         if page["page"] != index:
             raise VisualCheckError("visual region manifest pages must be ordered and one-based")
+        page_blank_regions = page["intentional_blank_text_regions"]
+        if (
+            isinstance(page_blank_regions, bool)
+            or not isinstance(page_blank_regions, int)
+            or page_blank_regions < 0
+            or page_blank_regions > MAX_VISUAL_REGIONS_PER_PAGE
+        ):
+            raise VisualCheckError(
+                "visual region intentional_blank_text_regions must be a bounded non-negative integer"
+            )
+        intentional_blank_text_regions += page_blank_regions
         page_width = _finite_number(page["width"], f"visual regions page {index}.width")
         page_height = _finite_number(page["height"], f"visual regions page {index}.height")
         if page_width <= 0 or page_height <= 0:
@@ -464,7 +480,9 @@ def _load_visual_regions(
         for region_index, region in enumerate(regions):
             label = f"visual regions page {index}.regions[{region_index}]"
             region = _exact_object_keys(
-                region, {"id", "category", "x", "y", "w", "h", "clipped"}, label
+                region,
+                {"id", "category", "paint_status", "x", "y", "w", "h", "clipped"},
+                label,
             )
             region_id = region["id"]
             if not isinstance(region_id, str) or not re.fullmatch(
@@ -478,6 +496,12 @@ def _load_visual_regions(
             category = region["category"]
             if category not in VISUAL_REGION_CATEGORIES or not region_id.startswith(f"{category}-"):
                 raise VisualCheckError(f"{label}.category is invalid or disagrees with id")
+            paint_status = region["paint_status"]
+            if category == "text":
+                if paint_status not in {"painted", "expected-missing"}:
+                    raise VisualCheckError(f"{label}.paint_status is invalid for text")
+            elif paint_status != "not-applicable":
+                raise VisualCheckError(f"{label}.paint_status must be not-applicable")
             if not isinstance(region["clipped"], bool):
                 raise VisualCheckError(f"{label}.clipped must be boolean")
             x = _finite_number(region["x"], f"{label}.x")
@@ -509,6 +533,7 @@ def _load_visual_regions(
         "bytes": snapshot.stat().st_size,
         "total_regions": total_regions,
         "category_counts": category_counts,
+        "intentional_blank_text_regions": intentional_blank_text_regions,
     }
 
 
@@ -1921,6 +1946,7 @@ def _score_visual_regions(
         base = {
             "id": region["id"],
             "category": region["category"],
+            "paint_status": region["paint_status"],
             "source_bounds_hwpunit": {
                 "x": region["x"],
                 "y": region["y"],
@@ -1935,6 +1961,17 @@ def _score_visual_regions(
                 or bottom != raw_bottom + dy
             ),
         }
+        if region["paint_status"] == "expected-missing":
+            base.update(
+                {
+                    "status": "unscorable",
+                    "reason": "source-visible paragraph produced no placed glyph in its page band",
+                    "aligned_bounds_px": None,
+                    "metrics": None,
+                }
+            )
+            results.append(base)
+            continue
         if right <= left or bottom <= top:
             base.update(
                 {
@@ -2614,6 +2651,9 @@ def _run_visual_check_from_snapshots(
             "bytes": visual_regions["bytes"],
             "total_regions": visual_regions["total_regions"],
             "category_counts": visual_regions["category_counts"],
+            "intentional_blank_text_regions": visual_regions[
+                "intentional_blank_text_regions"
+            ],
         }
         if visual_regions is not None
         else {"provided": False}
@@ -2744,6 +2784,7 @@ def _run_visual_check_from_snapshots(
                     {
                         "id": region["id"],
                         "category": region["category"],
+                        "paint_status": region["paint_status"],
                         "source_bounds_hwpunit": {
                             key: region[key] for key in ("x", "y", "w", "h")
                         },
@@ -2781,6 +2822,13 @@ def _run_visual_check_from_snapshots(
                     "alignment": None,
                     "metrics": None,
                     "semantic_regions": semantic_regions,
+                    "intentional_blank_text_regions": (
+                        visual_regions["document"]["pages"][page_number - 1][
+                            "intentional_blank_text_regions"
+                        ]
+                        if visual_regions is not None
+                        else 0
+                    ),
                     "artifacts": artifacts,
                 }
             )
@@ -2890,11 +2938,21 @@ def _run_visual_check_from_snapshots(
                 "alignment": metrics["alignment"],
                 "metrics": metrics,
                 "semantic_regions": semantic_regions,
+                "intentional_blank_text_regions": (
+                    visual_regions["document"]["pages"][page_number - 1][
+                        "intentional_blank_text_regions"
+                    ]
+                    if visual_regions is not None
+                    else 0
+                ),
                 "artifacts": artifacts,
             }
         )
 
     report["summary"] = _summarize_pages(report["pages"])
+    report["summary"]["intentional_blank_text_regions"] = sum(
+        page.get("intentional_blank_text_regions", 0) for page in report["pages"]
+    )
     report["summary"]["pixel_comparison_attempted"] = True
     if report["summary"]["unscorable_pages"]:
         report["status"] = "partially_unscorable"

--- a/scripts/tests/document-visual-check.test.mjs
+++ b/scripts/tests/document-visual-check.test.mjs
@@ -33,8 +33,8 @@ function fixture() {
     const regions = args[args.indexOf("--visual-regions") + 1];
     fs.writeFileSync(out, "%PDF-own\\n%%EOF\\n");
     fs.writeFileSync(regions, JSON.stringify({
-      schema_version: 1, coordinate_space: "HWPUNIT", candidate_pdf_sha256: "${"a".repeat(64)}",
-      pages: [{ page: 1, width: 59500, height: 84200, regions: [] }]
+      schema_version: 2, coordinate_space: "HWPUNIT", candidate_pdf_sha256: "${"a".repeat(64)}",
+      pages: [{ page: 1, width: 59500, height: 84200, intentional_blank_text_regions: 0, regions: [] }]
     }) + "\\n");
     const fontReportIndex = args.indexOf("--font-report");
     if (fontReportIndex >= 0) fs.writeFileSync(args[fontReportIndex + 1], JSON.stringify({

--- a/scripts/tests/test_pdf_visual_check.py
+++ b/scripts/tests/test_pdf_visual_check.py
@@ -106,7 +106,7 @@ class VisualRegionTests(unittest.TestCase):
 
     def manifest(self, candidate_sha256: str):
         return {
-            "schema_version": 1,
+            "schema_version": 2,
             "coordinate_space": "HWPUNIT",
             "candidate_pdf_sha256": candidate_sha256,
             "pages": [
@@ -114,10 +114,12 @@ class VisualRegionTests(unittest.TestCase):
                     "page": 1,
                     "width": 59500.0,
                     "height": 84200.0,
+                    "intentional_blank_text_regions": 2,
                     "regions": [
                         {
                             "id": "text-0001",
                             "category": "text",
+                            "paint_status": "painted",
                             "x": 1000.0,
                             "y": 2000.0,
                             "w": 10000.0,
@@ -142,6 +144,7 @@ class VisualRegionTests(unittest.TestCase):
         loaded = self.load(self.manifest(candidate_sha256), candidate_sha256)
         self.assertEqual(loaded["total_regions"], 1)
         self.assertEqual(loaded["category_counts"]["text"], 1)
+        self.assertEqual(loaded["intentional_blank_text_regions"], 2)
         self.assertNotIn("text", loaded["document"]["pages"][0]["regions"][0])
 
         for mutation, pattern in (
@@ -149,6 +152,18 @@ class VisualRegionTests(unittest.TestCase):
             (lambda doc: doc.update({"candidate_pdf_sha256": "b" * 64}), "SHA-256 mismatch"),
             (lambda doc: doc["pages"][0].update({"width": 59400}), "dimensions do not match"),
             (lambda doc: doc["pages"][0]["regions"][0].update({"category": "secret"}), "category"),
+            (
+                lambda doc: doc["pages"][0]["regions"][0].update(
+                    {"paint_status": "not-applicable"}
+                ),
+                "paint_status",
+            ),
+            (
+                lambda doc: doc["pages"][0].update(
+                    {"intentional_blank_text_regions": -1}
+                ),
+                "intentional_blank_text_regions",
+            ),
             (lambda doc: doc["pages"][0]["regions"][0].update({"x": -1}), "outside its page"),
             (lambda doc: doc["pages"][0]["regions"][0].update({"w": float("nan")}), "non-finite"),
         ):
@@ -165,6 +180,7 @@ class VisualRegionTests(unittest.TestCase):
             {
                 "id": f"text-{index:04d}",
                 "category": "text",
+                "paint_status": "painted",
                 "x": 0.0,
                 "y": 0.0,
                 "w": 59500.0,
@@ -204,6 +220,7 @@ class VisualRegionTests(unittest.TestCase):
                 {
                     "id": "table-0001",
                     "category": "table",
+                    "paint_status": "not-applicable",
                     "x": 20.0,
                     "y": 20.0,
                     "w": 40.0,
@@ -228,6 +245,16 @@ class VisualRegionTests(unittest.TestCase):
             100_000,
         )
         self.assertEqual(missing[0]["metrics"]["ink"]["f1"], 0.0)
+
+        page["regions"][0]["category"] = "text"
+        page["regions"][0]["id"] = "text-0001"
+        page["regions"][0]["paint_status"] = "expected-missing"
+        explicit_missing = pdf_visual_check._score_visual_regions(
+            page, reference, candidate, 10, 10, {"dx": 0, "dy": 0}, 100_000
+        )
+        self.assertEqual(explicit_missing[0]["status"], "unscorable")
+        self.assertIsNone(explicit_missing[0]["metrics"])
+        self.assertIn("no placed glyph", explicit_missing[0]["reason"])
         self.assertEqual(missing[0]["status"], "partially_unscorable")
         summary = pdf_visual_check._summarize_pages(
             [{"page": 1, "metrics": None, "semantic_regions": missing}]


### PR DESCRIPTION
## Summary
- upgrade candidate visual-region evidence to strict schema v2 with painted and expected-missing text status
- exclude intentional blank paragraph fragments from pixel ranking while preserving stable content-free ordinals
- document the unchanged canonical PDF and the now-isolated cumulative vertical drift signal

## Validation
- scripts/verify-local.sh --full through Rust, rhwp, AI120, 8/18/24 plus 98.9%, public-corpus/oracle, JS build, and 1,012 Vitest checks
- Chromium: 84 passed, 3 intentional skips, 1 retry-pass timing flake
- canonical candidate PDF SHA unchanged: 25524c3dfc15e19498fb5623e74bc38f16ba9e751dba7470ef441406cdb9e5bd
- external/rhwp unchanged at f137b4c9468eaff5bb43e25108e9c9d39a2ed15b

Closes #221