### PR TITLE
test(typeset): isolate HWP5 table-anchor spacing ownership

### DIFF
--- a/crates/hwp-core/tests/hwp5_table_spacing_ownership.rs
+++ b/crates/hwp-core/tests/hwp5_table_spacing_ownership.rs
@@ -1,0 +1,97 @@
+#![cfg(feature = "rhwp")]
+
+use hwp_core::{open_hwp5_own, Engine};
+use hwp_model::document::{Block, SemanticDoc};
+use hwp_model::prelude::{DocumentParser, SourceFormat};
+use hwp_rhwp::RhwpEngine;
+use hwp_typeset::{place_doc, ApproxFontMetrics, PlacedDoc};
+
+fn margins(doc: &SemanticDoc) -> Vec<(usize, usize, i32, i32, usize)> {
+    doc.sections
+        .iter()
+        .enumerate()
+        .flat_map(|(section, value)| {
+            value
+                .blocks
+                .iter()
+                .enumerate()
+                .filter_map(move |(block, value)| match value {
+                    Block::Table(table) => Some((
+                        section,
+                        block,
+                        table.outer_margin_top,
+                        table.outer_margin_bottom,
+                        table.rows,
+                    )),
+                    Block::Paragraph(_) => None,
+                })
+        })
+        .collect()
+}
+
+fn top_level_tables(doc: &PlacedDoc, page: usize) -> Vec<(usize, f64, f64)> {
+    doc.pages[page]
+        .tables
+        .iter()
+        .filter(|table| table.ancestors.is_empty())
+        .map(|table| (table.block, table.y, table.h))
+        .collect()
+}
+
+fn assert_same_table_geometry(left: &PlacedDoc, right: &PlacedDoc) {
+    assert_eq!(left.pages.len(), right.pages.len());
+    for page in 0..left.pages.len() {
+        let left = top_level_tables(left, page);
+        let right = top_level_tables(right, page);
+        assert_eq!(left.len(), right.len());
+        for (left, right) in left.iter().zip(right) {
+            assert_eq!(left.0, right.0);
+            assert_eq!(left.1.to_bits(), right.1.to_bits());
+            assert_eq!(left.2.to_bits(), right.2.to_bits());
+        }
+    }
+}
+
+#[test]
+fn benchmark_anchor_spacing_loss_is_not_a_margin_or_parser_delta() {
+    let bytes = std::fs::read(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../benchmarks/benchmark.hwp"
+    ))
+    .unwrap();
+    let owned = open_hwp5_own(&bytes).unwrap();
+    let rhwp = RhwpEngine::new().parse(&bytes, SourceFormat::Hwp5).unwrap();
+    let production = Engine::open(&bytes).unwrap();
+
+    assert_eq!(margins(&owned), margins(&rhwp));
+    assert_eq!(margins(&owned), margins(&production));
+    let owned_placed = place_doc(&owned, &ApproxFontMetrics);
+    let rhwp_placed = place_doc(&rhwp, &ApproxFontMetrics);
+    let production_placed = place_doc(&production, &ApproxFontMetrics);
+    assert_same_table_geometry(&owned_placed, &rhwp_placed);
+    assert_same_table_geometry(&owned_placed, &production_placed);
+
+    let page1 = top_level_tables(&production_placed, 0);
+    let page4 = top_level_tables(&production_placed, 3);
+    let page5 = top_level_tables(&production_placed, 4);
+    assert_eq!((page1[0].0, page1[1].0), (1, 3));
+    assert_eq!((page4[0].0, page4[1].0), (15, 17));
+    assert_eq!((page5[0].0, page5[1].0), (32, 34));
+
+    let placed_delta = |tables: &[(usize, f64, f64)]| tables[1].1 - tables[0].1;
+    assert_eq!(placed_delta(&page1), 1_989.0);
+    assert_eq!(placed_delta(&page4), 3_286.0);
+    assert_eq!(placed_delta(&page5), 3_286.0);
+
+    // Raw HWP5 PARA_LINE_SEG evidence is pinned independently in hwp-rhwp's
+    // table_anchor_spacing test. It predicts 2,441 / 4,246 / 4,246 HWPUNIT
+    // between table tops. The exact deficits are the preceding anchor line's
+    // stored line_spacing, not a table margin or parser disagreement.
+    assert_eq!(2_441.0 - placed_delta(&page1), 452.0);
+    assert_eq!(4_246.0 - placed_delta(&page4), 960.0);
+    assert_eq!(4_246.0 - placed_delta(&page5), 960.0);
+
+    println!(
+        "hwp5-table-spacing.v1 parsers=exact page1_missing=452 page4_missing=960 page5_missing=960 cause=anchor_line_spacing"
+    );
+}

