### PR TITLE
test(pdf): trace cumulative vertical transitions

### DIFF
--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,6 +3,32 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
+- 갱신: 2026-08-25 · Codex(sol) — **#223 report-only vertical-transition trace 구현·canonical 진단**.
+  fixed page alignment 뒤 text/table의 row-ink profile만 ±128px에서 비교하고 active-row F1→row-count
+  cosine 순으로 unique=`hypothesis`, exact tie=`ambiguous`, 증거 없음/예산 초과=`unscorable`로 낸다.
+  reference window 1회 scan + page당 50M work cap이며 score/threshold/pass에는 입력하지 않는다. 합성
+  exact·constant·2단 누적·blank gap·repeat tie·page clipping·missing/nontext·budget·overlap 10축 포함
+  Python **62** green. canonical candidate SHA `25524c3d…`·8쪽·global translations·T3/`pass=null`
+  불변, trace는 unique 55/tie 5·transitions hypothesis 26/ambiguous 26. 독립 2회 report JSON/HTML
+  SHA도 exact다. pages 4/5의 최초 안정 분기는 `table-0001→table-0002`에서 **0→+17/+19px**이고,
+  page1 +9px·page7 +33px 같은 transition class가 반복된다. 뒤 short text rows는 반복 패턴이라 noise가
+  커서 아직 table height/font/line metric 수정을 정당화하지 않는다. **다음:** overlap ambiguity 반영
+  canonical 재실행→docs/tests/quick→commit/push/PR `Closes #223`→CI/merge→consecutive-table/anchor-spacing
+  원인을 synthetic HWP/HWPX 최소 fixture로 분리하는 child. `verify-local` quick은 Rust workspace/rhwp
+  feature/wasm/licenses/AI120/8·18·24+98.9%/public corpus/oracle82 포함 전부 green. rhwp 무수정.
+
+- 갱신: 2026-08-25 · Codex(sol) — **PR #222 병합 · #223 vertical-transition trace 착수**.
+  #221 exact head `e192e5e`는 issue-link **4s**·licenses **3m51s**·build-test **9m58s** green,
+  MERGEABLE, 댓글/review 0으로 protected main `015eebc4`에 squash 병합됐다. #221은 close되고 원격
+  branch도 삭제했으며 #93/#114에 content-free 결과를 동기화했다. canonical PDF SHA `25524c3d…`는
+  불변이고 broad text 70개는 intentional blank **42** + paint-backed **28**, expected-missing 0이다.
+  생성 marker도 placed glyph가 band 안에 있으면 source text가 비어도 painted가 우선한다. 후속 P0
+  #223을 등재하고 exact main의 `codex/issue-223-vertical-transition-trace`를 만들었다. row-span 실측은
+  pages 4/5에서 title/table 시작 뒤 약 한 band, 다음 body에서 약 두 band로 커지는 불연속을 보이지만
+  아직 table margin/anchor spacing/line height 중 하나로 확정하지 않는다. **다음:** fixed page alignment와
+  score를 건드리지 않는 monotonic content-free transition trace 설계·합성 테스트→canonical 재측정.
+  font category/weight는 별도 축, T3/threshold/`pass=null`·8/18/24·98.9%·oracle82·rhwp는 불변이다.
+
 - 갱신: 2026-08-25 · Codex(sol) — **PR #220 병합 · #221 paint-backed text-region evidence 구현·재측정 완료**.
   #219 exact head `be39cae`는 교체 CI의 issue-link **3s**·licenses **2m51s**·build-test **11m1s**
   green, CLEAN/MERGEABLE, 댓글/review 0으로 protected main `ffce59dd`에 squash 병합됐다. #219는

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,12 @@
 
 ---
 
+## 2026-08-25 (Codex sol) · #223 vertical-transition trace
+- fixed alignment의 row-ink profile로 ±128px offset/transition 가설을 bounded·content-free하게 추가.
+- canonical은 SHA·scores 불변, unique/tie 55/5; page4/5 첫 table transition이 0→+17/+19px.
+- Python62·quick 전체 green, 독립 2회 JSON/HTML exact; rhwp/Rust/threshold/pass 불변.
+- 다음: PR/CI/merge→consecutive-table/anchor-spacing 최소 fixture child.
+
 ## 2026-08-25 (Codex sol) · #221 paint-backed visual regions
 - visual schema v2가 blank 42개를 제외하고 painted text 28개·expected-missing 0을 증명했다.
 - candidate PDF SHA는 #219와 exact; reference-empty 12개가 누적 수직 drift 축을 가리킨다.

