### PR TITLE
fix(hwp5): preserve source-adjacent table spacing

### DIFF
--- a/crates/hwp-core/src/lib.rs
+++ b/crates/hwp-core/src/lib.rs
@@ -32,8 +32,8 @@ impl Engine {
             }
             SourceFormat::Hwp5 => {
                 // Bootstrap body decode remains on governed rhwp. A strict first-party parse may
-                // enrich only page-number metadata that rhwp omitted; unsupported/conflicting input
-                // is an atomic no-op, never a hidden parser cutover.
+                // Enrich only strictly owned render metadata that rhwp omitted; unsupported/conflicting
+                // input is an atomic no-op for each axis, never a hidden parser cutover.
                 let mut d = RhwpEngine::new().parse(bytes, fmt)?;
                 enrich_hwp5_owned_page_numbers(bytes, &mut d);
                 d
@@ -63,6 +63,7 @@ fn enrich_hwp5_owned_page_numbers(bytes: &[u8], target: &mut SemanticDoc) {
         return;
     };
     merge_owned_page_numbers(target, &owned);
+    merge_owned_table_anchor_spacings(target, &owned);
 }
 
 fn merge_owned_page_numbers(target: &mut SemanticDoc, owned: &SemanticDoc) -> bool {
@@ -84,6 +85,142 @@ fn merge_owned_page_numbers(target: &mut SemanticDoc, owned: &SemanticDoc) -> bo
         if target.page_number.is_none() {
             target.page_number = owned.page_number;
         }
+    }
+    true
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct TableTopology {
+    rows: usize,
+    cols: usize,
+    cells: Vec<(usize, usize, usize, usize, bool, Option<HwpUnit>)>,
+    col_widths: Vec<HwpUnit>,
+    row_heights: Vec<HwpUnit>,
+    margins: [HwpUnit; 4],
+}
+
+fn visit_tables<'a>(blocks: &'a [Block], output: &mut Vec<&'a Table>) {
+    for block in blocks {
+        match block {
+            Block::Paragraph(paragraph) => {
+                for run in &paragraph.runs {
+                    for inline in &run.content {
+                        if let Inline::Note(note) = inline {
+                            visit_tables(&note.body, output);
+                        }
+                    }
+                }
+            }
+            Block::Table(table) => {
+                output.push(table);
+                if let Some(caption) = &table.caption {
+                    visit_tables(&caption.blocks, output);
+                }
+                for cell in &table.cells {
+                    visit_tables(&cell.blocks, output);
+                }
+            }
+        }
+    }
+}
+
+fn section_table_topology(section: &Section) -> Vec<TableTopology> {
+    let mut tables = Vec::new();
+    visit_tables(&section.blocks, &mut tables);
+    tables
+        .into_iter()
+        .map(|table| TableTopology {
+            rows: table.rows,
+            cols: table.cols,
+            cells: table
+                .cells
+                .iter()
+                .map(|cell| {
+                    (
+                        cell.row,
+                        cell.col,
+                        cell.row_span,
+                        cell.col_span,
+                        cell.active,
+                        cell.width,
+                    )
+                })
+                .collect(),
+            col_widths: table.col_widths.clone(),
+            row_heights: table.row_heights.clone(),
+            margins: [
+                table.outer_margin_left,
+                table.outer_margin_right,
+                table.outer_margin_top,
+                table.outer_margin_bottom,
+            ],
+        })
+        .collect()
+}
+
+fn visit_table_spacings_mut(blocks: &mut [Block], spacings: &mut impl Iterator<Item = HwpUnit>) {
+    for block in blocks {
+        match block {
+            Block::Paragraph(paragraph) => {
+                for run in &mut paragraph.runs {
+                    for inline in &mut run.content {
+                        if let Inline::Note(note) = inline {
+                            visit_table_spacings_mut(&mut note.body, spacings);
+                        }
+                    }
+                }
+            }
+            Block::Table(table) => {
+                table.source_anchor_spacing_after = spacings
+                    .next()
+                    .expect("table topology validated before mutation");
+                if let Some(caption) = &mut table.caption {
+                    visit_table_spacings_mut(&mut caption.blocks, spacings);
+                }
+                for cell in &mut table.cells {
+                    visit_table_spacings_mut(&mut cell.blocks, spacings);
+                }
+            }
+        }
+    }
+}
+
+/// Copy strictly owned HWP5 table-host spacing only after every section/table signature and every
+/// pre-existing typed value is compatible. Validation completes before the first mutation.
+fn merge_owned_table_anchor_spacings(target: &mut SemanticDoc, owned: &SemanticDoc) -> bool {
+    if target.sections.len() != owned.sections.len() {
+        return false;
+    }
+    let mut owned_by_section = Vec::with_capacity(owned.sections.len());
+    for (target_section, owned_section) in target.sections.iter().zip(&owned.sections) {
+        if section_table_topology(target_section) != section_table_topology(owned_section) {
+            return false;
+        }
+        let mut target_tables = Vec::new();
+        let mut owned_tables = Vec::new();
+        visit_tables(&target_section.blocks, &mut target_tables);
+        visit_tables(&owned_section.blocks, &mut owned_tables);
+        if target_tables
+            .iter()
+            .zip(&owned_tables)
+            .any(|(target, owned)| {
+                target.source_anchor_spacing_after != 0
+                    && target.source_anchor_spacing_after != owned.source_anchor_spacing_after
+            })
+        {
+            return false;
+        }
+        owned_by_section.push(
+            owned_tables
+                .iter()
+                .map(|table| table.source_anchor_spacing_after)
+                .collect::<Vec<_>>(),
+        );
+    }
+    for (section, spacings) in target.sections.iter_mut().zip(owned_by_section) {
+        let mut spacings = spacings.into_iter();
+        visit_table_spacings_mut(&mut section.blocks, &mut spacings);
+        debug_assert!(spacings.next().is_none());
     }
     true
 }
