### PR TITLE
test(pdf): classify text fidelity residuals

### DIFF
--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,6 +3,26 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
+- 갱신: 2026-08-25 · Codex(sol) — **#228 병합 · #229 text residual classifier 착수**.
+  #227 exact head `8b704c51`은 issue-link **2s**·licenses **2m3s**·build-test **9m25s** green,
+  CLEAN/MERGEABLE, 댓글/review 0으로 protected main `91231645`에 squash 병합됐다. #227은 close되고
+  원격 branch도 삭제했으며 #93/#114에 content-free 결과를 동기화했다. Goal의 AI-native #106은
+  main `e0b1c8d`의 deterministic **120-task** suite로 이미 완료 상태임을 재확인했다. 다음 P0 #229를
+  #93 child로 issue-first 등재하고 exact main의 `codex/issue-229-text-residual` worktree를 만들었다.
+  기존 candidate PDF·fixed page alignment·paint-backed text region을 재사용해 positioned ink와
+  ±32px bounded local-translation ink를 비교하는 report-only classifier를 구현했다. 페이지당 50M
+  work cap이며 geometry-dominant/glyph-style-dominant/mixed/ambiguous/unscorable만 낸다. pure move,
+  stroke, mixed, repeat tie, blank, page-edge clip, budget 합성 경계와 comparator Python **69**, Node **8**
+  green. 무등록 canonical 2회는 기존 PDF SHA `61ab5f3a…`, report SHA `077d4f47…`, report HTML SHA
+  `64e9946a…`가 각각 exact이고 8쪽/T3/`pass=null`과 모든 기존 score가 불변이다. paint-backed text
+  28개는 geometry **10**·mixed **9**·ambiguous **8**·unscorable **1**·glyph-style **0**이다. geometry
+  10개는 22 candidate ink pixel의 반복 short-glyph cohort로 local F1 **.954545~.977778**, offsets는
+  page4 `(18,22)`, page5 `(12,22)`, page7 `(12,16)`, page8 `(12,-4)`에 모인다. 폰트 교체보다 이
+  cohort의 generated-marker/field provenance와 x/y placement를 먼저 격리해야 한다. source text/font
+  path·bytes·proprietary name은 공개하지 않았고 layout/rhwp도 불변이다. quick은 Rust/rhwp, AI120,
+  8/18/24+98.9%, public corpus84, oracle82, wasm, licenses 전부 green이다. **다음:** final diff/privacy
+  감사→commit/push→PR `Closes #229`→CI/merge→반복 22px glyph provenance child를 issue-first 착수.
+
 - 갱신: 2026-08-25 · Codex(sol) — **#227 first-party HWP5 anchor spacing 구현·시각 실증·quick green**.
   #225 exact head `d170b00`은 issue-link **3s**·licenses **8m52s**·build-test **9m42s** green,
   MERGEABLE, 댓글/review 0으로 protected main `f8c3ccd`에 squash 병합됐다. #225는 close되고 원격

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,12 @@
 
 ---
 
+## 2026-08-25 (Codex sol) · #229 text residual classifier
+- fixed page alignment 뒤 ±32px/50M bounded local ink로 geometry·glyph-style·mixed·ambiguous를 분리.
+- 합성 경계 7축·Python69·Node8·quick 전체 green; score/threshold/T3/pass/layout/rhwp 불변.
+- canonical 2회 PDF `61ab5f3a…`·report `077d4f47…` exact; text 28=geometry10/mixed9/ambiguous8/unscorable1.
+- 다음: PR/CI/merge→반복 22px short-glyph의 generated-marker/field provenance와 x/y placement 격리.
+
 ## 2026-08-25 (Codex sol) · #227 first-party HWP5 anchor spacing
 - 양수-only 가설의 9쪽 반례를 폐기하고 strict next-host source adjacency만 소유하도록 고정.
 - rhwp base에 atomic owned enrichment, HWPX/synth=0, 모든 LOCKSTEP 경로 exact once를 구현.

