### PR TITLE
test(pdf): classify glyph provenance and placement

### DIFF
--- a/crates/hwp-export/src/pdf.rs
+++ b/crates/hwp-export/src/pdf.rs
@@ -23,7 +23,7 @@ use hwp_model::font_class::{classify, FontCategory};
 use hwp_model::layout::{PageLayerTree, PaintOp};
 use hwp_model::prelude::FontMetricsProvider;
 use hwp_model::types::Color;
-use hwp_typeset::{BlockKind, PlacedDoc};
+use hwp_typeset::{BlockKind, PlacedDoc, PlacedGlyph, PlacedGlyphOrigin};
 
 use krilla::color::rgb;
 use krilla::geom::{PathBuilder, Point, Rect};
@@ -278,6 +278,25 @@ pub struct PdfVisualRegion {
     pub w: f64,
     pub h: f64,
     pub clipped: bool,
+    /// Source-neutral aggregate origin for glyphs inside this exact placed paragraph band.
+    pub glyph_provenance: &'static str,
+    /// Baseline-anchored EM union from the same placement. `None` for non-text or missing paint.
+    pub placed_em_bounds_hwpunit: Option<PdfVisualBounds>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Serialize)]
+pub struct PdfVisualBounds {
+    pub x: f64,
+    pub y: f64,
+    pub w: f64,
+    pub h: f64,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct VisualRegionClassification {
+    paint_status: &'static str,
+    glyph_provenance: &'static str,
+    placed_em_bounds_hwpunit: Option<PdfVisualBounds>,
 }
 
 /// Result of a PDF export: the bytes plus what font path (if any) backed the glyphs.
@@ -300,7 +319,7 @@ fn push_visual_region(
     counters: &mut [usize; 4],
     category_index: usize,
     category: &'static str,
-    paint_status: &'static str,
+    classification: VisualRegionClassification,
     page_size: (f64, f64),
     raw: (f64, f64, f64, f64),
 ) -> Result<(), String> {
@@ -328,12 +347,14 @@ fn push_visual_region(
     regions.push(PdfVisualRegion {
         id: format!("{category}-{:04}", counters[category_index]),
         category,
-        paint_status,
+        paint_status: classification.paint_status,
         x: left,
         y: top,
         w: right - left,
         h: bottom - top,
         clipped: left != x || top != y || right != raw_right || bottom != raw_bottom,
+        glyph_provenance: classification.glyph_provenance,
+        placed_em_bounds_hwpunit: classification.placed_em_bounds_hwpunit,
     });
     Ok(())
 }
@@ -358,6 +379,75 @@ fn block_band_contains_glyph(
             && glyph.baseline >= block.y
             && glyph.baseline <= bottom
     })
+}
+
+fn glyphs_in_block_band<'a>(
+    page: &'a hwp_typeset::PlacedPage,
+    block: &hwp_typeset::PlacedBlock,
+) -> Vec<&'a PlacedGlyph> {
+    let right = block.x + block.w;
+    let bottom = block.y + block.h;
+    page.glyphs
+        .iter()
+        .filter(|glyph| {
+            glyph.x >= block.x
+                && glyph.x <= right
+                && glyph.baseline >= block.y
+                && glyph.baseline <= bottom
+        })
+        .collect()
+}
+
+fn glyph_origin_label(origin: PlacedGlyphOrigin) -> &'static str {
+    match origin {
+        PlacedGlyphOrigin::SourceText => "source-text",
+        PlacedGlyphOrigin::GeneratedMarker => "generated-marker",
+        PlacedGlyphOrigin::PageDecoration => "page-decoration",
+        PlacedGlyphOrigin::Unknown => "unknown",
+    }
+}
+
+fn text_glyph_evidence(
+    page: &hwp_typeset::PlacedPage,
+    block: &hwp_typeset::PlacedBlock,
+) -> (&'static str, Option<PdfVisualBounds>) {
+    let glyphs = glyphs_in_block_band(page, block);
+    let Some(first) = glyphs.first() else {
+        return ("unknown", None);
+    };
+    let first_origin = first.origin;
+    let provenance = if glyphs.iter().all(|glyph| glyph.origin == first_origin) {
+        glyph_origin_label(first_origin)
+    } else {
+        "mixed"
+    };
+    let raw_left = glyphs
+        .iter()
+        .map(|glyph| glyph.x)
+        .fold(f64::INFINITY, f64::min);
+    let raw_top = glyphs
+        .iter()
+        .map(|glyph| glyph.baseline - glyph.size)
+        .fold(f64::INFINITY, f64::min);
+    let raw_right = glyphs
+        .iter()
+        .map(|glyph| glyph.x + glyph.size)
+        .fold(f64::NEG_INFINITY, f64::max);
+    let raw_bottom = glyphs
+        .iter()
+        .map(|glyph| glyph.baseline)
+        .fold(f64::NEG_INFINITY, f64::max);
+    let left = raw_left.clamp(0.0, page.width);
+    let top = raw_top.clamp(0.0, page.height);
+    let right = raw_right.clamp(0.0, page.width);
+    let bottom = raw_bottom.clamp(0.0, page.height);
+    let bounds = (right > left && bottom > top).then_some(PdfVisualBounds {
+        x: left,
+        y: top,
+        w: right - left,
+        h: bottom - top,
+    });
+    (provenance, bounds)
 }
 
 fn paragraph_paint_status(
@@ -403,12 +493,17 @@ fn visual_evidence(
                 intentional_blank_text_regions += 1;
                 continue;
             };
+            let (glyph_provenance, placed_em_bounds_hwpunit) = text_glyph_evidence(page, block);
             push_visual_region(
                 &mut regions,
                 &mut counters,
                 0,
                 "text",
-                paint_status,
+                VisualRegionClassification {
+                    paint_status,
+                    glyph_provenance,
+                    placed_em_bounds_hwpunit,
+                },
                 (page.width, page.height),
                 (block.x, block.y, block.w, block.h),
             )?;
@@ -419,7 +514,11 @@ fn visual_evidence(
                 &mut counters,
                 1,
                 "table",
-                "not-applicable",
+                VisualRegionClassification {
+                    paint_status: "not-applicable",
+                    glyph_provenance: "not-applicable",
+                    placed_em_bounds_hwpunit: None,
+                },
                 (page.width, page.height),
                 (table.x, table.y, table.w, table.h),
             )?;
@@ -435,7 +534,11 @@ fn visual_evidence(
                 &mut counters,
                 category_index,
                 category,
-                "not-applicable",
+                VisualRegionClassification {
+                    paint_status: "not-applicable",
+                    glyph_provenance: "not-applicable",
+                    placed_em_bounds_hwpunit: None,
+                },
                 (page.width, page.height),
                 (image.x, image.y, image.w, image.h),
             )?;
@@ -449,7 +552,7 @@ fn visual_evidence(
         });
     }
     Ok(PdfVisualEvidence {
-        schema_version: 2,
+        schema_version: 3,
         coordinate_space: "HWPUNIT",
         candidate_pdf_sha256,
         pages,
@@ -1369,7 +1472,7 @@ mod tests {
             "non-trivial PDF size, got {}",
             out.bytes.len()
         );
-        assert_eq!(out.visual_evidence.schema_version, 2);
+        assert_eq!(out.visual_evidence.schema_version, 3);
         assert_eq!(out.visual_evidence.coordinate_space, "HWPUNIT");
         assert_eq!(out.visual_evidence.pages.len(), out.pages);
         assert_eq!(
@@ -1382,6 +1485,11 @@ mod tests {
             .iter()
             .filter(|region| region.category == "text")
             .all(|region| region.paint_status == "painted"));
+        assert!(regions
+            .iter()
+            .filter(|region| region.category == "text")
+            .all(|region| region.glyph_provenance == "source-text"
+                && region.placed_em_bounds_hwpunit.is_some()));
         assert_eq!(
             out.visual_evidence.pages[0].intentional_blank_text_regions,
             0
@@ -1425,6 +1533,8 @@ mod tests {
         assert_eq!(text_regions.len(), 1);
         assert_eq!(text_regions[0].id, "text-0002");
         assert_eq!(text_regions[0].paint_status, "painted");
+        assert_eq!(text_regions[0].glyph_provenance, "source-text");
+        assert!(text_regions[0].placed_em_bounds_hwpunit.is_some());
         assert_eq!(
             page.regions
                 .iter()
@@ -1475,6 +1585,7 @@ mod tests {
             italic: false,
             font: None,
             cluster: None,
+            origin: hwp_typeset::PlacedGlyphOrigin::SourceText,
         };
         let first_fragment = hwp_typeset::PlacedPage {
             glyphs: vec![glyph(120.0, 250.0)],
@@ -1506,6 +1617,107 @@ mod tests {
     }
 
     #[test]
+    fn glyph_evidence_distinguishes_source_generated_mixed_unknown_and_bounds() {
+        let block = hwp_typeset::PlacedBlock {
+            x: 100.0,
+            y: 200.0,
+            w: 400.0,
+            h: 200.0,
+            section: 0,
+            block: 0,
+            kind: BlockKind::Paragraph,
+        };
+        let glyph = |x, baseline, origin| hwp_typeset::PlacedGlyph {
+            x,
+            baseline,
+            ch: '가',
+            size: 100.0,
+            color: Color::default(),
+            underline: false,
+            bold: false,
+            italic: false,
+            font: None,
+            cluster: None,
+            origin,
+        };
+        let page = |glyphs| hwp_typeset::PlacedPage {
+            width: 1_000.0,
+            height: 2_000.0,
+            glyphs,
+            ..Default::default()
+        };
+
+        let source = page(vec![glyph(
+            120.0,
+            250.0,
+            hwp_typeset::PlacedGlyphOrigin::SourceText,
+        )]);
+        let (provenance, bounds) = text_glyph_evidence(&source, &block);
+        assert_eq!(provenance, "source-text");
+        let bounds = bounds.unwrap();
+        assert_eq!(
+            (bounds.x, bounds.y, bounds.w, bounds.h),
+            (120.0, 150.0, 100.0, 100.0)
+        );
+
+        let decoration = page(vec![glyph(
+            120.0,
+            250.0,
+            hwp_typeset::PlacedGlyphOrigin::PageDecoration,
+        )]);
+        assert_eq!(
+            text_glyph_evidence(&decoration, &block).0,
+            "page-decoration"
+        );
+
+        let marker = page(vec![glyph(
+            120.0,
+            250.0,
+            hwp_typeset::PlacedGlyphOrigin::GeneratedMarker,
+        )]);
+        assert_eq!(text_glyph_evidence(&marker, &block).0, "generated-marker");
+
+        let unknown = page(vec![glyph(
+            120.0,
+            250.0,
+            hwp_typeset::PlacedGlyphOrigin::Unknown,
+        )]);
+        assert_eq!(text_glyph_evidence(&unknown, &block).0, "unknown");
+
+        let mixed = page(vec![
+            glyph(120.0, 250.0, hwp_typeset::PlacedGlyphOrigin::SourceText),
+            glyph(
+                240.0,
+                250.0,
+                hwp_typeset::PlacedGlyphOrigin::GeneratedMarker,
+            ),
+        ]);
+        assert_eq!(text_glyph_evidence(&mixed, &block).0, "mixed");
+
+        let empty = page(Vec::new());
+        assert_eq!(text_glyph_evidence(&empty, &block), ("unknown", None));
+
+        let edge_block = hwp_typeset::PlacedBlock {
+            x: 950.0,
+            y: 0.0,
+            w: 50.0,
+            h: 80.0,
+            ..block
+        };
+        let edge = page(vec![glyph(
+            980.0,
+            60.0,
+            hwp_typeset::PlacedGlyphOrigin::SourceText,
+        )]);
+        let edge_bounds = text_glyph_evidence(&edge, &edge_block).1.unwrap();
+        assert_eq!(
+            (edge_bounds.x, edge_bounds.y, edge_bounds.w, edge_bounds.h),
+            (980.0, 0.0, 20.0, 60.0),
+            "aggregate EM evidence is clipped to the page without exposing the glyph"
+        );
+    }
+
+    #[test]
     fn clipped_visual_region_keeps_paint_status_and_bounded_geometry() {
         let mut regions = Vec::new();
         let mut counters = [0usize; 4];
@@ -1515,7 +1727,11 @@ mod tests {
             &mut counters,
             0,
             "text",
-            "painted",
+            VisualRegionClassification {
+                paint_status: "painted",
+                glyph_provenance: "source-text",
+                placed_em_bounds_hwpunit: None,
+            },
             (100.0, 200.0),
             (-10.0, 180.0, 50.0, 40.0),
         )

--- a/crates/hwp-typeset/src/diagnostic.rs
+++ b/crates/hwp-typeset/src/diagnostic.rs
@@ -388,7 +388,7 @@ pub fn compare_placed_docs(candidate: &PlacedDoc, oracle: &PlacedDoc) -> PlacedD
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{BlockKind, PlacedBlock, PlacedGlyph, PlacedImage};
+    use crate::{BlockKind, PlacedBlock, PlacedGlyph, PlacedGlyphOrigin, PlacedImage};
     use hwp_model::types::Color;
 
     fn glyph(x: f64, baseline: f64, ch: char) -> PlacedGlyph {
@@ -403,6 +403,7 @@ mod tests {
             italic: false,
             font: None,
             cluster: None,
+            origin: PlacedGlyphOrigin::SourceText,
         }
     }
 

--- a/crates/hwp-typeset/src/lib.rs
+++ b/crates/hwp-typeset/src/lib.rs
@@ -34,7 +34,7 @@ pub mod place;
 pub use place::{
     block_pages, cell_caret_rect, cell_caret_rect_path, cell_text_hit, column_offsets, place_doc,
     row_offsets, BlockKind, CellAddr, CellCaretRect, CellTextHit, PlacedBlock, PlacedCell,
-    PlacedDoc, PlacedGlyph, PlacedImage, PlacedPage, PlacedRect, PlacedTable,
+    PlacedDoc, PlacedGlyph, PlacedGlyphOrigin, PlacedImage, PlacedPage, PlacedRect, PlacedTable,
 };
 
 /// Half the EM for half-width glyphs.

--- a/crates/hwp-typeset/src/place.rs
+++ b/crates/hwp-typeset/src/place.rs
@@ -17,6 +17,18 @@ use hwp_model::prelude::*;
 use crate::{layout_paragraph, line_spacing_ratio, table_height, BASELINE_RATIO};
 
 /// A single positioned glyph in absolute page coordinates (HWPUNIT, page-top-left origin).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PlacedGlyphOrigin {
+    /// A scalar or cluster carried by a document paragraph run.
+    SourceText,
+    /// A list/numbering marker synthesized by the first-party typesetter.
+    GeneratedMarker,
+    /// A page decoration synthesized from typed section metadata, such as a page number.
+    PageDecoration,
+    /// A bounded producer that has not yet established a more specific origin.
+    Unknown,
+}
+
 #[derive(Clone, Debug)]
 pub struct PlacedGlyph {
     /// Left edge of the glyph's advance box.
@@ -44,6 +56,9 @@ pub struct PlacedGlyph {
     /// (Noto Serif CJK KR / Source Han Serif K) shapes the conjoining jamo into a syllable. `None`
     /// for every ordinary glyph → byte-identical to before (`ch` is drawn).
     pub cluster: Option<String>,
+    /// Source-neutral production class for visual diagnostics. This never contains text, addresses,
+    /// field payloads, or font identity and does not affect layout or paint replay.
+    pub origin: PlacedGlyphOrigin,
 }
 
 /// A positioned image/equation box in absolute page coordinates.
@@ -3098,6 +3113,7 @@ fn place_atom(
                     italic: glyph.italic,
                     font: glyph.font.clone(),
                     cluster: glyph.cluster.clone(),
+                    origin: PlacedGlyphOrigin::SourceText,
                 });
             }
             atom.advance(fonts)
@@ -3413,6 +3429,7 @@ fn place_page_number(
             italic: false,
             font: None,
             cluster: None,
+            origin: PlacedGlyphOrigin::PageDecoration,
         });
         x += fonts.advance_width(&key, ch, size as i32);
     }

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,6 +3,23 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
+- 갱신: 2026-08-25 · Codex(sol) — **#231 glyph provenance 구현·canonical 실증**.
+  first-party `PlacedGlyph`에 source-text/generated-marker/page-decoration/unknown origin을 붙이고,
+  visual-region schema v3가 같은 placement의 page-clipped aggregate EM bounds와 mixed 판정을 strict하게
+  운반한다. painted text의 null bounds, expected-missing의 stale provenance/bounds, non-text claim과 old/
+  unknown schema/field는 fail-closed다. Rust 관련 **153**, Python **70**, Node **4**가 green이며 source/
+  generated/decoration/mixed/unknown/empty/clipped/stale 경계를 잠갔다. canonical 2회는 candidate PDF SHA
+  `61ab5f3a…`, evidence `45d389cf…`, report `2bd3f3c8…`, HTML `0b23fb3f…` exact이다. 8쪽·60 scored
+  regions·42 intentional blank·T3/`pass=null`과 기존 metrics/rhwp는 불변이다. paint-backed text 28개와
+  geometry-dominant **10개 전부 source-text**이며, 후자는 모두 단일 1200×1200 HWPUNIT EM이 owning
+  band에서 x **+1008**, y **-180 HWPUNIT**로 동일하다. generated marker/decoration은 배제됐다. 다음
+  단일 renderer 축은 **source-text paragraph placement transform**이며 #231에서는 수정하지 않는다.
+  full은 Rust/rhwp, AI120, 8/18/24+98.9%, public corpus84, oracle82, wasm/licenses, JS build와 Vitest
+  **1,012**까지 green이다. sandbox port EPERM 뒤 권한 환경 Chromium도 **83 pass·3 intentional
+  skip·2 retry-pass flaky**로 exit 0이며, flakes는 hidden textarea visibility와 stale status-toast
+  timing이다. **다음:** final privacy/vendor/diff audit→commit/push→PR `Closes #231`→CI/merge→#93/#114
+  sync→해당 transform의 source-neutral parser/placement 비교 child를 issue-first 착수.
+
 - 갱신: 2026-08-25 · Codex(sol) — **#228 병합 · #229 text residual classifier 착수**.
   #227 exact head `8b704c51`은 issue-link **2s**·licenses **2m3s**·build-test **9m25s** green,
   CLEAN/MERGEABLE, 댓글/review 0으로 protected main `91231645`에 squash 병합됐다. #227은 close되고

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,7 +3,7 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
-- 갱신: 2026-08-25 · Codex(sol) — **#231 glyph provenance 구현·canonical 실증**.
+- 갱신: 2026-08-25 · Codex(sol) — **#231 구현 · PR #232 CI 대기**.
   first-party `PlacedGlyph`에 source-text/generated-marker/page-decoration/unknown origin을 붙이고,
   visual-region schema v3가 같은 placement의 page-clipped aggregate EM bounds와 mixed 판정을 strict하게
   운반한다. painted text의 null bounds, expected-missing의 stale provenance/bounds, non-text claim과 old/
@@ -17,8 +17,10 @@
   full은 Rust/rhwp, AI120, 8/18/24+98.9%, public corpus84, oracle82, wasm/licenses, JS build와 Vitest
   **1,012**까지 green이다. sandbox port EPERM 뒤 권한 환경 Chromium도 **83 pass·3 intentional
   skip·2 retry-pass flaky**로 exit 0이며, flakes는 hidden textarea visibility와 stale status-toast
-  timing이다. **다음:** final privacy/vendor/diff audit→commit/push→PR `Closes #231`→CI/merge→#93/#114
-  sync→해당 transform의 source-neutral parser/placement 비교 child를 issue-first 착수.
+  timing이다. privacy/vendor/diff audit 뒤 exact head `68e495a`를 push하고 PR **#232**(`Closes #231`)를
+  열었다. **다음:** issue-link/build-test/licenses와 review/comment 변화 추적→green/CLEAN이면 protected
+  main에 자율 merge→#93/#114 sync→해당 transform의 source-neutral parser/placement 비교 child를
+  issue-first 착수.
 
 - 갱신: 2026-08-25 · Codex(sol) — **#228 병합 · #229 text residual classifier 착수**.
   #227 exact head `8b704c51`은 issue-link **2s**·licenses **2m3s**·build-test **9m25s** green,

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,12 @@
 
 ---
 
+## 2026-08-25 (Codex sol) · #231 source-neutral glyph provenance
+- PlacedGlyph origin과 visual schema v3 aggregate EM bounds를 strict·content-free로 구현했다.
+- canonical geometry 10/10은 source-text·1200² EM·band 대비 (+1008,-180) HU로 일치했다.
+- PDF/evidence/report/HTML 2회 SHA exact; full green, Vitest1,012, Chromium83 pass/3 skip/2 retry-pass.
+- 다음: PR/CI/merge→#93/#114 sync→source-text paragraph placement transform child issue.
+
 ## 2026-08-25 (Codex sol) · #229 text residual classifier
 - fixed page alignment 뒤 ±32px/50M bounded local ink로 geometry·glyph-style·mixed·ambiguous를 분리.
 - 합성 경계 7축·Python69·Node8·quick 전체 green; score/threshold/T3/pass/layout/rhwp 불변.

--- a/docs/PDF-VISUAL-ORACLE.md
+++ b/docs/PDF-VISUAL-ORACLE.md
@@ -321,7 +321,7 @@ otherwise white, globally similar page.
 
 ### Semantic regions
 
-When `--candidate-regions` is supplied, visual-region schema v2 divides the candidate placement into
+When `--candidate-regions` is supplied, visual-region schema v3 divides the candidate placement into
 four content-free categories: paint-backed paragraph bands (`text`), placed table boxes (`table`), raster images
 (`image`), and SVG-backed equations/charts/other objects (`object`). IDs and HWPUNIT geometry are
 present; source text, paths, binary identifiers, and font paths are absent.
@@ -333,6 +333,14 @@ band with neither source-visible text nor a placed glyph is an intentional blank
 page-fragments are counted separately and never enter pixel ranking. `expected-missing` is an explicit
 unscorable placement failure. Non-text regions use `not-applicable`. A painted region that rasterizes
 without candidate ink remains partially unscorable with an explicit metric reason rather than being hidden.
+
+Schema v3 additionally binds every painted text region to the aggregate, page-clipped EM bounds and
+source-neutral origin of the glyphs already produced by that same first-party placement. Origins are
+limited to `source-text`, `generated-marker`, `page-decoration`, `mixed`, and `unknown`; non-text uses
+`not-applicable`. Painted text must carry finite non-empty bounds, while expected-missing text must be
+`unknown` with null bounds. The strict loader rejects stale versions, unknown fields, and contradictory
+paint/provenance claims. It never reads PDF text and emits no scalar, source text, field payload, model
+address, font identity, path, raw byte, or private hash.
 
 The manifest must be strict UTF-8 JSON with exactly the known fields, ordered one-based pages, finite
 positive in-page geometry, unique per-page IDs, matching MediaBox dimensions, and an exact SHA-256
@@ -594,6 +602,31 @@ Two independent runs preserved the exact #227 candidate PDF SHA-256
 SHA-256 `077d4f47e05cbc618d32e5fadaf6d390f8b54d51e9af1416a014a3f5f3f0e056`. The eight-page structure,
 all prior metrics, T3 labeling, and `policy.pass=null` are unchanged. No source text, glyph strings,
 font paths or bytes, proprietary font names, or document paths are emitted by the diagnostic.
+
+### Source-neutral glyph provenance and placement (2026-08-25, #231)
+
+Placed glyphs now carry a bounded production class from the first-party typesetter, and visual-region
+schema v3 reports that aggregate class plus the baseline-anchored EM union for each painted paragraph
+band. Synthetic tests cover source text, generated markers, page decorations, mixed and unknown
+production, empty placement, page-edge clipping, and stale provenance/bounds mismatches. The evidence
+is derived from the placement that produced the PDF; it does not re-typeset or inspect PDF text.
+
+On the canonical public pair, all 28 paint-backed text regions—and all ten geometry-dominant,
+22-candidate-ink-pixel residuals—are `source-text`. Every member of that ten-region cohort is one
+1200×1200 HWPUNIT EM box whose origin is consistently 1008 HWPUNIT right and 180 HWPUNIT above its
+owning paragraph-band origin. The local reference offsets still cluster at `(18,22)`, `(12,22)`,
+`(12,16)`, and `(12,-4)` pixels by page. This rules out generated marker/page-decoration provenance;
+the single next renderer axis is therefore the **source-text paragraph placement transform** (the
+mapping from placed paragraph origin/baseline to painted page coordinates), not font substitution.
+No correction is made in this slice.
+
+Two independent runs preserved candidate PDF SHA-256
+`61ab5f3a9329c9d78376813d63cffb62aa9f495962dda5bae97f402baa0789fb`, visual-evidence SHA-256
+`45d389cf08c2763990e488768c59c1deae920e42284022c072357bf7682331ef`, report SHA-256
+`2bd3f3c8e80c7794c1eb3c2a5d369d5fdcb8f7669fb6b2a8e2290901259f1823`, and HTML SHA-256
+`0b23fb3f2bfff43e9d700f91ad6dd9c4b452d7f8237ee13de9086bdd1adcf96d`. The document remains eight
+pages with 60 scored regions and 42 intentional blanks; all prior metrics, T3 authority,
+`policy.pass=null`, PDF bytes, and rhwp remain unchanged.
 
 ## Tests
 

--- a/scripts/pdf-visual-check.py
+++ b/scripts/pdf-visual-check.py
@@ -85,7 +85,7 @@ HARD_MAX_REPORT_BYTES = 2 * GIB
 HARD_MAX_SUBPROCESS_OUTPUT_BYTES = 4 * MIB
 HARD_SUBPROCESS_TIMEOUT_SECONDS = 300.0
 
-VISUAL_REGION_SCHEMA_VERSION = 2
+VISUAL_REGION_SCHEMA_VERSION = 3
 MAX_VISUAL_REGION_MANIFEST_BYTES = 8 * MIB
 MAX_VISUAL_REGIONS_TOTAL = 10_000
 MAX_VISUAL_REGIONS_PER_PAGE = 2_000
@@ -491,7 +491,18 @@ def _load_visual_regions(
             label = f"visual regions page {index}.regions[{region_index}]"
             region = _exact_object_keys(
                 region,
-                {"id", "category", "paint_status", "x", "y", "w", "h", "clipped"},
+                {
+                    "id",
+                    "category",
+                    "paint_status",
+                    "x",
+                    "y",
+                    "w",
+                    "h",
+                    "clipped",
+                    "glyph_provenance",
+                    "placed_em_bounds_hwpunit",
+                },
                 label,
             )
             region_id = region["id"]
@@ -512,6 +523,31 @@ def _load_visual_regions(
                     raise VisualCheckError(f"{label}.paint_status is invalid for text")
             elif paint_status != "not-applicable":
                 raise VisualCheckError(f"{label}.paint_status must be not-applicable")
+            glyph_provenance = region["glyph_provenance"]
+            placed_em_bounds = region["placed_em_bounds_hwpunit"]
+            if category == "text":
+                if glyph_provenance not in {
+                    "source-text",
+                    "generated-marker",
+                    "page-decoration",
+                    "mixed",
+                    "unknown",
+                }:
+                    raise VisualCheckError(f"{label}.glyph_provenance is invalid for text")
+                if paint_status == "expected-missing" and (
+                    glyph_provenance != "unknown" or placed_em_bounds is not None
+                ):
+                    raise VisualCheckError(
+                        f"{label} expected-missing text cannot claim placed glyph provenance"
+                    )
+                if paint_status == "painted" and placed_em_bounds is None:
+                    raise VisualCheckError(
+                        f"{label} painted text must carry placed glyph bounds"
+                    )
+            elif glyph_provenance != "not-applicable" or placed_em_bounds is not None:
+                raise VisualCheckError(
+                    f"{label} non-text region cannot claim placed glyph provenance"
+                )
             if not isinstance(region["clipped"], bool):
                 raise VisualCheckError(f"{label}.clipped must be boolean")
             x = _finite_number(region["x"], f"{label}.x")
@@ -528,6 +564,33 @@ def _load_visual_regions(
                 or y + height > page_height + epsilon
             ):
                 raise VisualCheckError(f"{label} is outside its page or has empty geometry")
+            if placed_em_bounds is not None:
+                placed_em_bounds = _exact_object_keys(
+                    placed_em_bounds, {"x", "y", "w", "h"}, f"{label}.placed_em_bounds_hwpunit"
+                )
+                em_x = _finite_number(
+                    placed_em_bounds["x"], f"{label}.placed_em_bounds_hwpunit.x"
+                )
+                em_y = _finite_number(
+                    placed_em_bounds["y"], f"{label}.placed_em_bounds_hwpunit.y"
+                )
+                em_width = _finite_number(
+                    placed_em_bounds["w"], f"{label}.placed_em_bounds_hwpunit.w"
+                )
+                em_height = _finite_number(
+                    placed_em_bounds["h"], f"{label}.placed_em_bounds_hwpunit.h"
+                )
+                if (
+                    em_x < -epsilon
+                    or em_y < -epsilon
+                    or em_width <= 0
+                    or em_height <= 0
+                    or em_x + em_width > page_width + epsilon
+                    or em_y + em_height > page_height + epsilon
+                ):
+                    raise VisualCheckError(
+                        f"{label}.placed_em_bounds_hwpunit is outside its page or empty"
+                    )
             page_region_area += width * height
             if (
                 page_region_area
@@ -2527,6 +2590,8 @@ def _score_visual_regions(
             "id": region["id"],
             "category": region["category"],
             "paint_status": region["paint_status"],
+            "glyph_provenance": region["glyph_provenance"],
+            "placed_em_bounds_hwpunit": region["placed_em_bounds_hwpunit"],
             "source_bounds_hwpunit": {
                 "x": region["x"],
                 "y": region["y"],
@@ -2673,6 +2738,8 @@ def _render_html(report: Mapping[str, Any]) -> str:
                 f"<td>{html.escape(region.get('vertical_trace', {}).get('status', 'unavailable'))}</td>"
                 f"<td>{_format_metric(region.get('vertical_trace', {}).get('offset_px'))}</td>"
                 f"<td>{html.escape(str(region.get('text_residual', {}).get('classification') or 'not-applicable'))}</td>"
+                f"<td>{html.escape(str(region.get('glyph_provenance', 'not-applicable')))}</td>"
+                f"<td>{_format_metric(region.get('placed_em_bounds_hwpunit'))}</td>"
                 f"<td>{_format_metric(region.get('text_residual', {}).get('best_local_ink_f1'))}</td>"
                 f"<td>{_format_metric(region.get('text_residual', {}).get('local_gain'))}</td>"
                 "</tr>"
@@ -2683,6 +2750,7 @@ def _render_html(report: Mapping[str, Any]) -> str:
                 "<table><tr><th>ID</th><th>Category</th><th>Status</th>"
                 "<th>Ink F1</th><th>Edge F1</th><th>Vertical trace</th>"
                 "<th>Offset hypothesis (px)</th><th>Text residual</th>"
+                "<th>Glyph provenance</th><th>Placed EM bounds (HWPUNIT)</th>"
                 "<th>Best local ink F1</th><th>Local gain</th></tr>"
                 f"{region_rows}</table>"
             )
@@ -2876,6 +2944,8 @@ def _summarize_pages(pages: Sequence[Mapping[str, Any]]) -> Dict[str, Any]:
     transition_hypotheses: List[Dict[str, Any]] = []
     text_residual_classification_counts: Dict[str, int] = {}
     text_residual_hypotheses: List[Dict[str, Any]] = []
+    glyph_provenance_counts: Dict[str, int] = {}
+    text_residual_by_glyph_provenance: Dict[str, Dict[str, int]] = {}
     for page in pages:
         for region in page.get("semantic_regions", []):
             trace_status = region.get("vertical_trace", {}).get("status")
@@ -2883,16 +2953,31 @@ def _summarize_pages(pages: Sequence[Mapping[str, Any]]) -> Dict[str, Any]:
                 trace_status_counts[trace_status] = trace_status_counts.get(trace_status, 0) + 1
             text_residual = region.get("text_residual", {})
             residual_classification = text_residual.get("classification")
+            glyph_provenance = region.get("glyph_provenance")
+            if region.get("category") == "text" and glyph_provenance is not None:
+                glyph_provenance_counts[glyph_provenance] = (
+                    glyph_provenance_counts.get(glyph_provenance, 0) + 1
+                )
             if residual_classification is not None:
                 text_residual_classification_counts[residual_classification] = (
                     text_residual_classification_counts.get(residual_classification, 0) + 1
                 )
                 if text_residual.get("status") == "hypothesis":
+                    provenance_counts = text_residual_by_glyph_provenance.setdefault(
+                        str(glyph_provenance), {}
+                    )
+                    provenance_counts[residual_classification] = (
+                        provenance_counts.get(residual_classification, 0) + 1
+                    )
                     text_residual_hypotheses.append(
                         {
                             "page": page["page"],
                             "id": region["id"],
                             "classification": residual_classification,
+                            "glyph_provenance": glyph_provenance,
+                            "placed_em_bounds_hwpunit": region.get(
+                                "placed_em_bounds_hwpunit"
+                            ),
                             "best_offset_px": text_residual.get("best_offset_px"),
                             "positioned_ink_f1": text_residual.get("positioned_ink_f1"),
                             "best_local_ink_f1": text_residual.get("best_local_ink_f1"),
@@ -2969,6 +3054,8 @@ def _summarize_pages(pages: Sequence[Mapping[str, Any]]) -> Dict[str, Any]:
         "vertical_transition_hypotheses": transition_hypotheses,
         "text_residual_classification_counts": text_residual_classification_counts,
         "text_residual_hypotheses": text_residual_hypotheses,
+        "glyph_provenance_counts": glyph_provenance_counts,
+        "text_residual_by_glyph_provenance": text_residual_by_glyph_provenance,
     }
 
 
@@ -3368,6 +3455,8 @@ def _run_visual_check_from_snapshots(
             "vertical_transition_hypotheses": [],
             "text_residual_classification_counts": {},
             "text_residual_hypotheses": [],
+            "glyph_provenance_counts": {},
+            "text_residual_by_glyph_provenance": {},
             "pixel_comparison_attempted": False,
         }
         _write_report(output_dir, report, {}, limits)
@@ -3474,6 +3563,10 @@ def _run_visual_check_from_snapshots(
                         "id": region["id"],
                         "category": region["category"],
                         "paint_status": region["paint_status"],
+                        "glyph_provenance": region["glyph_provenance"],
+                        "placed_em_bounds_hwpunit": region[
+                            "placed_em_bounds_hwpunit"
+                        ],
                         "source_bounds_hwpunit": {
                             key: region[key] for key in ("x", "y", "w", "h")
                         },

--- a/scripts/tests/document-visual-check.test.mjs
+++ b/scripts/tests/document-visual-check.test.mjs
@@ -33,7 +33,7 @@ function fixture() {
     const regions = args[args.indexOf("--visual-regions") + 1];
     fs.writeFileSync(out, "%PDF-own\\n%%EOF\\n");
     fs.writeFileSync(regions, JSON.stringify({
-      schema_version: 2, coordinate_space: "HWPUNIT", candidate_pdf_sha256: "${"a".repeat(64)}",
+      schema_version: 3, coordinate_space: "HWPUNIT", candidate_pdf_sha256: "${"a".repeat(64)}",
       pages: [{ page: 1, width: 59500, height: 84200, intentional_blank_text_regions: 0, regions: [] }]
     }) + "\\n");
     const fontReportIndex = args.indexOf("--font-report");

--- a/scripts/tests/test_pdf_visual_check.py
+++ b/scripts/tests/test_pdf_visual_check.py
@@ -106,7 +106,7 @@ class VisualRegionTests(unittest.TestCase):
 
     def manifest(self, candidate_sha256: str):
         return {
-            "schema_version": 2,
+            "schema_version": 3,
             "coordinate_space": "HWPUNIT",
             "candidate_pdf_sha256": candidate_sha256,
             "pages": [
@@ -125,6 +125,13 @@ class VisualRegionTests(unittest.TestCase):
                             "w": 10000.0,
                             "h": 3000.0,
                             "clipped": False,
+                            "glyph_provenance": "source-text",
+                            "placed_em_bounds_hwpunit": {
+                                "x": 1200.0,
+                                "y": 2200.0,
+                                "w": 900.0,
+                                "h": 1000.0,
+                            },
                         }
                     ],
                 }
@@ -146,6 +153,10 @@ class VisualRegionTests(unittest.TestCase):
         self.assertEqual(loaded["category_counts"]["text"], 1)
         self.assertEqual(loaded["intentional_blank_text_regions"], 2)
         self.assertNotIn("text", loaded["document"]["pages"][0]["regions"][0])
+        self.assertEqual(
+            loaded["document"]["pages"][0]["regions"][0]["glyph_provenance"],
+            "source-text",
+        )
 
         for mutation, pattern in (
             (lambda doc: doc.update({"unknown": True}), "fields differ"),
@@ -166,6 +177,18 @@ class VisualRegionTests(unittest.TestCase):
             ),
             (lambda doc: doc["pages"][0]["regions"][0].update({"x": -1}), "outside its page"),
             (lambda doc: doc["pages"][0]["regions"][0].update({"w": float("nan")}), "non-finite"),
+            (
+                lambda doc: doc["pages"][0]["regions"][0].update(
+                    {"glyph_provenance": "raw-secret"}
+                ),
+                "glyph_provenance",
+            ),
+            (
+                lambda doc: doc["pages"][0]["regions"][0][
+                    "placed_em_bounds_hwpunit"
+                ].update({"w": 0}),
+                "outside its page or empty",
+            ),
         ):
             with self.subTest(pattern=pattern):
                 document = self.manifest(candidate_sha256)
@@ -186,6 +209,13 @@ class VisualRegionTests(unittest.TestCase):
                 "w": 59500.0,
                 "h": 84200.0,
                 "clipped": False,
+                "glyph_provenance": "source-text",
+                "placed_em_bounds_hwpunit": {
+                    "x": 1.0,
+                    "y": 1.0,
+                    "w": 1.0,
+                    "h": 1.0,
+                },
             }
             for index in range(
                 1, pdf_visual_check.MAX_VISUAL_REGION_PAGE_AREA_MULTIPLIER + 2
@@ -194,6 +224,52 @@ class VisualRegionTests(unittest.TestCase):
 
         with self.assertRaisesRegex(pdf_visual_check.VisualCheckError, "scoring budget"):
             self.load(document, candidate_sha256)
+
+    def test_manifest_accepts_typed_origins_and_rejects_stale_or_nontext_claims(self):
+        candidate_sha256 = "a" * 64
+        for provenance in (
+            "source-text",
+            "generated-marker",
+            "page-decoration",
+            "mixed",
+            "unknown",
+        ):
+            with self.subTest(provenance=provenance):
+                document = self.manifest(candidate_sha256)
+                document["pages"][0]["regions"][0]["glyph_provenance"] = provenance
+                self.load(document, candidate_sha256)
+
+        stale = self.manifest(candidate_sha256)
+        stale_region = stale["pages"][0]["regions"][0]
+        stale_region["paint_status"] = "expected-missing"
+        with self.assertRaisesRegex(
+            pdf_visual_check.VisualCheckError, "cannot claim placed glyph provenance"
+        ):
+            self.load(stale, candidate_sha256)
+
+        missing = self.manifest(candidate_sha256)
+        missing_region = missing["pages"][0]["regions"][0]
+        missing_region["paint_status"] = "expected-missing"
+        missing_region["glyph_provenance"] = "unknown"
+        missing_region["placed_em_bounds_hwpunit"] = None
+        self.load(missing, candidate_sha256)
+
+        stale_bounds = self.manifest(candidate_sha256)
+        stale_bounds["pages"][0]["regions"][0]["placed_em_bounds_hwpunit"] = None
+        with self.assertRaisesRegex(
+            pdf_visual_check.VisualCheckError, "painted text must carry placed glyph bounds"
+        ):
+            self.load(stale_bounds, candidate_sha256)
+
+        nontext = self.manifest(candidate_sha256)
+        nontext_region = nontext["pages"][0]["regions"][0]
+        nontext_region.update(
+            id="table-0001", category="table", paint_status="not-applicable"
+        )
+        with self.assertRaisesRegex(
+            pdf_visual_check.VisualCheckError, "non-text region cannot claim"
+        ):
+            self.load(nontext, candidate_sha256)
 
     def test_manifest_rejects_page_mismatch_and_duplicate_region_ids(self):
         candidate_sha256 = "a" * 64
@@ -226,6 +302,8 @@ class VisualRegionTests(unittest.TestCase):
                     "w": 40.0,
                     "h": 40.0,
                     "clipped": False,
+                    "glyph_provenance": "not-applicable",
+                    "placed_em_bounds_hwpunit": None,
                 }
             ],
         }
@@ -249,6 +327,7 @@ class VisualRegionTests(unittest.TestCase):
         page["regions"][0]["category"] = "text"
         page["regions"][0]["id"] = "text-0001"
         page["regions"][0]["paint_status"] = "expected-missing"
+        page["regions"][0]["glyph_provenance"] = "unknown"
         explicit_missing = pdf_visual_check._score_visual_regions(
             page, reference, candidate, 10, 10, {"dx": 0, "dy": 0}, 100_000
         )
@@ -518,12 +597,21 @@ class TextResidualTraceTests(unittest.TestCase):
                             "id": "text-0001",
                             "category": "text",
                             "metrics": None,
+                            "glyph_provenance": "source-text",
+                            "placed_em_bounds_hwpunit": {
+                                "x": 1.0,
+                                "y": 2.0,
+                                "w": 3.0,
+                                "h": 4.0,
+                            },
                             "text_residual": residual,
                         },
                         {
                             "id": "text-0002",
                             "category": "text",
                             "metrics": None,
+                            "glyph_provenance": "unknown",
+                            "placed_em_bounds_hwpunit": None,
                             "text_residual": {
                                 "status": "ambiguous",
                                 "classification": "ambiguous",
@@ -545,6 +633,13 @@ class TextResidualTraceTests(unittest.TestCase):
                     "page": 1,
                     "id": "text-0001",
                     "classification": "geometry-dominant",
+                    "glyph_provenance": "source-text",
+                    "placed_em_bounds_hwpunit": {
+                        "x": 1.0,
+                        "y": 2.0,
+                        "w": 3.0,
+                        "h": 4.0,
+                    },
                     "best_offset_px": {"dx": 3, "dy": 2},
                     "positioned_ink_f1": 0.1,
                     "best_local_ink_f1": 0.95,
@@ -552,6 +647,14 @@ class TextResidualTraceTests(unittest.TestCase):
                     "candidate_to_reference_ink_ratio": 1.0,
                 }
             ],
+        )
+        self.assertEqual(
+            summary["glyph_provenance_counts"],
+            {"source-text": 1, "unknown": 1},
+        )
+        self.assertEqual(
+            summary["text_residual_by_glyph_provenance"],
+            {"source-text": {"geometry-dominant": 1}},
         )
 
 


### PR DESCRIPTION
Closes #231

## What changed
- add source-neutral `PlacedGlyphOrigin` classes for source text, generated markers, page decorations, and unknown producers
- bump strict visual-region evidence to schema v3 with aggregate page-bounded EM geometry and mixed provenance
- correlate report-only text residual hypotheses by provenance without changing scores, alignment, authority, or `policy.pass`
- add fail-closed synthetic coverage and document the canonical content-free result

## Canonical result
- all 28 paint-backed text regions and all 10 geometry-dominant short-glyph regions are `source-text`
- the ten-region cohort has one 1200x1200 HWPUNIT EM each at a consistent paragraph-relative origin (+1008, -180 HWPUNIT)
- next renderer axis: source-text paragraph placement transform; no correction in this PR
- two final runs preserve PDF `61ab5f3a...`, evidence `45d389cf...`, report `2bd3f3c8...`, and HTML `0b23fb3f...`

## Verification
- `scripts/verify-local.sh --full`: all non-browser gates green; sandbox-only port bind blocked the embedded E2E step
- Chromium outside sandbox: 83 passed, 3 intentional skips, 2 retry-pass flakes, exit 0
- Vitest: 1,012 passed
- canonical: 8/18/24 pages and 98.9%+ line gate; AI 120; public corpus 84; oracle 82
- `external/rhwp`: unchanged

No source text, glyph scalar, field payload, model address, font identity/path, raw bytes, or private document material is emitted.