@@ -180,6 +317,21 @@ mod hwp5_candidate_tests {
         }
     }
 
+    fn table_doc(rows: usize, spacing: HwpUnit) -> SemanticDoc {
+        SemanticDoc {
+            sections: vec![Section {
+                blocks: vec![Block::Table(Table {
+                    rows,
+                    cols: 1,
+                    source_anchor_spacing_after: spacing,
+                    ..Table::default()
+                })],
+                ..Section::default()
+            }],
+            ..SemanticDoc::default()
+        }
+    }
+
     #[test]
     fn page_number_merge_is_atomic_for_topology_partial_and_typed_conflicts() {
         let first = number(1, PageNumberPosition::BottomCenter);
@@ -219,6 +371,50 @@ mod hwp5_candidate_tests {
             open_hwp5_own(&benchmark()).unwrap().sections[0].page_number
         );
         assert!(doc.sections[0].page_number.is_some());
+    }
+
+    #[test]
+    fn table_anchor_spacing_merge_is_atomic_for_topology_and_typed_conflicts() {
+        let owned = table_doc(1, 300);
+
+        let mut topology = table_doc(2, 0);
+        assert!(!merge_owned_table_anchor_spacings(&mut topology, &owned));
+        let Block::Table(table) = &topology.sections[0].blocks[0] else {
+            unreachable!()
+        };
+        assert_eq!(table.source_anchor_spacing_after, 0);
+
+        let mut conflict = table_doc(1, 200);
+        assert!(!merge_owned_table_anchor_spacings(&mut conflict, &owned));
+        let Block::Table(table) = &conflict.sections[0].blocks[0] else {
+            unreachable!()
+        };
+        assert_eq!(table.source_anchor_spacing_after, 200);
+
+        let mut compatible = table_doc(1, 0);
+        assert!(merge_owned_table_anchor_spacings(&mut compatible, &owned));
+        let Block::Table(table) = &compatible.sections[0].blocks[0] else {
+            unreachable!()
+        };
+        assert_eq!(table.source_anchor_spacing_after, 300);
+    }
+
+    #[test]
+    fn production_hwp5_open_enriches_owned_anchor_spacing_without_rhwp_ownership() {
+        let bytes = benchmark();
+        let owned = open_hwp5_own(&bytes).unwrap();
+        let rhwp = RhwpEngine::new().parse(&bytes, SourceFormat::Hwp5).unwrap();
+        let production = Engine::open(&bytes).unwrap();
+        let spacing = |doc: &SemanticDoc, block: usize| match &doc.sections[0].blocks[block] {
+            Block::Table(table) => table.source_anchor_spacing_after,
+            Block::Paragraph(_) => panic!("expected canonical table block"),
+        };
+
+        for (block, expected) in [(1, 452), (15, 960), (32, 960)] {
+            assert_eq!(spacing(&owned, block), expected);
+            assert_eq!(spacing(&rhwp, block), 0, "rhwp lift is not the owner");
+            assert_eq!(spacing(&production, block), expected);
+        }
     }
 
     #[test]

--- a/crates/hwp-core/tests/hwp5_empty_run_layout.rs
+++ b/crates/hwp-core/tests/hwp5_empty_run_layout.rs
@@ -151,6 +151,31 @@ fn same_glyph_paint(left: &PlacedDoc, right: &PlacedDoc) -> bool {
     })
 }
 