--- a/docs/PDF-VISUAL-ORACLE.md
+++ b/docs/PDF-VISUAL-ORACLE.md
@@ -571,6 +571,30 @@ masked or thresholded. Two independent runs produced byte-identical candidate PD
 `45a910358e2ebffe4eb906eef6cdcc157546f86a3ce2ee33f5a8ef320d7b7e49`; T3, global alignment,
 scoring, thresholds, and `policy.pass=null` are unchanged.
 
+### Content-free text residual classification (2026-08-25, #229)
+
+Paint-backed text regions now carry an additive report-only diagnostic that compares their existing
+positioned ink overlap with a bounded local x/y translation. The search is limited to ±32 pixels and
+50 million work units per page. Page-edge clipping, missing or blank ink, repeated equal-best shapes,
+and budget exhaustion remain explicitly unscorable or ambiguous. A high-fidelity recovery with
+similar ink density is geometry-dominant; an already-optimal position with remaining ink-shape
+difference is glyph-style-dominant; partial positional recovery is mixed. These are hypotheses only:
+they do not feed page/region scores, alignment, reference authority, thresholds, or pass policy.
+
+Synthetic fixtures cover pure translation, stroke change, mixed change, repeated ties, blank input,
+clipping, and budget exhaustion. On the canonical unregistered-font pair, 28 paint-backed text regions
+split into 10 geometry-dominant, 9 mixed, 8 ambiguous, and 1 unscorable; none is uniquely
+glyph-style-dominant. The ten geometry cases form a repeated 22-candidate-ink-pixel cohort with local
+ink F1 0.954545–0.977778 and page-clustered offsets: `(18,22)` on page 4, `(12,22)` on page 5,
+`(12,16)` on page 7, and `(12,-4)` on page 8. This supports a next provenance/placement diagnostic for
+the repeated short glyph rather than an immediate font substitution.
+
+Two independent runs preserved the exact #227 candidate PDF SHA-256
+`61ab5f3a9329c9d78376813d63cffb62aa9f495962dda5bae97f402baa0789fb` and produced identical report
+SHA-256 `077d4f47e05cbc618d32e5fadaf6d390f8b54d51e9af1416a014a3f5f3f0e056`. The eight-page structure,
+all prior metrics, T3 labeling, and `policy.pass=null` are unchanged. No source text, glyph strings,
+font paths or bytes, proprietary font names, or document paths are emitted by the diagnostic.
+
 ## Tests
 
 Run the dependency-free synthetic metric and PNG codec suite with:

--- a/scripts/pdf-visual-check.py
+++ b/scripts/pdf-visual-check.py
@@ -94,6 +94,13 @@ VISUAL_REGION_CATEGORIES = frozenset({"text", "table", "image", "object"})
 MAX_VERTICAL_TRACE_PX = 128
 HARD_MAX_VERTICAL_TRACE_WORK_PER_PAGE = 50_000_000
 VERTICAL_TRACE_PROFILE_ROW_COST = 6