--- a/crates/hwp-hwpx/src/parse.rs
+++ b/crates/hwp-hwpx/src/parse.rs
@@ -2791,6 +2791,48 @@ pub(crate) mod tests {
         );
     }
 
+    #[test]
+    fn two_hwpx_table_hosts_keep_only_their_explicit_margin_evidence() {
+        let cell = |text: &str| {
+            format!(
+                r#"<hp:tr><hp:tc><hp:subList><hp:p><hp:run><hp:t>{text}</hp:t></hp:run></hp:p></hp:subList><hp:cellAddr colAddr="0" rowAddr="0"/><hp:cellSpan colSpan="1" rowSpan="1"/><hp:cellSz width="1000" height="500"/></hp:tc></hp:tr>"#
+            )
+        };
+        let table = |id: usize, top: i32, bottom: i32| {
+            format!(
+                r#"<hp:p id="{id}"><hp:run><hp:tbl rowCnt="1" colCnt="1"><hp:outMargin left="0" right="0" top="{top}" bottom="{bottom}"/>{}</hp:tbl><hp:t></hp:t></hp:run></hp:p>"#,
+                cell("셀")
+            )
+        };
+        let xml = format!(
+            r#"<hs:sec xmlns:hs="s" xmlns:hp="p">{}{}</hs:sec>"#,
+            table(1, 100, 200),
+            table(2, 300, 400),
+        );
+        let mut blocks = Vec::new();
+        parse_section(&xml, &mut blocks, &mut Vec::new(), &Default::default()).unwrap();
+
+        let tables: Vec<_> = blocks
+            .iter()
+            .filter_map(|block| match block {
+                Block::Table(table) => Some((table.outer_margin_top, table.outer_margin_bottom)),
+                Block::Paragraph(_) => None,
+            })
+            .collect();
+        let anchors: Vec<_> = blocks
+            .iter()
+            .filter_map(|block| match block {
+                Block::Paragraph(paragraph) => Some((
+                    paragraph.is_table_anchor,
+                    paragraph.source_line_metrics.len(),
+                )),
+                Block::Table(_) => None,
+            })
+            .collect();
+        assert_eq!(tables, vec![(100, 200), (300, 400)]);
+        assert_eq!(anchors, vec![(true, 0), (true, 0)]);
+    }
+
     /// 표를 품었어도 **보이는 텍스트가 있으면** 앵커가 아니다 — 그 줄은 실제로 조판돼야 한다.
     #[test]
     fn table_host_paragraph_with_text_is_not_an_anchor() {

--- a/crates/hwp-model/src/document.rs
+++ b/crates/hwp-model/src/document.rs
@@ -259,8 +259,10 @@ pub struct Paragraph {
     pub column_layout_before: Option<ColumnLayout>,
     /// This (empty) paragraph is a pure TABLE/object ANCHOR — in HWP a table control hangs off a host
     /// paragraph; the lift emits that host as an empty `Paragraph` immediately before the `Table` block.
-    /// Hancom reserves NO line for such an anchor, so pagination skips its height (a genuine blank
-    /// spacer paragraph — text-empty but NOT hosting a control — is left alone and keeps its line).
+    /// The anchor reserves no ordinary text line, so pagination skips its height (a genuine blank
+    /// spacer paragraph — text-empty but NOT hosting a control — keeps its line). Binary HWP5 may
+    /// separately store inter-object distance in the anchor line's `line_spacing`; that source-owned
+    /// axis is diagnosed by #225 and must not be confused with restoring a phantom text line.
     pub is_table_anchor: bool,
     /// Requested named style (e.g. "개요 1"); resolved to a `styleIDRef` by the serializer.
     pub style_name: Option<String>,

--- a/crates/hwp-rhwp/tests/table_anchor_spacing.rs
+++ b/crates/hwp-rhwp/tests/table_anchor_spacing.rs
@@ -1,0 +1,63 @@
+#![cfg(feature = "rhwp")]
+
+use rhwp::model::control::Control;
+
+#[test]
+fn benchmark_anchor_lines_pin_the_missing_inter_table_spacing() {
+    let bytes = std::fs::read(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../benchmarks/benchmark.hwp"
+    ))
+    .unwrap();
+    let document = rhwp::parse_document(&bytes).unwrap();
+    let paragraphs = &document.sections[0].paragraphs;
+
+    let evidence = |ordinal: usize| {
+        let paragraph = &paragraphs[ordinal];
+        let line = paragraph
+            .line_segs
+            .first()
+            .expect("table host has a line segment");
+        let table = paragraph
+            .controls
+            .iter()
+            .find_map(|control| match control {
+                Control::Table(table) => Some(table),
+                _ => None,
+            })
+            .expect("selected paragraph hosts a table");
+        (
+            line.vertical_pos,
+            line.line_height,
+            line.line_spacing,
+            table.outer_margin_top,
+            table.outer_margin_bottom,
+        )
+    };
+
+    let page1_first = evidence(0);
+    let page1_second = evidence(1);
+    let page4_first = evidence(8);
+    let page4_second = evidence(9);
+    let page5_first = evidence(23);
+    let page5_second = evidence(24);
+
+    assert_eq!(page1_first, (0, 2_130, 452, 141, 141));
+    assert_eq!(page1_second.0, 2_582);
+    assert_eq!(page4_first, (0, 3_285, 960, 140, 140));
+    assert_eq!(page4_second.0, 4_245);
+    assert_eq!(page5_first, (0, 3_285, 960, 140, 140));
+    assert_eq!(page5_second.0, 4_245);
+
+    for (first, second) in [
+        (page1_first, page1_second),
+        (page4_first, page4_second),
+        (page5_first, page5_second),
+    ] {
+        assert_eq!(
+            second.0 - (first.0 + first.1),
+            first.2,
+            "the next table host starts after the preceding stored line spacing"
+        );
+    }
+}

--- a/crates/hwp-typeset/src/place.rs
+++ b/crates/hwp-typeset/src/place.rs
@@ -5373,6 +5373,125 @@ mod tests {
         );
     }
 