--- a/docs/PDF-VISUAL-ORACLE.md
+++ b/docs/PDF-VISUAL-ORACLE.md
@@ -346,6 +346,26 @@ ink, and edge diagnostics, explicit unscorable reasons, per-category counts, and
 regions. Regions are additive and may overlap—for example, cell text remains inside a table region—so
 they are diagnostic lenses rather than a partition or an aggregate quality score.
 
+### Bounded vertical-transition trace
+
+For `text` and `table` regions, the report also emits a content-free, report-only vertical trace.
+It keeps the page's already-selected global alignment and the region's fixed horizontal extent, then
+compares candidate and reference row-ink profiles over integer vertical offsets from -128 through
++128 pixels. Ranking is lexicographic: active-row F1 first, row-ink-count cosine second. There is no
+minimum score or confidence threshold. A unique best rank is labeled `hypothesis`; an exact tie is
+`ambiguous`; absent candidate/reference overlap, missing placement evidence, or exhausted bounded work
+is `unscorable`. Image/object regions are `not-applicable`.
+
+The search reads each candidate crop and the union of its reference search window once. Per-page work
+is capped at 50,000,000 pixel/profile operations. The report records the considered offset range,
+best and runner-up evidence, tied offsets, active-row counts, and work units. None of these fields feed
+page metrics, region metrics, alignment, thresholds, status, or `policy.pass`.
+
+Adjacent non-overlapping text/table regions are ordered by aligned top coordinate. When both endpoint
+traces are unique and their reference hypotheses remain non-overlapping and monotonic, the report
+records candidate/reference gap hypotheses and the offset increment. Ties, missing evidence, source
+overlap, or hypothesis-induced overlap remain explicit ambiguity instead of becoming a layout fact.
+
 ## Visual report
 
 For every dimension-compatible page, `index.html` shows:
@@ -484,6 +504,24 @@ bounded cumulative vertical-position drift: lower-page candidate symbols/heading
 the reference content has already moved. The next rendering child should isolate the first divergent
 vertical increment; font weight/category remains a separate axis. T3 authority, translation bounds,
 thresholds, and `pass=null` remain unchanged.
+
+### First vertical-transition trace (2026-08-25, #223)
+
+The trace reran the exact #219/#221 candidate PDF SHA-256
+`25524c3dfc15e19498fb5623e74bc38f16ba9e751dba7470ef441406cdb9e5bd`; export bytes, eight-page
+structure, global translations, page/region scores, T3 authority, and `pass=null` were unchanged.
+All 60 paint-backed text/table regions produced content-free trace evidence: 55 unique hypotheses and
+5 exact ties in the first run. Repeated short marker rows explain the ties and remain visible rather
+than receiving an arbitrary nearest match. Of 52 adjacent pairs, 26 remain valid hypotheses and 26
+are explicit ambiguity because their source regions overlap, their endpoints tie, or the inferred
+reference gaps would overlap. Two independent runs produced byte-identical JSON and HTML reports.
+
+The earliest stable page-4/page-5 divergence is bounded to `table-0001 → table-0002`: the first table
+anchors at 0 px while the second table's reference-row hypothesis is +17 px and +19 px lower,
+respectively. The same transition class is +9 px on page 1 and +33 px on page 7, while later isolated
+text rows often repeat and therefore do not yet identify a safe renderer formula. This supports a
+separate consecutive-table/anchor-spacing investigation; it does not justify changing table height,
+paragraph line metrics, or font realization in #223.
 
 ## Tests
 

--- a/scripts/pdf-visual-check.py
+++ b/scripts/pdf-visual-check.py
@@ -91,6 +91,9 @@ MAX_VISUAL_REGIONS_TOTAL = 10_000
 MAX_VISUAL_REGIONS_PER_PAGE = 2_000
 MAX_VISUAL_REGION_PAGE_AREA_MULTIPLIER = 16
 VISUAL_REGION_CATEGORIES = frozenset({"text", "table", "image", "object"})