+MAX_TEXT_RESIDUAL_TRANSLATION_PX = 32
+HARD_MAX_TEXT_RESIDUAL_WORK_PER_PAGE = 50_000_000
+TEXT_RESIDUAL_GEOMETRY_MIN_F1 = 0.90
+TEXT_RESIDUAL_MATERIAL_GAIN = 0.15
+TEXT_RESIDUAL_MIXED_GAIN = 0.05
+TEXT_RESIDUAL_INK_RATIO_MIN = 0.80
+TEXT_RESIDUAL_INK_RATIO_MAX = 1.25
 
 REFERENCE_TIERS: Mapping[str, str] = {
     "T0": "Licensed Hancom Windows/WebHWP rendering with product, build, and font provenance.",
@@ -2103,6 +2110,264 @@ def _vertical_trace(
     }
 
 
+def _binary_integral(image: GrayImage) -> List[int]:
+    """Return a one-cell-padded summed-area table for thresholded foreground ink."""
+    stride = image.width + 1
+    integral = [0] * (stride * (image.height + 1))
+    for y in range(image.height):
+        row_sum = 0
+        source = y * image.width
+        target = (y + 1) * stride
+        previous = y * stride
+        for x in range(image.width):
+            row_sum += int(image.pixels[source + x] < INK_THRESHOLD)
+            integral[target + x + 1] = integral[previous + x + 1] + row_sum
+    return integral
+
+
+def _integral_rect_count(
+    integral: Sequence[int], stride: int, left: int, top: int, right: int, bottom: int
+) -> int:
+    return (
+        integral[bottom * stride + right]
+        - integral[top * stride + right]
+        - integral[bottom * stride + left]
+        + integral[top * stride + left]
+    )
+
+
+def _text_residual_trace(
+    category: str,
+    paint_status: str,
+    bounds: Optional[Mapping[str, int]],
+    reference: GrayImage,
+    aligned_candidate: GrayImage,
+    alignment_clipped: bool = False,
+    max_work: int = HARD_MAX_TEXT_RESIDUAL_WORK_PER_PAGE,
+    max_translation: int = MAX_TEXT_RESIDUAL_TRANSLATION_PX,
+) -> Dict[str, Any]:
+    """Classify text residuals without changing any scored metric or page alignment."""
+    policy = {
+        "role": "report_only_hypothesis",
+        "search_axis": "bounded_local_xy_translation",
+        "max_abs_offset_px": max_translation,
+        "ink_threshold_gray_lt": INK_THRESHOLD,
+        "geometry_min_local_ink_f1": TEXT_RESIDUAL_GEOMETRY_MIN_F1,
+        "material_local_gain": TEXT_RESIDUAL_MATERIAL_GAIN,
+        "mixed_local_gain": TEXT_RESIDUAL_MIXED_GAIN,
+        "similar_ink_ratio": [
+            TEXT_RESIDUAL_INK_RATIO_MIN,
+            TEXT_RESIDUAL_INK_RATIO_MAX,
+        ],
+    }
+    if category != "text":
+        return {
+            "status": "not-applicable",
+            "classification": None,
+            "reason": "category is not a paint-backed text region",
+            "policy": policy,
+        }
+    if paint_status == "expected-missing":
+        return {
+            "status": "unscorable",
+            "classification": "unscorable",
+            "reason": "source-visible text produced no placed glyph",
+            "policy": policy,
+        }
+    if bounds is None:
+        return {
+            "status": "unscorable",
+            "classification": "unscorable",
+            "reason": "aligned region bounds are unavailable",
+            "policy": policy,
+        }
+    if alignment_clipped:
+        return {
+            "status": "unscorable",
+            "classification": "unscorable",
+            "reason": "global alignment clipped the text region",
+            "policy": policy,
+        }
+
+    if max_translation < 0 or max_translation > MAX_TEXT_RESIDUAL_TRANSLATION_PX:
+        raise ValueError(
+            f"text residual translation bound must be between 0 and {MAX_TEXT_RESIDUAL_TRANSLATION_PX}px"
+        )
+    left = int(bounds["left"])
+    top = int(bounds["top"])
+    width = int(bounds["width"])
+    height = int(bounds["height"])
+    radius = max_translation
+    if (
+        left - radius < 0
+        or top - radius < 0
+        or left + width + radius > reference.width
+        or top + height + radius > reference.height
+    ):
+        return {
+            "status": "unscorable",
+            "classification": "unscorable",
+            "reason": "bounded local search window is clipped by the page edge",
+            "policy": policy,
+            "work_units": 0,
+        }
+
+    reference_window = _crop_image(
+        reference,
+        left - radius,
+        top - radius,
+        left + width + radius,
+        top + height + radius,
+    )
+    candidate_crop = _crop_image(
+        aligned_candidate,
+        left,
+        top,
+        left + width,
+        top + height,
+    )
+    candidate_points = [
+        divmod(index, width)
+        for index, value in enumerate(candidate_crop.pixels)
+        if value < INK_THRESHOLD
+    ]
+    if not candidate_points:
+        return {
+            "status": "unscorable",
+            "classification": "unscorable",
+            "reason": "candidate text region has no ink",
+            "policy": policy,
+            "work_units": width * height,
+        }
+
+    offsets = list(_translation_order(radius))
+    work_units = (
+        width * height
+        + reference_window.width * reference_window.height
+        + len(candidate_points) * len(offsets)
+        + len(offsets)
+    )
+    if work_units > max_work:
+        return {
+            "status": "unscorable",
+            "classification": "unscorable",
+            "reason": "bounded per-page text residual work budget is exhausted",
+            "policy": policy,
+            "work_units": 0,
+        }
+
+    integral = _binary_integral(reference_window)
+    stride = reference_window.width + 1
+    candidate_count = len(candidate_points)
+    rankings: List[Dict[str, Any]] = []
+    for dx, dy in offsets:
+        origin_x = radius + dx
+        origin_y = radius + dy
+        reference_count = _integral_rect_count(
+            integral,
+            stride,
+            origin_x,
+            origin_y,
+            origin_x + width,
+            origin_y + height,
+        )
+        intersection = sum(
+            reference_window.pixels[(origin_y + y) * reference_window.width + origin_x + x]
+            < INK_THRESHOLD
+            for y, x in candidate_points
+        )
+        denominator = candidate_count + reference_count
+        rankings.append(
+            {
+                "offset_px": {"dx": dx, "dy": dy},
+                "ink_f1": 0.0 if denominator == 0 else 2.0 * intersection / denominator,
+                "candidate_to_reference_ink_ratio": (
+                    None if reference_count == 0 else candidate_count / reference_count
+                ),
+                "overlap_ink_pixels": intersection,
+                "reference_ink_pixels": reference_count,
+            }
+        )
+
+    positioned = next(
+        item
+        for item in rankings
+        if item["offset_px"] == {"dx": 0, "dy": 0}
+    )
+    best_f1 = max(item["ink_f1"] for item in rankings)
+    best = [item for item in rankings if item["ink_f1"] == best_f1]
+    lower = sorted(
+        (item for item in rankings if item["ink_f1"] < best_f1),
+        key=lambda item: (
+            -item["ink_f1"],
+            abs(item["offset_px"]["dx"]) + abs(item["offset_px"]["dy"]),
+            item["offset_px"]["dy"],
+            item["offset_px"]["dx"],
+        ),
+    )
+    common = {
+        "policy": policy,
+        "positioned_ink_f1": positioned["ink_f1"],
+        "best_local_ink_f1": best_f1,
+        "local_gain": best_f1 - positioned["ink_f1"],
+        "runner_up": lower[0] if lower else None,
+        "work_units": work_units,
+    }
+    if best_f1 == 0.0:
+        return {
+            **common,
+            "status": "unscorable",
+            "classification": "unscorable",
+            "reason": "candidate and reference have no overlapping ink in the bounded search window",
+        }
+    if len(best) != 1:
+        return {
+            **common,
+            "status": "ambiguous",
+            "classification": "ambiguous",
+            "reason": "multiple local translations have the same best ink F1",
+            "best_offsets_px": [item["offset_px"] for item in best],
+        }
+
+    winner = best[0]
+    offset = winner["offset_px"]
+    nonzero_offset = offset != {"dx": 0, "dy": 0}
+    ratio = winner["candidate_to_reference_ink_ratio"]
+    similar_ink = (
+        ratio is not None
+        and TEXT_RESIDUAL_INK_RATIO_MIN <= ratio <= TEXT_RESIDUAL_INK_RATIO_MAX
+    )
+    gain = common["local_gain"]
+    if (
+        nonzero_offset
+        and gain >= TEXT_RESIDUAL_MATERIAL_GAIN
+        and best_f1 >= TEXT_RESIDUAL_GEOMETRY_MIN_F1
+        and similar_ink
+    ):
+        classification = "geometry-dominant"
+        reason = "bounded local translation materially restores high-fidelity ink overlap"
+    elif not nonzero_offset and best_f1 < 1.0:
+        classification = "glyph-style-dominant"
+        reason = "position is already optimal while glyph ink shape or density remains different"
+    elif nonzero_offset and gain >= TEXT_RESIDUAL_MIXED_GAIN:
+        classification = "mixed"
+        reason = "local translation helps, but glyph ink shape or density remains different"
+    else:
+        classification = "ambiguous"
+        reason = "bounded evidence does not uniquely separate geometry from glyph style"
+    return {
+        **common,
+        "status": "hypothesis" if classification != "ambiguous" else "ambiguous",
+        "classification": classification,
+        "reason": reason,
+        "best_offset_px": offset,
+        "candidate_to_reference_ink_ratio": ratio,
+        "overlap_ink_pixels": winner["overlap_ink_pixels"],
+        "reference_ink_pixels": winner["reference_ink_pixels"],
+        "candidate_ink_pixels": candidate_count,
+    }
+
+
 def _vertical_transitions(regions: Sequence[Mapping[str, Any]]) -> List[Dict[str, Any]]:
     ordered = sorted(
         (
@@ -2203,6 +2468,7 @@ def _score_visual_regions(
     dy = int(translation["dy"])
     results: List[Dict[str, Any]] = []
     vertical_trace_work = 0
+    text_residual_work = 0
 
     def trace(
         category: str,
@@ -2219,6 +2485,25 @@ def _score_visual_regions(
             HARD_MAX_VERTICAL_TRACE_WORK_PER_PAGE - vertical_trace_work,
         )
         vertical_trace_work += int(result.get("work_units", 0))
+        return result
+
+    def text_residual(
+        category: str,
+        paint_status: str,
+        bounds: Optional[Mapping[str, int]],
+        alignment_clipped: bool,
+    ) -> Dict[str, Any]:
+        nonlocal text_residual_work
+        result = _text_residual_trace(
+            category,
+            paint_status,
+            bounds,
+            reference,
+            aligned_candidate,
+            alignment_clipped,
+            HARD_MAX_TEXT_RESIDUAL_WORK_PER_PAGE - text_residual_work,
+        )
+        text_residual_work += int(result.get("work_units", 0))
         return result
 
     for region in page_contract["regions"]:
@@ -2270,6 +2555,9 @@ def _score_visual_regions(
                 region["paint_status"],
                 None,
             )
+            base["text_residual"] = text_residual(
+                region["category"], region["paint_status"], None, False
+            )
             results.append(base)
             continue
         if right <= left or bottom <= top:
@@ -2285,6 +2573,9 @@ def _score_visual_regions(
                 region["category"],
                 region["paint_status"],
                 None,
+            )
+            base["text_residual"] = text_residual(
+                region["category"], region["paint_status"], None, False
             )
             results.append(base)
             continue
@@ -2319,6 +2610,12 @@ def _score_visual_regions(
                     region["category"],
                     region["paint_status"],
                     aligned_bounds,
+                ),
+                "text_residual": text_residual(
+                    region["category"],
+                    region["paint_status"],
+                    aligned_bounds,
+                    base["alignment_clipped"],
                 ),
             }
         )
@@ -2375,6 +2672,9 @@ def _render_html(report: Mapping[str, Any]) -> str:
                 f"<td>{_format_metric(None if region.get('metrics') is None else region['metrics']['edge_f1'])}</td>"
                 f"<td>{html.escape(region.get('vertical_trace', {}).get('status', 'unavailable'))}</td>"
                 f"<td>{_format_metric(region.get('vertical_trace', {}).get('offset_px'))}</td>"
+                f"<td>{html.escape(str(region.get('text_residual', {}).get('classification') or 'not-applicable'))}</td>"
+                f"<td>{_format_metric(region.get('text_residual', {}).get('best_local_ink_f1'))}</td>"
+                f"<td>{_format_metric(region.get('text_residual', {}).get('local_gain'))}</td>"
                 "</tr>"
                 for region in semantic_regions
             )
@@ -2382,7 +2682,8 @@ def _render_html(report: Mapping[str, Any]) -> str:
                 "<h3>Semantic regions (additive, report-only)</h3>"
                 "<table><tr><th>ID</th><th>Category</th><th>Status</th>"
                 "<th>Ink F1</th><th>Edge F1</th><th>Vertical trace</th>"
-                "<th>Offset hypothesis (px)</th></tr>"
+                "<th>Offset hypothesis (px)</th><th>Text residual</th>"
+                "<th>Best local ink F1</th><th>Local gain</th></tr>"
                 f"{region_rows}</table>"
             )
         else:
@@ -2573,11 +2874,34 @@ def _summarize_pages(pages: Sequence[Mapping[str, Any]]) -> Dict[str, Any]:
     trace_status_counts: Dict[str, int] = {}
     transition_status_counts: Dict[str, int] = {}
     transition_hypotheses: List[Dict[str, Any]] = []
+    text_residual_classification_counts: Dict[str, int] = {}
+    text_residual_hypotheses: List[Dict[str, Any]] = []
     for page in pages:
         for region in page.get("semantic_regions", []):
             trace_status = region.get("vertical_trace", {}).get("status")
             if trace_status is not None:
                 trace_status_counts[trace_status] = trace_status_counts.get(trace_status, 0) + 1
+            text_residual = region.get("text_residual", {})
+            residual_classification = text_residual.get("classification")
+            if residual_classification is not None:
+                text_residual_classification_counts[residual_classification] = (
+                    text_residual_classification_counts.get(residual_classification, 0) + 1
+                )
+                if text_residual.get("status") == "hypothesis":
+                    text_residual_hypotheses.append(
+                        {
+                            "page": page["page"],
+                            "id": region["id"],
+                            "classification": residual_classification,
+                            "best_offset_px": text_residual.get("best_offset_px"),
+                            "positioned_ink_f1": text_residual.get("positioned_ink_f1"),
+                            "best_local_ink_f1": text_residual.get("best_local_ink_f1"),
+                            "local_gain": text_residual.get("local_gain"),
+                            "candidate_to_reference_ink_ratio": text_residual.get(
+                                "candidate_to_reference_ink_ratio"
+                            ),
+                        }
+                    )
             category = region["category"]
             counts = category_counts.setdefault(
                 category,
@@ -2643,6 +2967,8 @@ def _summarize_pages(pages: Sequence[Mapping[str, Any]]) -> Dict[str, Any]:
         "vertical_trace_status_counts": trace_status_counts,
         "vertical_transition_status_counts": transition_status_counts,
         "vertical_transition_hypotheses": transition_hypotheses,
+        "text_residual_classification_counts": text_residual_classification_counts,
+        "text_residual_hypotheses": text_residual_hypotheses,
     }
 
 
@@ -3040,6 +3366,8 @@ def _run_visual_check_from_snapshots(
             "vertical_trace_status_counts": {},
             "vertical_transition_status_counts": {},
             "vertical_transition_hypotheses": [],
+            "text_residual_classification_counts": {},
+            "text_residual_hypotheses": [],
             "pixel_comparison_attempted": False,
         }
         _write_report(output_dir, report, {}, limits)
@@ -3156,6 +3484,13 @@ def _run_visual_check_from_snapshots(
                         "aligned_bounds_px": None,
                         "metrics": None,
                         "vertical_trace": _vertical_trace(
+                            region["category"],
+                            region["paint_status"],
+                            None,
+                            reference_raw_image,
+                            candidate_raw_image,
+                        ),
+                        "text_residual": _text_residual_trace(
                             region["category"],
                             region["paint_status"],
                             None,

--- a/scripts/tests/test_pdf_visual_check.py
+++ b/scripts/tests/test_pdf_visual_check.py
@@ -395,6 +395,166 @@ class VerticalTraceTests(unittest.TestCase):
         self.assertIn("overlap", transitions[0]["reason"])
 
 
+class TextResidualTraceTests(unittest.TestCase):
+    def bounds(self, left=10, top=10, width=10, height=10):
+        return {"left": left, "top": top, "width": width, "height": height}
+
+    def trace(self, reference, candidate, bounds=None, **kwargs):
+        return pdf_visual_check._text_residual_trace(
+            "text",
+            "painted",
+            bounds or self.bounds(),
+            reference,
+            candidate,
+            max_translation=kwargs.pop("max_translation", 4),
+            **kwargs,
+        )
+
+    def test_pure_local_translation_is_geometry_dominant(self):
+        candidate = gray_image(32, 32, rectangle(12, 12, 15, 15))
+        reference = gray_image(32, 32, rectangle(15, 14, 18, 17))
+
+        trace = self.trace(reference, candidate)
+
+        self.assertEqual(trace["status"], "hypothesis")
+        self.assertEqual(trace["classification"], "geometry-dominant")
+        self.assertEqual(trace["best_offset_px"], {"dx": 3, "dy": 2})
+        self.assertEqual(trace["best_local_ink_f1"], 1.0)
+        self.assertGreaterEqual(trace["local_gain"], 0.15)
+
+    def test_same_position_with_different_stroke_is_glyph_style_dominant(self):
+        candidate_points = [(12, 12), (13, 12), (12, 13)]
+        reference_points = candidate_points + [(13, 13)]
+        candidate = gray_image(32, 32, candidate_points)
+        reference = gray_image(32, 32, reference_points)
+
+        trace = self.trace(reference, candidate)
+
+        self.assertEqual(trace["status"], "hypothesis")
+        self.assertEqual(trace["classification"], "glyph-style-dominant")
+        self.assertEqual(trace["best_offset_px"], {"dx": 0, "dy": 0})
+        self.assertLess(trace["best_local_ink_f1"], 1.0)
+
+    def test_translation_plus_shape_change_is_mixed(self):
+        candidate_points = [(12, 12), (13, 12), (12, 13)]
+        reference_points = [(16, 12), (17, 12), (16, 13), (17, 13), (18, 12)]
+        candidate = gray_image(32, 32, candidate_points)
+        reference = gray_image(32, 32, reference_points)
+
+        trace = self.trace(reference, candidate)
+
+        self.assertEqual(trace["status"], "hypothesis")
+        self.assertEqual(trace["classification"], "mixed")
+        self.assertEqual(trace["best_offset_px"], {"dx": 4, "dy": 0})
+        self.assertLess(trace["best_local_ink_f1"], 0.9)
+
+    def test_repeated_shape_is_ambiguous_instead_of_inventing_a_class(self):
+        points = [(12, 12), (13, 12), (12, 13)]
+        candidate = gray_image(40, 40, points)
+        reference = gray_image(40, 40, points + [(x + 8, y) for x, y in points])
+        bounds = self.bounds(left=10, top=10, width=5, height=5)
+
+        trace = self.trace(
+            reference, candidate, bounds=bounds, max_translation=8
+        )
+
+        self.assertEqual(trace["status"], "ambiguous")
+        self.assertEqual(trace["classification"], "ambiguous")
+        self.assertEqual(
+            trace["best_offsets_px"],
+            [{"dx": 0, "dy": 0}, {"dx": 8, "dy": 0}],
+        )
+
+    def test_blank_clipping_and_budget_are_explicitly_unscorable(self):
+        blank = gray_image(32, 32)
+        ink = gray_image(32, 32, [(12, 12)])
+
+        no_candidate = self.trace(ink, blank)
+        clipped = self.trace(
+            ink,
+            ink,
+            bounds=self.bounds(left=2, top=2),
+        )
+        exhausted = self.trace(ink, ink, max_work=1)
+
+        self.assertEqual(no_candidate["classification"], "unscorable")
+        self.assertIn("no ink", no_candidate["reason"])
+        self.assertEqual(clipped["classification"], "unscorable")
+        self.assertIn("page edge", clipped["reason"])
+        self.assertEqual(exhausted["classification"], "unscorable")
+        self.assertIn("work budget", exhausted["reason"])
+        self.assertEqual(exhausted["work_units"], 0)
+
+    def test_nontext_and_expected_missing_never_receive_a_hypothesis(self):
+        image = gray_image(32, 32, [(12, 12)])
+        nontext = pdf_visual_check._text_residual_trace(
+            "table", "not-applicable", self.bounds(), image, image
+        )
+        missing = pdf_visual_check._text_residual_trace(
+            "text", "expected-missing", None, image, image
+        )
+
+        self.assertEqual(nontext["status"], "not-applicable")
+        self.assertIsNone(nontext["classification"])
+        self.assertEqual(missing["classification"], "unscorable")
+
+    def test_summary_counts_classes_and_keeps_only_content_free_hypotheses(self):
+        residual = {
+            "status": "hypothesis",
+            "classification": "geometry-dominant",
+            "best_offset_px": {"dx": 3, "dy": 2},
+            "positioned_ink_f1": 0.1,
+            "best_local_ink_f1": 0.95,
+            "local_gain": 0.85,
+            "candidate_to_reference_ink_ratio": 1.0,
+        }
+        summary = pdf_visual_check._summarize_pages(
+            [
+                {
+                    "page": 1,
+                    "metrics": None,
+                    "semantic_regions": [
+                        {
+                            "id": "text-0001",
+                            "category": "text",
+                            "metrics": None,
+                            "text_residual": residual,
+                        },
+                        {
+                            "id": "text-0002",
+                            "category": "text",
+                            "metrics": None,
+                            "text_residual": {
+                                "status": "ambiguous",
+                                "classification": "ambiguous",
+                            },
+                        },
+                    ],
+                }
+            ]
+        )
+
+        self.assertEqual(
+            summary["text_residual_classification_counts"],
+            {"geometry-dominant": 1, "ambiguous": 1},
+        )
+        self.assertEqual(
+            summary["text_residual_hypotheses"],
+            [
+                {
+                    "page": 1,
+                    "id": "text-0001",
+                    "classification": "geometry-dominant",
+                    "best_offset_px": {"dx": 3, "dy": 2},
+                    "positioned_ink_f1": 0.1,
+                    "best_local_ink_f1": 0.95,
+                    "local_gain": 0.85,
+                    "candidate_to_reference_ink_ratio": 1.0,
+                }
+            ],
+        )
+
+
 class MetricRegressionTests(unittest.TestCase):
     def test_bounded_translation_is_detected_and_reported(self):
         reference = gray_image(16, 16, rectangle(2, 2, 5, 5))


### PR DESCRIPTION
Closes #229
Refs #93

## What changed
- add a report-only, content-free text residual classifier after the existing fixed page alignment
- compare positioned ink with a bounded local x/y search of at most 32 px and 50M work units per page
- emit geometry-dominant, glyph-style-dominant, mixed, ambiguous, or unscorable without feeding any score or pass policy
- expose classification counts and content-free hypotheses in JSON and HTML

## Fail-closed boundaries
- repeated equal-best shapes remain ambiguous
- blank or missing ink, page-edge clipping, and budget exhaustion remain unscorable
- no source text, glyph strings, font paths or bytes, proprietary font names, or document paths are emitted
- layout/PDF bytes, global alignment, metrics, thresholds, reference tier, T3, and policy.pass=null are unchanged

## Canonical evidence
- 28 paint-backed text regions: geometry 10, mixed 9, ambiguous 8, unscorable 1, glyph-style 0
- the 10 geometry cases form a repeated 22-candidate-ink-pixel cohort with local F1 .954545-.977778
- page-clustered offsets: page4 18/22, page5 12/22, page7 12/16, page8 12/-4
- exact independent runs: candidate PDF 61ab5f3a9329c9d78376813d63cffb62aa9f495962dda5bae97f402baa0789fb; report 077d4f47e05cbc618d32e5fadaf6d390f8b54d51e9af1416a014a3f5f3f0e056

## Verification
- Python comparator: 69 passed
- Node visual/calibration: 8 passed
- scripts/verify-local.sh: green, including AI120, canonical 8/18/24 + 98.9%, public corpus84, oracle82, wasm, licenses
- external/rhwp remains pinned and clean at f137b4c9