+fn clear_anchor_spacing(blocks: &mut [Block]) {
+    for block in blocks {
+        match block {
+            Block::Paragraph(paragraph) => {
+                for run in &mut paragraph.runs {
+                    for inline in &mut run.content {
+                        if let Inline::Note(note) = inline {
+                            clear_anchor_spacing(&mut note.body);
+                        }
+                    }
+                }
+            }
+            Block::Table(table) => {
+                table.source_anchor_spacing_after = 0;
+                if let Some(caption) = &mut table.caption {
+                    clear_anchor_spacing(&mut caption.blocks);
+                }
+                for cell in &mut table.cells {
+                    clear_anchor_spacing(&mut cell.blocks);
+                }
+            }
+        }
+    }
+}
+
 #[test]
 fn benchmark_empty_run_deltas_are_content_free_and_layout_classified() {
     let bytes = std::fs::read(concat!(
@@ -235,24 +260,41 @@ fn benchmark_empty_run_deltas_are_content_free_and_layout_classified() {
     let candidate_placed = place_doc(&candidate, &ApproxFontMetrics);
     let oracle_placed = place_doc(&oracle, &ApproxFontMetrics);
     let production_placed = place_doc(&production, &ApproxFontMetrics);
-    let typed_delta = compare_placed_docs(&candidate_placed, &oracle_placed);
+    // This test owns only empty-run/page-number classification. Remove the independently owned #227
+    // table-anchor axis when comparing the strict parser to the deliberately unenriched rhwp base.
+    let mut candidate_without_anchor_spacing = candidate.clone();
+    for section in &mut candidate_without_anchor_spacing.sections {
+        clear_anchor_spacing(&mut section.blocks);
+    }
+    let candidate_oracle_placed = place_doc(&candidate_without_anchor_spacing, &ApproxFontMetrics);
+    let typed_delta = compare_placed_docs(&candidate_oracle_placed, &oracle_placed);
     assert_eq!(candidate_placed.pages.len(), 8);
-    assert_eq!(candidate_placed.pages.len(), oracle_placed.pages.len());
-    for (candidate_page, oracle_page) in candidate_placed.pages.iter().zip(&oracle_placed.pages) {
+    assert_eq!(
+        candidate_oracle_placed.pages.len(),
+        oracle_placed.pages.len()
+    );
+    for (candidate_page, oracle_page) in candidate_oracle_placed
+        .pages
+        .iter()
+        .zip(&oracle_placed.pages)
+    {
         assert_eq!(candidate_page.blocks.len(), oracle_page.blocks.len());
         assert_eq!(candidate_page.tables.len(), oracle_page.tables.len());
         assert_eq!(candidate_page.rects.len(), oracle_page.rects.len());
         assert_eq!(candidate_page.lines.len(), oracle_page.lines.len());
     }
     assert!(same_page_and_block_geometry(
-        &candidate_placed,
+        &candidate_oracle_placed,
         &oracle_placed
     ));
-    assert!(same_table_geometry(&candidate_placed, &oracle_placed));
-    assert!(same_rect_geometry(&candidate_placed, &oracle_placed));
-    assert!(same_line_geometry(&candidate_placed, &oracle_placed));
+    assert!(same_table_geometry(
+        &candidate_oracle_placed,
+        &oracle_placed
+    ));
+    assert!(same_rect_geometry(&candidate_oracle_placed, &oracle_placed));
+    assert!(same_line_geometry(&candidate_oracle_placed, &oracle_placed));
     assert_eq!(
-        candidate_placed
+        candidate_oracle_placed
             .pages
             .iter()
             .map(|page| page.glyphs.len())

--- a/crates/hwp-core/tests/hwp5_table_spacing_ownership.rs
+++ b/crates/hwp-core/tests/hwp5_table_spacing_ownership.rs
@@ -53,7 +53,7 @@ fn assert_same_table_geometry(left: &PlacedDoc, right: &PlacedDoc) {
 }
 
 #[test]
-fn benchmark_anchor_spacing_loss_is_not_a_margin_or_parser_delta() {
+fn benchmark_anchor_spacing_is_owned_without_changing_margin_or_table_geometry() {
     let bytes = std::fs::read(concat!(
         env!("CARGO_MANIFEST_DIR"),
         "/../../benchmarks/benchmark.hwp"
@@ -68,9 +68,33 @@ fn benchmark_anchor_spacing_loss_is_not_a_margin_or_parser_delta() {
     let owned_placed = place_doc(&owned, &ApproxFontMetrics);
     let rhwp_placed = place_doc(&rhwp, &ApproxFontMetrics);
     let production_placed = place_doc(&production, &ApproxFontMetrics);
-    assert_same_table_geometry(&owned_placed, &rhwp_placed);
+    let positive_spacing: Vec<_> = production.sections[0]
+        .blocks
+        .iter()
+        .enumerate()
+        .filter_map(|(block, value)| match value {
+            Block::Table(table) if table.source_anchor_spacing_after > 0 => {
+                Some((block, table.source_anchor_spacing_after))
+            }
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        positive_spacing,
+        vec![
+            (1, 452),
+            (15, 960),
+            (32, 960),
+            (52, 900),
+            (58, 900),
+            (62, 960)
+        ]
+    );
     assert_same_table_geometry(&owned_placed, &production_placed);
 
+    let rhwp_page1 = top_level_tables(&rhwp_placed, 0);
+    let rhwp_page4 = top_level_tables(&rhwp_placed, 3);
+    let rhwp_page5 = top_level_tables(&rhwp_placed, 4);
     let page1 = top_level_tables(&production_placed, 0);
     let page4 = top_level_tables(&production_placed, 3);
     let page5 = top_level_tables(&production_placed, 4);
@@ -79,19 +103,22 @@ fn benchmark_anchor_spacing_loss_is_not_a_margin_or_parser_delta() {
     assert_eq!((page5[0].0, page5[1].0), (32, 34));
 
     let placed_delta = |tables: &[(usize, f64, f64)]| tables[1].1 - tables[0].1;
-    assert_eq!(placed_delta(&page1), 1_989.0);
-    assert_eq!(placed_delta(&page4), 3_286.0);
-    assert_eq!(placed_delta(&page5), 3_286.0);
+    assert_eq!(placed_delta(&rhwp_page1), 1_989.0);
+    assert_eq!(placed_delta(&rhwp_page4), 3_286.0);
+    assert_eq!(placed_delta(&rhwp_page5), 3_286.0);
+    assert_eq!(placed_delta(&page1), 2_441.0);
+    assert_eq!(placed_delta(&page4), 4_246.0);
+    assert_eq!(placed_delta(&page5), 4_246.0);
 
     // Raw HWP5 PARA_LINE_SEG evidence is pinned independently in hwp-rhwp's
     // table_anchor_spacing test. It predicts 2,441 / 4,246 / 4,246 HWPUNIT
     // between table tops. The exact deficits are the preceding anchor line's
     // stored line_spacing, not a table margin or parser disagreement.
-    assert_eq!(2_441.0 - placed_delta(&page1), 452.0);
-    assert_eq!(4_246.0 - placed_delta(&page4), 960.0);
-    assert_eq!(4_246.0 - placed_delta(&page5), 960.0);
+    assert_eq!(placed_delta(&page1) - placed_delta(&rhwp_page1), 452.0);
+    assert_eq!(placed_delta(&page4) - placed_delta(&rhwp_page4), 960.0);
+    assert_eq!(placed_delta(&page5) - placed_delta(&rhwp_page5), 960.0);
 
     println!(
-        "hwp5-table-spacing.v1 parsers=exact page1_missing=452 page4_missing=960 page5_missing=960 cause=anchor_line_spacing"
+        "hwp5-table-spacing.v2 owned_adjacent_hosts=6 page1_added=452 page4_added=960 page5_added=960 owner=first_party_ir"
     );
 }

--- a/crates/hwp-hwp5/src/semantic.rs
+++ b/crates/hwp-hwp5/src/semantic.rs
@@ -956,6 +956,7 @@ fn parse_section(
     let mut has_active_columns = false;
     let mut column_zone_count = 0usize;
     let mut separator_zone_seen = false;
+    let mut pending_table_host: Option<(usize, HostLineMetric)> = None;
     let starts: Vec<usize> = stream
         .records
         .iter()
@@ -1054,8 +1055,15 @@ fn parse_section(
             }
             parsed.paragraph.is_table_anchor = true;
         }
+        let current_host = parsed
+            .paragraph
+            .is_table_anchor
+            .then_some(parsed.host_line)
+            .flatten();
+        attach_source_adjacent_table_spacing(&mut blocks, pending_table_host, current_host);
         blocks.push(Block::Paragraph(parsed.paragraph));
         blocks.extend(parsed.tables.into_iter().map(Block::Table));
+        pending_table_host = current_host.map(|metric| (blocks.len() - 1, metric));
     }
     Ok(Section {
         blocks,
@@ -1074,6 +1082,44 @@ struct ParsedParagraph {
     page: Option<PageSetup>,
     page_number: Option<PageNumberDecoration>,
     tables: Vec<Table>,
+    host_line: Option<HostLineMetric>,
+}
+
+#[derive(Clone, Copy)]
+struct HostLineMetric {
+    vertical_pos: HwpUnit,
+    height: HwpUnit,
+    spacing: HwpUnit,
+}
+
+fn attach_source_adjacent_table_spacing(
+    blocks: &mut [Block],
+    pending: Option<(usize, HostLineMetric)>,
+    current: Option<HostLineMetric>,
+) {
+    let (Some((table_index, previous)), Some(current)) = (pending, current) else {
+        return;
+    };
+    if previous
+        .vertical_pos
+        .checked_add(previous.height)
+        .and_then(|end| end.checked_add(previous.spacing))
+        != Some(current.vertical_pos)
+    {
+        return;
+    }
+    let Some(Block::Table(table)) = blocks.get_mut(table_index) else {
+        unreachable!("pending table host always points at its final table")
+    };
+    table.source_anchor_spacing_after = previous.spacing;
+}
+
+#[derive(Default)]
+struct ParsedLineMetrics {
+    render: Vec<SourceLineMetric>,
+    /// A pure one-line HWP5 table host may own an additional gap after its final hosted table.
+    /// Kept private until the paragraph/control structure proves that it is such a host.
+    single_positive_host_line: Option<HostLineMetric>,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1395,6 +1441,11 @@ fn parse_paragraph(
         &header,
         section,
     )?;
+    let host_line = if decoded.chars.is_empty() && !tables.is_empty() {
+        line_metrics.single_positive_host_line
+    } else {
+        None
+    };
     let paragraph = Paragraph {
         para_shape: para_shape_id + 1,
         page_break_before: break_type & 0x04 != 0,
@@ -1404,7 +1455,7 @@ fn parse_paragraph(
         // Stored line boxes are only an authored-height hint for a true blank spacer.
         // They never dictate line breaks for visible text or a control-host paragraph.
         source_line_metrics: if decoded.chars.is_empty() && decoded.structural_controls.is_empty() {
-            line_metrics
+            line_metrics.render
         } else {
             Vec::new()
         },
@@ -1422,6 +1473,7 @@ fn parse_paragraph(
         page,
         page_number,
         tables,
+        host_line,
     })
 }
 
@@ -3071,10 +3123,10 @@ fn parse_line_metrics(
     decoded: &DecodedText,
     header: &Record,
     section: usize,
-) -> Result<Vec<SourceLineMetric>> {
+) -> Result<ParsedLineMetrics> {
     let Some(record) = record else {
         return if declared == 0 {
-            Ok(Vec::new())
+            Ok(ParsedLineMetrics::default())
         } else {
             Err(malformed(
                 header,
@@ -3102,6 +3154,7 @@ fn parse_line_metrics(
     let mut prior_start = None;
     let mut metrics = Vec::with_capacity(actual);
     let mut all_zero_height = true;
+    let mut single_positive_host_line = None;
     for entry in bytes.chunks_exact(36) {
         let text_start = read_u32(entry, 0).expect("chunk length checked");
         if prior_start.is_some_and(|prior| prior > text_start) {
@@ -3143,6 +3196,13 @@ fn parse_line_metrics(
             ));
         }
         all_zero_height &= height == 0 && text_height == 0;
+        if actual == 1 && height > 0 && line_spacing > 0 {
+            single_positive_host_line = Some(HostLineMetric {
+                vertical_pos,
+                height,
+                spacing: line_spacing,
+            });
+        }
         metrics.push(SourceLineMetric {
             height,
             text_height,
@@ -3151,8 +3211,12 @@ fn parse_line_metrics(
     }
     if all_zero_height {
         metrics.clear();
+        single_positive_host_line = None;
     }
-    Ok(metrics)
+    Ok(ParsedLineMetrics {
+        render: metrics,
+        single_positive_host_line,
+    })
 }
 
 #[derive(Default)]
@@ -3700,6 +3764,45 @@ impl<'a> Reader<'a> {
 #[cfg(test)]
 mod support_pool_tests {
     use super::*;
+
+    #[test]
+    fn source_adjacency_assigns_spacing_only_to_the_final_hosted_table() {
+        let mut blocks = vec![
+            Block::Table(Table::default()),
+            Block::Table(Table::default()),
+        ];
+        let previous = HostLineMetric {
+            vertical_pos: 100,
+            height: 1_000,
+            spacing: 300,
+        };
+        let adjacent = HostLineMetric {
+            vertical_pos: 1_400,
+            height: 1_000,
+            spacing: 200,
+        };
+        attach_source_adjacent_table_spacing(&mut blocks, Some((1, previous)), Some(adjacent));
+        let [Block::Table(first), Block::Table(last)] = blocks.as_slice() else {
+            unreachable!()
+        };
+        assert_eq!(first.source_anchor_spacing_after, 0);
+        assert_eq!(last.source_anchor_spacing_after, 300);
+
+        let mut mismatch = vec![Block::Table(Table::default())];
+        let non_adjacent = HostLineMetric {
+            vertical_pos: 1_401,
+            ..adjacent
+        };
+        attach_source_adjacent_table_spacing(
+            &mut mismatch,
+            Some((0, previous)),
+            Some(non_adjacent),
+        );
+        let Block::Table(table) = &mismatch[0] else {
+            unreachable!()
+        };
+        assert_eq!(table.source_anchor_spacing_after, 0);
+    }
 
     fn record(tag: u16, size: usize) -> Record {
         Record {

--- a/crates/hwp-hwp5/tests/layout_semantic.rs
+++ b/crates/hwp-hwp5/tests/layout_semantic.rs
@@ -613,6 +613,10 @@ fn owns_strict_inline_one_by_one_table_as_anchor_plus_shared_ir() {
     assert!(table.keep_together);
     assert_eq!(table.col_widths, vec![20_000]);
     assert_eq!(table.row_heights, vec![2_000]);
+    assert_eq!(
+        table.source_anchor_spacing_after, 0,
+        "a host without a following source-adjacent table cannot claim its stored spacing"
+    );
     assert_eq!(table.padding, Some([510, 510, 141, 141]));
     assert!(table.borders.iter().all(Option::is_some));
     let cell = &table.cells[0];
@@ -802,6 +806,8 @@ fn owns_two_ordered_tables_in_one_text_empty_host_and_cell_own_padding() {
     assert!(anchor.is_table_anchor);
     assert_eq!((first.rows, first.cols, first.cells.len()), (10, 2, 17));
     assert_eq!((second.rows, second.cols, second.cells.len()), (1, 1, 1));
+    assert_eq!(first.source_anchor_spacing_after, 0);
+    assert_eq!(second.source_anchor_spacing_after, 0);
     assert_eq!(second.cells[0].blocks.len(), 4);
     assert_eq!(second.cells[0].padding, Some([283, 283, 141, 141]));
     assert_eq!(second.cells[0].width, Some(20_000));
@@ -1528,7 +1534,7 @@ fn fixture(mutation: Mutation) -> Vec<u8> {
         } else {
             1
         },
-        0,
+        u16::from(has_table),
         if has_columns {
             0x03
         } else if matches!(mutation, Mutation::ColumnBreakWithoutDefinition) {
@@ -1559,6 +1565,14 @@ fn fixture(mutation: Mutation) -> Vec<u8> {
         shape_refs(&[(0, 0)])
     };
     push_record(&mut body, TAG_PARA_CHAR_SHAPE, 1, &host_shape_refs);
+    if has_table {
+        push_record(
+            &mut body,
+            TAG_PARA_LINE_SEG,
+            1,
+            &line_seg(0, 1_500, 1_200, 900),
+        );
+    }
     let mut section_control = Vec::with_capacity(28);
     section_control.extend_from_slice(&CTRL_SECTION_DEF.to_le_bytes());
     section_control.extend([0; 24]);

--- a/crates/hwp-hwpx/src/parse.rs
+++ b/crates/hwp-hwpx/src/parse.rs
@@ -2815,7 +2815,11 @@ pub(crate) mod tests {
         let tables: Vec<_> = blocks
             .iter()
             .filter_map(|block| match block {
-                Block::Table(table) => Some((table.outer_margin_top, table.outer_margin_bottom)),
+                Block::Table(table) => Some((
+                    table.outer_margin_top,
+                    table.outer_margin_bottom,
+                    table.source_anchor_spacing_after,
+                )),
                 Block::Paragraph(_) => None,
             })
             .collect();
@@ -2829,7 +2833,7 @@ pub(crate) mod tests {
                 Block::Table(_) => None,
             })
             .collect();
-        assert_eq!(tables, vec![(100, 200), (300, 400)]);
+        assert_eq!(tables, vec![(100, 200, 0), (300, 400, 0)]);
         assert_eq!(anchors, vec![(true, 0), (true, 0)]);
     }
 

--- a/crates/hwp-jsx/src/lib.rs
+++ b/crates/hwp-jsx/src/lib.rs
@@ -1189,6 +1189,8 @@ fn parse_table(el: &JsxElement) -> Result<Table> {
             .get("data-omb")
             .and_then(|v| v.parse().ok())
             .unwrap_or(0),
+        // Source-owned HWP5 anchor evidence is not an authorable JSX field.
+        source_anchor_spacing_after: 0,
         // F2 serialization-fidelity fields (054) are not projected into JSX yet (the JSX surface is
         // render/edit-oriented): a JSX round-trip keeps pre-F2 semantics for them (defaults).
         outer_margin_left: 0,

--- a/crates/hwp-model/src/document.rs
+++ b/crates/hwp-model/src/document.rs
@@ -529,6 +529,12 @@ pub struct Table {
     /// consecutive tables abut with no breathing room (the "tables stuck together" artifact).
     pub outer_margin_top: HwpUnit,
     pub outer_margin_bottom: HwpUnit,
+    /// RENDER-IR ONLY (never serialized): binary HWP5 may store an additional authored gap after
+    /// the pure paragraph that hosts this table. The host itself remains a zero-height anchor; this
+    /// field preserves only its positive `PARA_LINE_SEG.line_spacing` evidence. The strict first-party
+    /// HWP5 parser owns the value and production may copy it into an rhwp-base document only after a
+    /// fail-closed table-topology check. HWPX and synthesized tables leave it at zero.
+    pub source_anchor_spacing_after: HwpUnit,
     /// `[start, end)` byte range of this TOP-LEVEL `<hp:tbl>…</hp:tbl>` within
     /// `Section.provenance.raw` (set by the HWPX parser only) — lets the serializer re-emit a
     /// dirty table IN PLACE at its original anchor instead of appending it at the section end

--- a/crates/hwp-typeset/src/lib.rs
+++ b/crates/hwp-typeset/src/lib.rs
@@ -629,7 +629,9 @@ impl LayoutEngine for NaiveLayout {
                                 page,
                             );
                         }
-                        vert += t.outer_margin_bottom.max(0) as f64;
+                        vert += (t.outer_margin_bottom.max(0)
+                            + t.source_anchor_spacing_after.max(0))
+                            as f64;
                     }
                 }
             }
@@ -773,7 +775,11 @@ fn layout_columns(doc: &SemanticDoc, fonts: &dyn FontMetricsProvider) -> LayoutR
                             page,
                         );
                     }
-                    flow.add(table.outer_margin_bottom.max(0) as f64);
+                    flow.add(
+                        (table.outer_margin_bottom.max(0)
+                            + table.source_anchor_spacing_after.max(0))
+                            as f64,
+                    );
                 }
             }
         }
@@ -954,6 +960,9 @@ pub fn unwrap_frame_table(t: &Table) -> Option<(Table, Option<CellEdge>)> {
     }
     if inner.outer_margin_bottom == 0 {
         inner.outer_margin_bottom = t.outer_margin_bottom;
+    }
+    if inner.source_anchor_spacing_after == 0 {
+        inner.source_anchor_spacing_after = t.source_anchor_spacing_after;
     }
     // The outer cell's frame edge (the box around the wrapped table). Prefer a real per-edge border;
     // fall back to a default hairline only when the cell merely flags a legacy box.

--- a/crates/hwp-typeset/src/place.rs
+++ b/crates/hwp-typeset/src/place.rs
@@ -541,7 +541,8 @@ pub fn place_doc(doc: &SemanticDoc, fonts: &dyn FontMetricsProvider) -> PlacedDo
                     // vert>body_h and resolved by the NEXT block's page reserve — IDENTICAL to
                     // NaiveLayout, keeping the two page counts in lockstep (a `while vert>body_h` here
                     // would re-fragment an over-tall row that NaiveLayout leaves whole → page drift).
-                    vert += t.outer_margin_bottom.max(0) as f64;
+                    vert += (t.outer_margin_bottom.max(0) + t.source_anchor_spacing_after.max(0))
+                        as f64;
                     started = true;
                 }
             }
@@ -729,7 +730,11 @@ fn place_doc_columns(doc: &SemanticDoc, fonts: &dyn FontMetricsProvider) -> Plac
                             });
                         }
                     }
-                    flow.add(table.outer_margin_bottom.max(0) as f64);
+                    flow.add(
+                        (table.outer_margin_bottom.max(0)
+                            + table.source_anchor_spacing_after.max(0))
+                            as f64,
+                    );
                     started = true;
                 }
             }
@@ -950,7 +955,8 @@ pub fn block_pages(doc: &SemanticDoc, fonts: &dyn FontMetricsProvider) -> Vec<Ve
                             &mut vert,
                         );
                     }
-                    vert += t.outer_margin_bottom.max(0) as f64;
+                    vert += (t.outer_margin_bottom.max(0) + t.source_anchor_spacing_after.max(0))
+                        as f64;
                     // No trailing page-slice (matches place_doc/NaiveLayout): a leftover over-tall row /
                     // margin spill is resolved by the next block's reserve, so the recorded start pages
                     // stay aligned with place_doc's fragment pages.
@@ -1200,7 +1206,11 @@ fn block_pages_columns(doc: &SemanticDoc, fonts: &dyn FontMetricsProvider) -> Ve
                             &mut page_index,
                         );
                     }
-                    flow.add(table.outer_margin_bottom.max(0) as f64);
+                    flow.add(
+                        (table.outer_margin_bottom.max(0)
+                            + table.source_anchor_spacing_after.max(0))
+                            as f64,
+                    );
                     started = true;
                 }
             }
@@ -5430,6 +5440,80 @@ mod tests {
     }
 
     #[test]
+    fn hwp5_anchor_spacing_is_added_once_and_does_not_carry_to_a_fresh_lane() {
+        use crate::LayoutEngine;
+
+        let mut first = table_with_margins(0, 300);
+        first.source_anchor_spacing_after = 700;
+        let doc = doc_with(vec![
+            Block::Table(first),
+            Block::Table(table_with_margins(500, 0)),
+        ]);
+        let tables = top_level_table_tops(&doc);
+        assert_eq!(
+            tables[1].0 - (tables[0].0 + tables[0].1),
+            1_500.0,
+            "bottom margin + source anchor spacing + next top margin, exactly once"
+        );
+        assert_eq!(
+            place_doc(&doc, &ApproxFontMetrics).pages.len(),
+            crate::NaiveLayout
+                .layout(&doc, &ApproxFontMetrics)
+                .unwrap()
+                .pages
+                .len(),
+            "LOCKSTEP"
+        );
+
+        let mut overflowing = one_cell_table(0);
+        overflowing.row_heights = vec![1_000];
+        overflowing.source_anchor_spacing_after = 2_000;
+        let mut following = one_cell_table(0);
+        following.row_heights = vec![1_000];
+        let fresh_page = doc_with_page(
+            vec![
+                Block::Table(overflowing.clone()),
+                Block::Table(following.clone()),
+            ],
+            2_500,
+        );
+        let placed = place_doc(&fresh_page, &ApproxFontMetrics);
+        let naive = crate::NaiveLayout
+            .layout(&fresh_page, &ApproxFontMetrics)
+            .unwrap();
+        assert_eq!(placed.pages.len(), 2);
+        assert_eq!(placed.pages.len(), naive.pages.len(), "LOCKSTEP");
+        assert_eq!(placed.pages[1].tables[0].y, 0.0, "spacing is not carried");
+        assert_eq!(block_pages(&fresh_page, &ApproxFontMetrics)[0], vec![0, 1]);
+
+        let column_anchor = Paragraph {
+            is_table_anchor: true,
+            column_layout_before: Some(ColumnLayout {
+                widths: vec![10_000, 10_000],
+                gaps: vec![1_000],
+                ..ColumnLayout::default()
+            }),
+            ..Paragraph::default()
+        };
+        let columns = doc_with_page(
+            vec![
+                Block::Paragraph(column_anchor),
+                Block::Table(overflowing),
+                Block::Table(following),
+            ],
+            2_500,
+        );
+        let placed = place_doc(&columns, &ApproxFontMetrics);
+        let naive = crate::NaiveLayout
+            .layout(&columns, &ApproxFontMetrics)
+            .unwrap();
+        assert_eq!(placed.pages.len(), 1);
+        assert_eq!(placed.pages.len(), naive.pages.len(), "column LOCKSTEP");
+        assert!(placed.pages[0].tables[1].x > placed.pages[0].tables[0].x);
+        assert_eq!(block_pages(&columns, &ApproxFontMetrics)[0], vec![0, 0, 0]);
+    }
+
+    #[test]
     fn table_anchor_is_zero_but_real_spacer_and_page_break_are_owned() {
         use crate::LayoutEngine;
 
@@ -5474,8 +5558,10 @@ mod tests {
             page_break_before: true,
             ..Default::default()
         };
+        let mut before_break = one_cell_table(0);
+        before_break.source_anchor_spacing_after = 700;
         let page_break = doc_with(vec![
-            Block::Table(one_cell_table(0)),
+            Block::Table(before_break),
             Block::Paragraph(break_anchor),
             Block::Table(table_with_margins(700, 0)),
         ]);

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,6 +3,27 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
+- 갱신: 2026-08-25 · Codex(sol) — **#227 first-party HWP5 anchor spacing 구현·시각 실증·quick green**.
+  #225 exact head `d170b00`은 issue-link **3s**·licenses **8m52s**·build-test **9m42s** green,
+  MERGEABLE, 댓글/review 0으로 protected main `f8c3ccd`에 squash 병합됐다. #225는 close되고 원격
+  branch도 삭제했으며 #93/#114를 content-free 결과로 동기화했다. 후속 P0 #227을 issue-first로
+  등재하고 exact main worktree `codex/issue-227-anchor-spacing`을 만들었다. `Table`에 render-only
+  source spacing-after 축을 추가했으나 **양수만으로 적용하자 8→9쪽이 된 반례**를 즉시 폐기했다.
+  확정 계약은 strict owned parser가 one-line host의 다음 pure-table host 시작점이 정확히
+  `vertical+height+spacing`일 때만 마지막 hosted table에 귀속하는 것이다. production rhwp-base에는
+  whole-document strict parse + section/table/cell topology·typed conflict 전수 검증 뒤 atomic 보강하고
+  rhwp lift 자체는 0이라 소유권이 우리 엔진에 있다. HWPX/synth/non-adjacent는 0이다. 간격은
+  place/Naive/block_pages/columns에 exact once로 연결했고 page/lane carry를 기존 overflow reserve로
+  억제한다. canonical은 6개 source-adjacent host를 소유하며 8쪽 유지, page1/4/5 table transition이
+  **+9/+17/+19→0/0/0px**. page ink F1은 1 `+.062901`, 4 `+.134124`, 5 `+.186803`, 6 `+.407532`,
+  7 `+.128682`; page3 `-.000397`, page8 `-.002868`은 정직한 잔여다. 독립 2회 candidate SHA
+  `61ab5f3a…`·report SHA `45a91035…` exact, 60 regions/42 intentional blank·T3/`pass=null` 불변.
+  quick과 full은 8/18/24+98.9%, AI120, oracle82, Rust/rhwp/wasm/licenses, JS build,
+  Vitest **1,012** 전부 green이다. 샌드박스 포트 EPERM 뒤 권한 환경 Chromium도 **84 pass·3
+  intentional skip·1 retry-pass**이며, 재시도는 기존 image-insert toast timing flake다. rhwp
+  `f137b4c9`는 clean이다. **다음:** final diff/privacy/vendor 감사→commit/push→PR `Closes #227`→
+  exact-head CI/comments green 자율 병합→#93/#114 동기화→다음 visual residual을 issue-first 격리.
+
 - 갱신: 2026-08-25 · Codex(sol) — **#225 원인 단일화·회귀 계약·full 검증 완료, PR 직전**.
   #223 head `bc6b2f5`의 CI 3종 green·댓글/review 0 뒤 main `edb6ac94` 병합, #93/#114 동기화,
   #225 issue-first/exact-main worktree 착수. canonical page4 candidate/reference 첫 표 ink span은

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,12 @@
 
 ---
 
+## 2026-08-25 (Codex sol) · #227 first-party HWP5 anchor spacing
+- 양수-only 가설의 9쪽 반례를 폐기하고 strict next-host source adjacency만 소유하도록 고정.
+- rhwp base에 atomic owned enrichment, HWPX/synth=0, 모든 LOCKSTEP 경로 exact once를 구현.
+- 8쪽 유지·page1/4/5 transition +9/+17/+19→0; 독립 PDF/report SHA exact, threshold 불변.
+- full green: AI120·oracle82·Vitest1,012·Chromium84 pass/3 skip/1 retry-pass. 다음: PR/CI/merge→잔차 child.
+
 ## 2026-08-25 (Codex sol) · #225 HWP5 table-anchor spacing ownership
 - page1/4/5의 +9/+19/+19px 누락이 raw host `line_spacing` 452/960/960 HWPUNIT와 exact임을 격리.
 - margins/table geometry는 owned·rhwp·production exact; HWPX는 explicit margins만 소유함을 분리.

--- a/docs/PDF-VISUAL-ORACLE.md
+++ b/docs/PDF-VISUAL-ORACLE.md
@@ -545,6 +545,32 @@ zero-height pure anchor, a real blank spacer, fresh-page behavior, and `place_do
 no source anchor-line metric, so HWPX's established zero-height anchor contract must not inherit this
 HWP5-only source evidence. A renderer fix belongs in a separate child and must preserve that boundary.
 
+### First-party source-adjacent anchor spacing (2026-08-25, #227)
+
+The initial implementation deliberately tested the weaker hypothesis “every positive table-host
+`line_spacing` is a post-table gap.” It produced nine candidate pages against the eight-page source and
+was rejected. Positive spacing becomes authoritative only when the immediately following pure table
+host starts at exactly `previous.vertical_pos + previous.line_height + previous.line_spacing`. A page
+reset, ordinary paragraph, missing/multi-line metric, or arithmetic mismatch therefore leaves the
+render-only value at zero. When one host contains multiple table controls, only its final table owns
+the gap.
+
+The strict first-party HWP5 parser owns this evidence. The production rhwp-base document receives it
+only after a whole-document strict parse and validation-before-mutation comparison of section count,
+ordered table/cell topology, stored sizes, and margins. rhwp itself still supplies zero for the new
+axis; HWPX and synthesized tables also remain zero. `place_doc`, `NaiveLayout`, `block_pages`, and the
+column variants consume the same value once, after the table's bottom margin. Overflow advances the
+next block to a fresh page/lane and resets the cursor, so spacing is never carried onto the new lane.
+
+The canonical document contains six such source-adjacent hosts. It remains eight pages, while the
+page 1/4/5 first table transitions move from +9/+17/+19 pixels to 0/0/0. Page ink F1 deltas against the
+#223 report are +0.062901, +0.000087, -0.000397, +0.134124, +0.186803, +0.407532, +0.128682, and
+-0.002868 for pages 1–8 respectively. The two small negative deltas remain visible rather than being
+masked or thresholded. Two independent runs produced byte-identical candidate PDF SHA-256
+`61ab5f3a9329c9d78376813d63cffb62aa9f495962dda5bae97f402baa0789fb` and report SHA-256
+`45a910358e2ebffe4eb906eef6cdcc157546f86a3ce2ee33f5a8ef320d7b7e49`; T3, global alignment,
+scoring, thresholds, and `policy.pass=null` are unchanged.
+
 ## Tests
 
 Run the dependency-free synthetic metric and PNG codec suite with:


### PR DESCRIPTION
Closes #227

## What changed
- add a render-only HWP5 table-anchor spacing axis owned by the strict first-party parser
- accept spacing only when the next pure table host starts at the exact source-adjacent position
- enrich the production rhwp-base document only after whole-document topology and typed-conflict validation
- consume the value exactly once in place_doc, NaiveLayout, block_pages, and column paths; keep HWPX and synthesized tables at zero

## Rejected hypothesis
Applying every positive host line_spacing produced 9 pages for the 8-page canonical document. That weaker rule was rejected; positive spacing alone is not authoritative.

## Visual evidence
- canonical remains 8 pages
- page 1/4/5 first table-transition offsets improve from +9/+17/+19 px to 0/0/0
- page ink F1 deltas: +.062901, +.000087, -.000397, +.134124, +.186803, +.407532, +.128682, -.002868
- two independent runs: candidate SHA 61ab5f3a9329c9d78376813d63cffb62aa9f495962dda5bae97f402baa0789fb; report SHA 45a910358e2ebffe4eb906eef6cdcc157546f86a3ce2ee33f5a8ef320d7b7e49
- score, thresholds, T3, global alignment, and policy.pass=null are unchanged

## Verification
- scripts/verify-local.sh: green
- scripts/verify-local.sh --full: Rust/rhwp/AI120/8-18-24+98.9%/oracle82/wasm/licenses/JS/Vitest 1,012 green
- Chromium: 84 passed, 3 intentional skips, 1 retry-pass from the existing image-insert toast timing flake
- external/rhwp remains pinned and clean at f137b4c9