+    fn table_with_margins(top: i32, bottom: i32) -> Table {
+        let mut table = one_cell_table(0);
+        table.outer_margin_top = top;
+        table.outer_margin_bottom = bottom;
+        table
+    }
+
+    fn top_level_table_tops(doc: &SemanticDoc) -> Vec<(f64, f64)> {
+        place_doc(doc, &ApproxFontMetrics).pages[0]
+            .tables
+            .iter()
+            .filter(|table| table.ancestors.is_empty())
+            .map(|table| (table.y, table.h))
+            .collect()
+    }
+
+    #[test]
+    fn consecutive_table_gap_is_exact_bottom_plus_top_margin() {
+        use crate::LayoutEngine;
+
+        for (first_bottom, second_top) in [(0, 0), (300, 0), (0, 700), (300, 700)] {
+            let doc = doc_with(vec![
+                Block::Table(table_with_margins(900, first_bottom)),
+                Block::Table(table_with_margins(second_top, 800)),
+            ]);
+            let tables = top_level_table_tops(&doc);
+            let gap = tables[1].0 - (tables[0].0 + tables[0].1);
+            assert_eq!(
+                gap,
+                f64::from(first_bottom + second_top),
+                "only the preceding bottom and following top margins form the gap"
+            );
+            if first_bottom > 0 && second_top > 0 {
+                assert_ne!(
+                    gap,
+                    f64::from(first_bottom.max(second_top)),
+                    "the current contract sums margins instead of collapsing to max"
+                );
+            }
+            assert_eq!(
+                tables[0].0, 7_200.0,
+                "page-top suppresses the first table margin but keeps the page margin"
+            );
+            assert_eq!(
+                place_doc(&doc, &ApproxFontMetrics).pages.len(),
+                crate::NaiveLayout
+                    .layout(&doc, &ApproxFontMetrics)
+                    .unwrap()
+                    .pages
+                    .len(),
+                "LOCKSTEP"
+            );
+            assert_eq!(block_pages(&doc, &ApproxFontMetrics)[0], vec![0, 0]);
+        }
+    }
+
+    #[test]
+    fn table_anchor_is_zero_but_real_spacer_and_page_break_are_owned() {
+        use crate::LayoutEngine;
+
+        let anchor = Paragraph {
+            is_table_anchor: true,
+            ..Default::default()
+        };
+        let without_anchor = doc_with(vec![
+            Block::Table(one_cell_table(0)),
+            Block::Table(one_cell_table(0)),
+        ]);
+        let with_anchor = doc_with(vec![
+            Block::Table(one_cell_table(0)),
+            Block::Paragraph(anchor.clone()),
+            Block::Table(one_cell_table(0)),
+        ]);
+        assert_eq!(
+            top_level_table_tops(&without_anchor),
+            top_level_table_tops(&with_anchor),
+            "a pure host anchor contributes no line"
+        );
+
+        let with_spacer = doc_with(vec![
+            Block::Table(one_cell_table(0)),
+            Block::Paragraph(para("")),
+            Block::Table(one_cell_table(0)),
+        ]);
+        let spacer_tables = top_level_table_tops(&with_spacer);
+        let spacer_placed = place_doc(&with_spacer, &ApproxFontMetrics);
+        let spacer_band = spacer_placed.pages[0]
+            .blocks
+            .iter()
+            .find(|block| block.block == 1)
+            .expect("real blank spacer has a provenance band");
+        assert_eq!(
+            spacer_tables[1].0 - (spacer_tables[0].0 + spacer_tables[0].1),
+            spacer_band.h,
+        );
+
+        let break_anchor = Paragraph {
+            is_table_anchor: true,
+            page_break_before: true,
+            ..Default::default()
+        };
+        let page_break = doc_with(vec![
+            Block::Table(one_cell_table(0)),
+            Block::Paragraph(break_anchor),
+            Block::Table(table_with_margins(700, 0)),
+        ]);
+        let placed = place_doc(&page_break, &ApproxFontMetrics);
+        let naive = crate::NaiveLayout
+            .layout(&page_break, &ApproxFontMetrics)
+            .unwrap();
+        assert_eq!(placed.pages.len(), 2);
+        assert_eq!(placed.pages.len(), naive.pages.len(), "LOCKSTEP");
+        assert_eq!(placed.pages[1].tables[0].y, 7_200.0);
+        assert_eq!(
+            block_pages(&page_break, &ApproxFontMetrics)[0],
+            vec![0, 1, 1]
+        );
+    }
+
     #[test]
     fn placed_blocks_resolve_point_to_the_right_block() {
         // Two paragraphs framing a table: every top-level block must get exactly one provenance band

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,6 +3,25 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
+- 갱신: 2026-08-25 · Codex(sol) — **#225 원인 단일화·회귀 계약·full 검증 완료, PR 직전**.
+  #223 head `bc6b2f5`의 CI 3종 green·댓글/review 0 뒤 main `edb6ac94` 병합, #93/#114 동기화,
+  #225 issue-first/exact-main worktree 착수. canonical page4 candidate/reference 첫 표 ink span은
+  143–206/143–205px로 높이 문제가 아니고 둘째 표
+  시작만 210→229px(+19)이다. raw HWP5 anchor는 page4/5 첫 line `(vertical=0,height=3285,
+  spacing=960)` 다음 line `vertical=4245`; page1은 `(0,2130,452)`→`2582`라 #223의 +19/+9px와
+  exact 단위 변환(HWPUNIT/50 at 144 DPI)으로 맞는다. own/rhwp/production의 모든 top-level table
+  margin·placed geometry는 exact이며 current delta는 page1 1989(owned 2441 대비 -452), page4/5
+  3286(owned 4246 대비 -960)이다. 즉 margin parse/table height가 아니라 host anchor의 stored
+  `line_spacing` 소실이다. synthetic은 margin sum vs max/collapse, zero/top/bottom/both, anchor=0,
+  real spacer, page break + place/Naive/block_pages LOCKSTEP을 잠갔고 HWPX 두 표는 explicit margins만
+  소유하고 source anchor metric이 없음을 분리했다. focused 5종과 full의 Rust workspace/rhwp/AI120/
+  8·18·24+98.9%/oracle82/wasm/licenses/JS build/Vitest1,012가 모두 green이다. 샌드박스 포트 EPERM 뒤
+  권한 환경 Chromium도 **83 pass·3 intentional skip·2 retry-pass**(기존 타이밍 계열)다. production
+  조판·score/threshold는 무변경이고 rhwp `f137b4c9`도 clean이다. **다음:** diff/privacy/vendor 감사→
+  commit/push/PR `Closes #225`→CI/merge 후,
+  HWP5 source anchor spacing을 별도 IR 축으로 owned parse→rhwp base enrichment→세 LOCKSTEP 경로에
+  fail-closed 연결하는 renderer child. HWPX anchor skip, rhwp vendor, scores/threshold는 불변.
+
 - 갱신: 2026-08-25 · Codex(sol) — **#223 report-only vertical-transition trace 구현·canonical 진단**.
   fixed page alignment 뒤 text/table의 row-ink profile만 ±128px에서 비교하고 active-row F1→row-count
   cosine 순으로 unique=`hypothesis`, exact tie=`ambiguous`, 증거 없음/예산 초과=`unscorable`로 낸다.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,12 @@
 
 ---
 
+## 2026-08-25 (Codex sol) · #225 HWP5 table-anchor spacing ownership
+- page1/4/5의 +9/+19/+19px 누락이 raw host `line_spacing` 452/960/960 HWPUNIT와 exact임을 격리.
+- margins/table geometry는 owned·rhwp·production exact; HWPX는 explicit margins만 소유함을 분리.
+- full green: 8/18/24+98.9%, AI120, oracle82, Vitest1,012, Chromium83 pass/3 skip/2 retry-pass.
+- 다음: 진단 PR/CI/merge→HWP5-only spacing IR·owned/rhwp enrichment·LOCKSTEP renderer child.
+
 ## 2026-08-25 (Codex sol) · #223 vertical-transition trace
 - fixed alignment의 row-ink profile로 ±128px offset/transition 가설을 bounded·content-free하게 추가.
 - canonical은 SHA·scores 불변, unique/tie 55/5; page4/5 첫 table transition이 0→+17/+19px.

--- a/docs/PDF-VISUAL-ORACLE.md
+++ b/docs/PDF-VISUAL-ORACLE.md
@@ -523,6 +523,28 @@ text rows often repeat and therefore do not yet identify a safe renderer formula
 separate consecutive-table/anchor-spacing investigation; it does not justify changing table height,
 paragraph line metrics, or font realization in #223.
 
+### HWP5 table-anchor spacing ownership (2026-08-25, #225)
+
+The #223 transition was decomposed without changing placement. On canonical page 4, the candidate
+and reference first-table ink spans are rows 143–206 and 143–205, while the second table begins on
+rows 210 and 229. The first table's height is therefore not the missing 19-pixel increment.
+
+Content-free HWP5 `PARA_LINE_SEG` evidence identifies the exact source-owned distance. On pages 4 and
+5, the first table host has `(vertical_pos=0, line_height=3285, line_spacing=960)` and the next host
+starts at `vertical_pos=4245`; on page 1 the corresponding values are `(0, 2130, 452)` and `2582`.
+At the report's 144 DPI, 960 and 452 HWPUNIT are 19.2 and 9.04 pixels—the observed +19 and +9
+transition increments. The production layout instead advances only by table height plus the preceding
+bottom and following top margins: 3,286 rather than 4,246 HWPUNIT on pages 4/5, and 1,989 rather than
+2,441 on page 1.
+
+The strict owned HWP5 parser, rhwp-base lift, and production-enriched document have identical
+top-level table margins and placed table geometry, so this is neither margin parse loss nor an
+own-vs-rhwp discrepancy. Synthetic tests separately pin summed (not collapsed) table margins, a
+zero-height pure anchor, a real blank spacer, fresh-page behavior, and `place_doc`/`NaiveLayout`/
+`block_pages` page ownership. An owned HWPX pair retains only its explicit outer margins and carries
+no source anchor-line metric, so HWPX's established zero-height anchor contract must not inherit this
+HWP5-only source evidence. A renderer fix belongs in a separate child and must preserve that boundary.
+
 ## Tests
 
 Run the dependency-free synthetic metric and PNG codec suite with:


### PR DESCRIPTION
Closes #225

## Outcome
- proves canonical page 1/4/5 table-start deficits (452/960/960 HWPUNIT) exactly equal the preceding HWP5 host line_spacing
- proves owned HWP5, rhwp lift, and production have identical table margins and placed table geometry
- locks margin sum, zero-height anchor, real spacer, page boundary, and place_doc/NaiveLayout/block_pages ownership
- keeps HWPX explicit-margin evidence separate from HWP5-only source line metrics

## Scope
Diagnostic and regression tests only. No production placement, score, threshold, parser vendor, or external/rhwp change.

## Verification
- focused Rust tests: 5 green
- scripts/verify-local.sh --full: every non-browser stage green, including 8/18/24 + 98.9%, AI120, oracle82, wasm, licenses, JS builds, and Vitest 1,012
- Chromium outside sandbox: 83 passed, 3 intentional skipped, 2 retry-passed timing flakes