+MAX_VERTICAL_TRACE_PX = 128
+HARD_MAX_VERTICAL_TRACE_WORK_PER_PAGE = 50_000_000
+VERTICAL_TRACE_PROFILE_ROW_COST = 6
 
 REFERENCE_TIERS: Mapping[str, str] = {
     "T0": "Licensed Hancom Windows/WebHWP rendering with product, build, and font provenance.",
@@ -1912,6 +1915,279 @@ def _crop_image(image: GrayImage, left: int, top: int, right: int, bottom: int) 
     return GrayImage(width, bottom - top, bytes(pixels))
 
 
+def _row_ink_counts(
+    image: GrayImage, left: int, top: int, right: int, bottom: int
+) -> List[int]:
+    counts: List[int] = []
+    for row in range(top, bottom):
+        start = row * image.width + left
+        counts.append(
+            sum(
+                1
+                for value in image.pixels[start : start + (right - left)]
+                if value < INK_THRESHOLD
+            )
+        )
+    return counts
+
+
+def _row_profile_similarity(
+    candidate_counts: Sequence[int], reference_counts: Sequence[int]
+) -> Tuple[float, float, int]:
+    candidate_active = {index for index, count in enumerate(candidate_counts) if count}
+    reference_active = {index for index, count in enumerate(reference_counts) if count}
+    overlap = len(candidate_active & reference_active)
+    active_total = len(candidate_active) + len(reference_active)
+    row_f1 = 0.0 if active_total == 0 else (2.0 * overlap / active_total)
+    dot = sum(left * right for left, right in zip(candidate_counts, reference_counts))
+    candidate_norm = sum(value * value for value in candidate_counts)
+    reference_norm = sum(value * value for value in reference_counts)
+    cosine = (
+        0.0
+        if candidate_norm == 0 or reference_norm == 0
+        else dot / math.sqrt(candidate_norm * reference_norm)
+    )
+    return row_f1, cosine, overlap
+
+
+def _vertical_trace(
+    category: str,
+    paint_status: str,
+    bounds: Optional[Mapping[str, int]],
+    reference: GrayImage,
+    aligned_candidate: GrayImage,
+    max_work: int = HARD_MAX_VERTICAL_TRACE_WORK_PER_PAGE,
+) -> Dict[str, Any]:
+    policy = {
+        "role": "report_only_hypothesis",
+        "search_axis": "vertical_only",
+        "max_abs_offset_px": MAX_VERTICAL_TRACE_PX,
+        "ink_threshold_gray_lt": INK_THRESHOLD,
+        "ranking": ["active_row_f1", "row_ink_count_cosine"],
+    }
+    if category not in {"text", "table"}:
+        return {
+            "status": "not-applicable",
+            "reason": "category has no vertical text/table transition",
+            "policy": policy,
+        }
+    if paint_status == "expected-missing":
+        return {
+            "status": "unscorable",
+            "reason": "source-visible text produced no placed glyph",
+            "policy": policy,
+        }
+    if bounds is None:
+        return {
+            "status": "unscorable",
+            "reason": "aligned region bounds are unavailable",
+            "policy": policy,
+        }
+
+    left = int(bounds["left"])
+    top = int(bounds["top"])
+    right = left + int(bounds["width"])
+    bottom = top + int(bounds["height"])
+    minimum_offset = max(-MAX_VERTICAL_TRACE_PX, -top)
+    maximum_offset = min(MAX_VERTICAL_TRACE_PX, reference.height - bottom)
+    considered = {
+        "min": minimum_offset,
+        "max": maximum_offset,
+        "count": max(0, maximum_offset - minimum_offset + 1),
+    }
+    width = right - left
+    height = bottom - top
+    work_units = (
+        width * height
+        + width * (height + maximum_offset - minimum_offset)
+        + height * considered["count"] * VERTICAL_TRACE_PROFILE_ROW_COST
+    )
+    if work_units > max_work:
+        return {
+            "status": "unscorable",
+            "reason": "bounded per-page vertical trace work budget is exhausted",
+            "policy": policy,
+            "considered_offsets_px": considered,
+            "work_units": 0,
+        }
+
+    candidate_counts = _row_ink_counts(aligned_candidate, left, top, right, bottom)
+    candidate_active_rows = sum(1 for count in candidate_counts if count)
+    if candidate_active_rows == 0:
+        return {
+            "status": "unscorable",
+            "reason": "candidate region has no ink rows",
+            "policy": policy,
+            "candidate_active_rows": 0,
+            "work_units": width * height,
+        }
+    reference_window = _row_ink_counts(
+        reference,
+        left,
+        top + minimum_offset,
+        right,
+        bottom + maximum_offset,
+    )
+    rankings: List[Dict[str, Any]] = []
+    for offset in range(minimum_offset, maximum_offset + 1):
+        start = offset - minimum_offset
+        reference_counts = reference_window[start : start + height]
+        row_f1, cosine, overlap = _row_profile_similarity(
+            candidate_counts, reference_counts
+        )
+        rankings.append(
+            {
+                "offset_px": offset,
+                "active_row_f1": row_f1,
+                "row_ink_count_cosine": cosine,
+                "overlapping_active_rows": overlap,
+                "reference_active_rows": sum(1 for count in reference_counts if count),
+            }
+        )
+    if not rankings or max(item["reference_active_rows"] for item in rankings) == 0:
+        return {
+            "status": "unscorable",
+            "reason": "reference search window has no ink rows",
+            "policy": policy,
+            "candidate_active_rows": candidate_active_rows,
+            "considered_offsets_px": considered,
+            "work_units": work_units,
+        }
+
+    def rank(item: Mapping[str, Any]) -> Tuple[float, float]:
+        return (item["active_row_f1"], item["row_ink_count_cosine"])
+
+    best_rank = max(rank(item) for item in rankings)
+    best = [item for item in rankings if rank(item) == best_rank]
+    lower = [item for item in rankings if rank(item) < best_rank]
+    lower.sort(
+        key=lambda item: (
+            -item["active_row_f1"],
+            -item["row_ink_count_cosine"],
+            abs(item["offset_px"]),
+            item["offset_px"],
+        )
+    )
+    runner_up = lower[0] if lower else None
+    common = {
+        "policy": policy,
+        "candidate_active_rows": candidate_active_rows,
+        "considered_offsets_px": considered,
+        "best_score": {
+            "active_row_f1": best_rank[0],
+            "row_ink_count_cosine": best_rank[1],
+        },
+        "runner_up": runner_up,
+        "work_units": work_units,
+    }
+    if best_rank[0] == 0.0:
+        return {
+            **common,
+            "status": "unscorable",
+            "reason": "candidate and reference have no overlapping active rows in the bounded search window",
+        }
+    if len(best) != 1:
+        return {
+            **common,
+            "status": "ambiguous",
+            "reason": "multiple offsets have the same best row-profile rank",
+            "best_offsets_px": [item["offset_px"] for item in best],
+        }
+    return {
+        **common,
+        "status": "hypothesis",
+        "reason": None,
+        "offset_px": best[0]["offset_px"],
+        "reference_active_rows": best[0]["reference_active_rows"],
+        "overlapping_active_rows": best[0]["overlapping_active_rows"],
+    }
+
+
+def _vertical_transitions(regions: Sequence[Mapping[str, Any]]) -> List[Dict[str, Any]]:
+    ordered = sorted(
+        (
+            region
+            for region in regions
+            if region.get("category") in {"text", "table"}
+            and region.get("aligned_bounds_px") is not None
+        ),
+        key=lambda region: (
+            region["aligned_bounds_px"]["top"],
+            region["aligned_bounds_px"]["left"],
+            region["id"],
+        ),
+    )
+    transitions: List[Dict[str, Any]] = []
+    for previous, current in zip(ordered, ordered[1:]):
+        previous_bounds = previous["aligned_bounds_px"]
+        current_bounds = current["aligned_bounds_px"]
+        previous_trace = previous["vertical_trace"]
+        current_trace = current["vertical_trace"]
+        item: Dict[str, Any] = {
+            "from_region_id": previous["id"],
+            "from_category": previous["category"],
+            "to_region_id": current["id"],
+            "to_category": current["category"],
+            "candidate_gap_px": current_bounds["top"]
+            - (previous_bounds["top"] + previous_bounds["height"]),
+        }
+        if item["candidate_gap_px"] < 0:
+            item.update(
+                status="ambiguous",
+                reason="aligned source regions overlap, so they are not a sequential vertical transition",
+            )
+            transitions.append(item)
+            continue
+        statuses = {previous_trace["status"], current_trace["status"]}
+        if "unscorable" in statuses:
+            item.update(
+                status="unscorable",
+                reason="one or both endpoint traces are unscorable",
+            )
+        elif "ambiguous" in statuses:
+            item.update(
+                status="ambiguous",
+                reason="one or both endpoint traces have tied best offsets",
+            )
+        elif statuses != {"hypothesis"}:
+            item.update(
+                status="not-applicable",
+                reason="one or both endpoint categories are not traceable",
+            )
+        else:
+            previous_reference_top = previous_bounds["top"] + previous_trace["offset_px"]
+            current_reference_top = current_bounds["top"] + current_trace["offset_px"]
+            if current_reference_top < previous_reference_top:
+                item.update(
+                    status="ambiguous",
+                    reason="best-offset hypotheses reverse region top order",
+                )
+            else:
+                reference_gap = current_reference_top - (
+                    previous_reference_top + previous_bounds["height"]
+                )
+                if reference_gap < 0:
+                    item.update(
+                        status="ambiguous",
+                        reason="best-offset hypotheses make non-overlapping source regions overlap",
+                        reference_gap_hypothesis_px=reference_gap,
+                    )
+                else:
+                    item.update(
+                        status="hypothesis",
+                        reason=None,
+                        from_offset_px=previous_trace["offset_px"],
+                        to_offset_px=current_trace["offset_px"],
+                        offset_increment_px=(
+                            current_trace["offset_px"]
+                            - previous_trace["offset_px"]
+                        ),
+                        reference_gap_hypothesis_px=reference_gap,
+                    )
+        transitions.append(item)
+    return transitions
+
+
 def _score_visual_regions(
     page_contract: Mapping[str, Any],
     reference: GrayImage,
@@ -1926,6 +2202,25 @@ def _score_visual_regions(
     dx = int(translation["dx"])
     dy = int(translation["dy"])
     results: List[Dict[str, Any]] = []
+    vertical_trace_work = 0
+
+    def trace(
+        category: str,
+        paint_status: str,
+        bounds: Optional[Mapping[str, int]],
+    ) -> Dict[str, Any]:
+        nonlocal vertical_trace_work
+        result = _vertical_trace(
+            category,
+            paint_status,
+            bounds,
+            reference,
+            aligned_candidate,
+            HARD_MAX_VERTICAL_TRACE_WORK_PER_PAGE - vertical_trace_work,
+        )
+        vertical_trace_work += int(result.get("work_units", 0))
+        return result
+
     for region in page_contract["regions"]:
         raw_left = math.floor(float(region["x"]) * candidate_raw_width / page_width)
         raw_top = math.floor(float(region["y"]) * candidate_raw_height / page_height)
@@ -1970,6 +2265,11 @@ def _score_visual_regions(
                     "metrics": None,
                 }
             )
+            base["vertical_trace"] = trace(
+                region["category"],
+                region["paint_status"],
+                None,
+            )
             results.append(base)
             continue
         if right <= left or bottom <= top:
@@ -1981,8 +2281,19 @@ def _score_visual_regions(
                     "metrics": None,
                 }
             )
+            base["vertical_trace"] = trace(
+                region["category"],
+                region["paint_status"],
+                None,
+            )
             results.append(base)
             continue
+        aligned_bounds = {
+            "left": left,
+            "top": top,
+            "width": right - left,
+            "height": bottom - top,
+        }
         reference_crop = _crop_image(reference, left, top, right, bottom)
         candidate_crop = _crop_image(aligned_candidate, left, top, right, bottom)
         _, metrics = _compare_images(
@@ -1995,12 +2306,7 @@ def _score_visual_regions(
             {
                 "status": metrics["status"],
                 "reason": None,
-                "aligned_bounds_px": {
-                    "left": left,
-                    "top": top,
-                    "width": right - left,
-                    "height": bottom - top,
-                },
+                "aligned_bounds_px": aligned_bounds,
                 "metrics": {
                     "global_ssim_like": metrics["ssim_like"]["global"],
                     "local_ssim_like_mean": metrics["ssim_like"]["local"]["mean"],
@@ -2009,6 +2315,11 @@ def _score_visual_regions(
                     "edge_f1": metrics["edge"]["f1"],
                     "unscorable_metrics": metrics["unscorable_metrics"],
                 },
+                "vertical_trace": trace(
+                    region["category"],
+                    region["paint_status"],
+                    aligned_bounds,
+                ),
             }
         )
         results.append(base)
@@ -2062,17 +2373,42 @@ def _render_html(report: Mapping[str, Any]) -> str:
                 f"<td>{html.escape(region['status'])}</td>"
                 f"<td>{_format_metric(None if region.get('metrics') is None else region['metrics']['ink']['f1'])}</td>"
                 f"<td>{_format_metric(None if region.get('metrics') is None else region['metrics']['edge_f1'])}</td>"
+                f"<td>{html.escape(region.get('vertical_trace', {}).get('status', 'unavailable'))}</td>"
+                f"<td>{_format_metric(region.get('vertical_trace', {}).get('offset_px'))}</td>"
                 "</tr>"
                 for region in semantic_regions
             )
             region_table = (
                 "<h3>Semantic regions (additive, report-only)</h3>"
                 "<table><tr><th>ID</th><th>Category</th><th>Status</th>"
-                "<th>Ink F1</th><th>Edge F1</th></tr>"
+                "<th>Ink F1</th><th>Edge F1</th><th>Vertical trace</th>"
+                "<th>Offset hypothesis (px)</th></tr>"
                 f"{region_rows}</table>"
             )
         else:
             region_table = "<p class=muted>No first-party semantic region manifest was provided.</p>"
+        vertical_transitions = page.get("vertical_transitions", [])
+        if vertical_transitions:
+            transition_rows = "".join(
+                "<tr>"
+                f"<td>{html.escape(item['from_region_id'])}</td>"
+                f"<td>{html.escape(item['to_region_id'])}</td>"
+                f"<td>{html.escape(item['status'])}</td>"
+                f"<td>{_format_metric(item.get('candidate_gap_px'))}</td>"
+                f"<td>{_format_metric(item.get('offset_increment_px'))}</td>"
+                f"<td>{html.escape(str(item.get('reason') or ''))}</td>"
+                "</tr>"
+                for item in vertical_transitions
+            )
+            transition_table = (
+                "<h3>Vertical transitions (report-only hypotheses)</h3>"
+                "<table><tr><th>From</th><th>To</th><th>Status</th>"
+                "<th>Candidate gap (px)</th><th>Offset increment (px)</th>"
+                "<th>Evidence note</th></tr>"
+                f"{transition_rows}</table>"
+            )
+        else:
+            transition_table = ""
         artifacts = page.get("artifacts", {})
         image_cards: List[str] = []
         for key, label in (
@@ -2101,6 +2437,7 @@ def _render_html(report: Mapping[str, Any]) -> str:
               <p>{html.escape(offset_text)}</p>
               {metric_rows}
               {region_table}
+              {transition_table}
               <div class=images>{''.join(image_cards)}</div>
               <details><summary>Page JSON</summary><pre>{html.escape(json.dumps(page, ensure_ascii=False, indent=2, sort_keys=True))}</pre></details>
             </section>
@@ -2233,8 +2570,14 @@ def _summarize_pages(pages: Sequence[Mapping[str, Any]]) -> Dict[str, Any]:
     unscorable_regions = 0
     partially_unscorable_regions = 0
     category_counts: Dict[str, Dict[str, int]] = {}
+    trace_status_counts: Dict[str, int] = {}
+    transition_status_counts: Dict[str, int] = {}
+    transition_hypotheses: List[Dict[str, Any]] = []
     for page in pages:
         for region in page.get("semantic_regions", []):
+            trace_status = region.get("vertical_trace", {}).get("status")
+            if trace_status is not None:
+                trace_status_counts[trace_status] = trace_status_counts.get(trace_status, 0) + 1
             category = region["category"]
             counts = category_counts.setdefault(
                 category,
@@ -2261,6 +2604,18 @@ def _summarize_pages(pages: Sequence[Mapping[str, Any]]) -> Dict[str, Any]:
                     "aligned_bounds_px": region["aligned_bounds_px"],
                 }
             )
+        for transition in page.get("vertical_transitions", []):
+            transition_status = transition["status"]
+            transition_status_counts[transition_status] = (
+                transition_status_counts.get(transition_status, 0) + 1
+            )
+            if transition_status == "hypothesis":
+                transition_hypotheses.append(
+                    {
+                        "page": page["page"],
+                        **transition,
+                    }
+                )
 
     def region_key(region: Mapping[str, Any]) -> Tuple[float, float, int, str]:
         return (
@@ -2285,6 +2640,9 @@ def _summarize_pages(pages: Sequence[Mapping[str, Any]]) -> Dict[str, Any]:
         "partially_unscorable_regions": partially_unscorable_regions,
         "unscorable_regions": unscorable_regions,
         "region_category_counts": category_counts,
+        "vertical_trace_status_counts": trace_status_counts,
+        "vertical_transition_status_counts": transition_status_counts,
+        "vertical_transition_hypotheses": transition_hypotheses,
     }
 
 
@@ -2679,6 +3037,9 @@ def _run_visual_check_from_snapshots(
             "worst_regions": [],
             "scored_regions": 0,
             "unscorable_regions": 0,
+            "vertical_trace_status_counts": {},
+            "vertical_transition_status_counts": {},
+            "vertical_transition_hypotheses": [],
             "pixel_comparison_attempted": False,
         }
         _write_report(output_dir, report, {}, limits)
@@ -2794,6 +3155,13 @@ def _run_visual_check_from_snapshots(
                         "reason": "page raster dimensions are unscorable without forbidden resizing",
                         "aligned_bounds_px": None,
                         "metrics": None,
+                        "vertical_trace": _vertical_trace(
+                            region["category"],
+                            region["paint_status"],
+                            None,
+                            reference_raw_image,
+                            candidate_raw_image,
+                        ),
                     }
                     for region in visual_regions["document"]["pages"][page_number - 1]["regions"]
                 ]
@@ -2822,6 +3190,7 @@ def _run_visual_check_from_snapshots(
                     "alignment": None,
                     "metrics": None,
                     "semantic_regions": semantic_regions,
+                    "vertical_transitions": [],
                     "intentional_blank_text_regions": (
                         visual_regions["document"]["pages"][page_number - 1][
                             "intentional_blank_text_regions"
@@ -2924,6 +3293,7 @@ def _run_visual_check_from_snapshots(
                 metrics["alignment"]["candidate_translation_px"],
                 limits.max_edge_work,
             )
+        vertical_transitions = _vertical_transitions(semantic_regions)
         report["pages"].append(
             {
                 "page": page_number,
@@ -2938,6 +3308,7 @@ def _run_visual_check_from_snapshots(
                 "alignment": metrics["alignment"],
                 "metrics": metrics,
                 "semantic_regions": semantic_regions,
+                "vertical_transitions": vertical_transitions,
                 "intentional_blank_text_regions": (
                     visual_regions["document"]["pages"][page_number - 1][
                         "intentional_blank_text_regions"
@@ -2990,7 +3361,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--candidate-regions",
         help=(
-            "optional schema-v1 content-free HWPUNIT region manifest emitted from "
+            "optional schema-v2 content-free HWPUNIT region manifest emitted from "
             "the same first-party placement as the candidate PDF"
         ),
     )

--- a/scripts/tests/test_pdf_visual_check.py
+++ b/scripts/tests/test_pdf_visual_check.py
@@ -266,6 +266,135 @@ class VisualRegionTests(unittest.TestCase):
         )
 
 
+class VerticalTraceTests(unittest.TestCase):
+    def bounds(self, left=0, top=0, width=3, height=6):
+        return {"left": left, "top": top, "width": width, "height": height}
+
+    def test_exact_and_constant_offset_are_report_only_hypotheses(self):
+        candidate = gray_image(8, 24, [(1, 6), (2, 7)])
+        exact = pdf_visual_check._vertical_trace(
+            "text", "painted", self.bounds(top=4), candidate, candidate
+        )
+        reference = gray_image(8, 24, [(1, 9), (2, 10)])
+        shifted = pdf_visual_check._vertical_trace(
+            "text", "painted", self.bounds(top=4), reference, candidate
+        )
+
+        self.assertEqual(exact["status"], "hypothesis")
+        self.assertEqual(exact["offset_px"], 0)
+        self.assertEqual(shifted["status"], "hypothesis")
+        self.assertEqual(shifted["offset_px"], 3)
+        self.assertEqual(shifted["policy"]["role"], "report_only_hypothesis")
+        self.assertNotIn("passed", shifted)
+
+    def test_two_transition_offsets_expose_cumulative_increment_and_blank_gap(self):
+        candidate = gray_image(12, 48, [(1, 11), (6, 27)])
+        reference = gray_image(12, 48, [(1, 13), (6, 32)])
+        first_bounds = self.bounds(left=0, top=9, width=3, height=5)
+        second_bounds = self.bounds(left=5, top=25, width=3, height=5)
+        regions = [
+            {
+                "id": "text-0001",
+                "category": "text",
+                "aligned_bounds_px": first_bounds,
+                "vertical_trace": pdf_visual_check._vertical_trace(
+                    "text", "painted", first_bounds, reference, candidate
+                ),
+            },
+            {
+                "id": "table-0002",
+                "category": "table",
+                "aligned_bounds_px": second_bounds,
+                "vertical_trace": pdf_visual_check._vertical_trace(
+                    "table", "not-applicable", second_bounds, reference, candidate
+                ),
+            },
+        ]
+
+        transitions = pdf_visual_check._vertical_transitions(regions)
+
+        self.assertEqual(regions[0]["vertical_trace"]["offset_px"], 2)
+        self.assertEqual(regions[1]["vertical_trace"]["offset_px"], 5)
+        self.assertEqual(transitions[0]["status"], "hypothesis")
+        self.assertEqual(transitions[0]["candidate_gap_px"], 11)
+        self.assertEqual(transitions[0]["offset_increment_px"], 3)
+        self.assertEqual(transitions[0]["reference_gap_hypothesis_px"], 14)
+
+    def test_repeated_row_pattern_is_explicitly_ambiguous(self):
+        candidate = gray_image(4, 16, [(1, 3)])
+        reference = gray_image(4, 16, [(1, 3), (1, 9)])
+        trace = pdf_visual_check._vertical_trace(
+            "text", "painted", self.bounds(top=2, width=3, height=3), reference, candidate
+        )
+
+        self.assertEqual(trace["status"], "ambiguous")
+        self.assertEqual(trace["best_offsets_px"], [0, 6])
+        self.assertIn("same best", trace["reason"])
+
+    def test_page_edge_clips_search_window_without_moving_the_region(self):
+        candidate = gray_image(5, 12, [(1, 1)])
+        reference = gray_image(5, 12, [(1, 2)])
+        trace = pdf_visual_check._vertical_trace(
+            "text", "painted", self.bounds(top=0, height=4), reference, candidate
+        )
+
+        self.assertEqual(trace["status"], "hypothesis")
+        self.assertEqual(trace["offset_px"], 1)
+        self.assertEqual(trace["considered_offsets_px"], {"min": 0, "max": 8, "count": 9})
+
+    def test_missing_blank_and_nontext_evidence_never_become_zero_score(self):
+        blank = gray_image(6, 12)
+        reference = gray_image(6, 12, [(1, 4)])
+        bounds = self.bounds(top=2)
+
+        missing = pdf_visual_check._vertical_trace(
+            "text", "painted", bounds, reference, blank
+        )
+        expected_missing = pdf_visual_check._vertical_trace(
+            "text", "expected-missing", None, reference, blank
+        )
+        nontext = pdf_visual_check._vertical_trace(
+            "image", "not-applicable", bounds, reference, blank
+        )
+
+        self.assertEqual(missing["status"], "unscorable")
+        self.assertEqual(expected_missing["status"], "unscorable")
+        self.assertEqual(nontext["status"], "not-applicable")
+        self.assertNotIn("offset_px", missing)
+
+    def test_trace_work_is_bounded_and_reported_unscorable(self):
+        image = gray_image(10, 20, [(1, 4)])
+        trace = pdf_visual_check._vertical_trace(
+            "text", "painted", self.bounds(top=2), image, image, max_work=1
+        )
+
+        self.assertEqual(trace["status"], "unscorable")
+        self.assertIn("work budget", trace["reason"])
+        self.assertEqual(trace["work_units"], 0)
+
+    def test_overlapping_regions_are_not_claimed_as_sequential_transitions(self):
+        trace = {"status": "hypothesis", "offset_px": 0}
+        transitions = pdf_visual_check._vertical_transitions(
+            [
+                {
+                    "id": "table-0001",
+                    "category": "table",
+                    "aligned_bounds_px": self.bounds(top=2, height=8),
+                    "vertical_trace": trace,
+                },
+                {
+                    "id": "text-0002",
+                    "category": "text",
+                    "aligned_bounds_px": self.bounds(top=5, height=2),
+                    "vertical_trace": trace,
+                },
+            ]
+        )
+
+        self.assertEqual(transitions[0]["status"], "ambiguous")
+        self.assertIn("overlap", transitions[0]["reason"])
+
+
 class MetricRegressionTests(unittest.TestCase):
     def test_bounded_translation_is_detected_and_reported(self):
         reference = gray_image(16, 16, rectangle(2, 2, 5, 5))


### PR DESCRIPTION
Closes #223

## Outcome
- add a content-free, report-only vertical row-profile trace for text/table regions
- expose unique hypotheses, exact ties, unscorable evidence, runner-up evidence, and adjacent transition increments
- cap trace work per page and keep source/ref overlap ambiguity explicit
- leave structural checks, global alignment, pixel scores, thresholds, and policy.pass unchanged

## Canonical evidence
- exact candidate SHA: 25524c3dfc15e19498fb5623e74bc38f16ba9e751dba7470ef441406cdb9e5bd
- trace statuses: 55 hypothesis / 5 ambiguous
- transition statuses: 26 hypothesis / 26 ambiguous
- first stable page 4/5 table transition: 0 to +17/+19 px
- independent JSON and HTML reports are byte-identical

## Verification
- Python visual oracle tests: 62 passed
- scripts/verify-local.sh: green
- canonical 8/18/24 pages and 98.9%+ line gate unchanged
- AI-native 120-task suite, public corpus, oracle82, wasm, licenses green
- external/rhwp remains pinned and unmodified