### PR TITLE
feat: diagnose HWP5 source-line transforms

### DIFF
--- a/crates/hwp-core/src/lib.rs
+++ b/crates/hwp-core/src/lib.rs
@@ -64,6 +64,90 @@ fn enrich_hwp5_owned_page_numbers(bytes: &[u8], target: &mut SemanticDoc) {
     };
     merge_owned_page_numbers(target, &owned);
     merge_owned_table_anchor_spacings(target, &owned);
+    merge_owned_source_line_geometry(target, &owned);
+}
+
+#[derive(PartialEq, Eq)]
+enum ParagraphInlineIdentity {
+    Text(String),
+    FieldBegin(String, String),
+    FieldEnd,
+    Bookmark(String),
+    Image,
+    Equation,
+    Chart,
+    Note,
+    Raw,
+}
+
+fn paragraph_inline_identity(paragraph: &Paragraph) -> Vec<ParagraphInlineIdentity> {
+    let mut identity = Vec::new();
+    for inline in paragraph.runs.iter().flat_map(|run| &run.content) {
+        match inline {
+            Inline::Text(text) => match identity.last_mut() {
+                Some(ParagraphInlineIdentity::Text(previous)) => previous.push_str(text),
+                _ => identity.push(ParagraphInlineIdentity::Text(text.clone())),
+            },
+            Inline::FieldBegin(field) => identity.push(ParagraphInlineIdentity::FieldBegin(
+                field.field_type.clone(),
+                field.command.clone(),
+            )),
+            Inline::FieldEnd(_) => identity.push(ParagraphInlineIdentity::FieldEnd),
+            Inline::Bookmark(name) => {
+                identity.push(ParagraphInlineIdentity::Bookmark(name.clone()))
+            }
+            Inline::Image(_) => identity.push(ParagraphInlineIdentity::Image),
+            Inline::Equation(_) => identity.push(ParagraphInlineIdentity::Equation),
+            Inline::Chart(_) => identity.push(ParagraphInlineIdentity::Chart),
+            Inline::Note(_) => identity.push(ParagraphInlineIdentity::Note),
+            Inline::Raw(_) => identity.push(ParagraphInlineIdentity::Raw),
+        }
+    }
+    identity
+}
+
+fn paragraph_identity(left: &Paragraph, right: &Paragraph) -> bool {
+    paragraph_inline_identity(left) == paragraph_inline_identity(right)
+}
+
+fn source_line_section_compatible(target: &Section, owned: &Section) -> bool {
+    target.blocks.len() == owned.blocks.len()
+        && target
+            .blocks
+            .iter()
+            .zip(&owned.blocks)
+            .all(|(target, owned)| match (target, owned) {
+                (Block::Paragraph(target), Block::Paragraph(owned)) => {
+                    paragraph_identity(target, owned)
+                        && (target.source_line_geometry.is_empty()
+                            || target.source_line_geometry == owned.source_line_geometry)
+                }
+                (Block::Table(_), Block::Table(_)) => true,
+                _ => false,
+            })
+}
+
+/// Atomically attach strict first-party HWP5 line geometry to the rhwp bootstrap model. This is
+/// diagnostic-only metadata: `hwp-typeset` does not read it, and any block/content/conflict mismatch
+/// leaves the entire production document unchanged.
+fn merge_owned_source_line_geometry(target: &mut SemanticDoc, owned: &SemanticDoc) -> bool {
+    if target.sections.len() != owned.sections.len()
+        || !target
+            .sections
+            .iter()
+            .zip(&owned.sections)
+            .all(|(target, owned)| source_line_section_compatible(target, owned))
+    {
+        return false;
+    }
+    for (target, owned) in target.sections.iter_mut().zip(&owned.sections) {
+        for (target, owned) in target.blocks.iter_mut().zip(&owned.blocks) {
+            if let (Block::Paragraph(target), Block::Paragraph(owned)) = (target, owned) {
+                target.source_line_geometry = owned.source_line_geometry.clone();
+            }
+        }
+    }
+    true
 }
 
 fn merge_owned_page_numbers(target: &mut SemanticDoc, owned: &SemanticDoc) -> bool {
@@ -332,6 +416,38 @@ mod hwp5_candidate_tests {
         }
     }
 
+    fn line_geometry(vertical_pos: HwpUnit) -> SourceLineGeometry {
+        SourceLineGeometry {
+            vertical_pos,
+            height: 1_500,
+            text_height: 1_200,
+            baseline: 900,
+            line_spacing: 300,
+            column_start: 0,
+            segment_width: 40_000,
+        }
+    }
+
+    fn paragraph_doc(text_runs: &[&str], geometry: &[SourceLineGeometry]) -> SemanticDoc {
+        SemanticDoc {
+            sections: vec![Section {
+                blocks: vec![Block::Paragraph(Paragraph {
+                    runs: text_runs
+                        .iter()
+                        .map(|text| Run {
+                            content: vec![Inline::Text((*text).into())],
+                            ..Run::default()
+                        })
+                        .collect(),
+                    source_line_geometry: geometry.to_vec(),
+                    ..Paragraph::default()
+                })],
+                ..Section::default()
+            }],
+            ..SemanticDoc::default()
+        }
+    }
+
     #[test]
     fn page_number_merge_is_atomic_for_topology_partial_and_typed_conflicts() {
         let first = number(1, PageNumberPosition::BottomCenter);
@@ -415,6 +531,72 @@ mod hwp5_candidate_tests {
             assert_eq!(spacing(&rhwp, block), 0, "rhwp lift is not the owner");
             assert_eq!(spacing(&production, block), expected);
         }
+    }
+
+    #[test]
+    fn source_line_geometry_merge_is_atomic_and_run_boundary_neutral() {
+        let geometry = line_geometry(100);
+        let owned = paragraph_doc(&["a", "b"], &[geometry]);
+
+        let mut compatible = paragraph_doc(&["ab"], &[]);
+        assert!(merge_owned_source_line_geometry(&mut compatible, &owned));
+        let Block::Paragraph(paragraph) = &compatible.sections[0].blocks[0] else {
+            unreachable!()
+        };
+        assert_eq!(paragraph.source_line_geometry, vec![geometry]);
+
+        let mut content_conflict = paragraph_doc(&["ac"], &[]);
+        assert!(!merge_owned_source_line_geometry(
+            &mut content_conflict,
+            &owned
+        ));
+        let Block::Paragraph(paragraph) = &content_conflict.sections[0].blocks[0] else {
+            unreachable!()
+        };
+        assert!(paragraph.source_line_geometry.is_empty());
+
+        let existing = line_geometry(200);
+        let mut typed_conflict = paragraph_doc(&["ab"], &[existing]);
+        assert!(!merge_owned_source_line_geometry(
+            &mut typed_conflict,
+            &owned
+        ));
+        let Block::Paragraph(paragraph) = &typed_conflict.sections[0].blocks[0] else {
+            unreachable!()
+        };
+        assert_eq!(paragraph.source_line_geometry, vec![existing]);
+
+        let mut topology = paragraph_doc(&["ab"], &[]);
+        topology.sections[0]
+            .blocks
+            .push(Block::Table(Table::default()));
+        assert!(!merge_owned_source_line_geometry(&mut topology, &owned));
+        let Block::Paragraph(paragraph) = &topology.sections[0].blocks[0] else {
+            unreachable!()
+        };
+        assert!(paragraph.source_line_geometry.is_empty());
+    }
+
+    #[test]
+    fn production_hwp5_open_enriches_owned_line_geometry_without_rhwp_ownership() {
+        let bytes = benchmark();
+        let owned = open_hwp5_own(&bytes).unwrap();
+        let rhwp = RhwpEngine::new().parse(&bytes, SourceFormat::Hwp5).unwrap();
+        let production = Engine::open(&bytes).unwrap();
+        let count = |doc: &SemanticDoc| {
+            doc.sections
+                .iter()
+                .flat_map(|section| &section.blocks)
+                .filter_map(|block| match block {
+                    Block::Paragraph(paragraph) => Some(paragraph.source_line_geometry.len()),
+                    Block::Table(_) => None,
+                })
+                .sum::<usize>()
+        };
+
+        assert!(count(&owned) > 0);
+        assert_eq!(count(&rhwp), 0, "rhwp lift is not the owner");
+        assert_eq!(count(&production), count(&owned));
     }
 
     #[test]

--- a/crates/hwp-export/src/pdf.rs
+++ b/crates/hwp-export/src/pdf.rs
@@ -22,7 +22,7 @@ use hwp_model::document::{Block, Inline, LineStyle, Paragraph, SemanticDoc};
 use hwp_model::font_class::{classify, FontCategory};
 use hwp_model::layout::{PageLayerTree, PaintOp};
 use hwp_model::prelude::FontMetricsProvider;
-use hwp_model::types::Color;
+use hwp_model::types::{Color, HwpUnit};
 use hwp_typeset::{BlockKind, PlacedDoc, PlacedGlyph, PlacedGlyphOrigin};
 
 use krilla::color::rgb;
@@ -282,6 +282,9 @@ pub struct PdfVisualRegion {
     pub glyph_provenance: &'static str,
     /// Baseline-anchored EM union from the same placement. `None` for non-text or missing paint.
     pub placed_em_bounds_hwpunit: Option<PdfVisualBounds>,
+    /// Report-only comparison between one strict first-party HWP5 source line and this paragraph
+    /// placement. It is never an input to layout or PDF paint and carries no text or binary fields.
+    pub source_line_transform: PdfSourceLineTransform,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Serialize)]
@@ -292,11 +295,60 @@ pub struct PdfVisualBounds {
     pub h: f64,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+pub struct PdfSourceLineGeometry {
+    pub vertical_pos: HwpUnit,
+    pub height: HwpUnit,
+    pub text_height: HwpUnit,
+    pub baseline: HwpUnit,
+    pub line_spacing: HwpUnit,
+    pub column_start: HwpUnit,
+    pub segment_width: HwpUnit,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Serialize)]
+pub struct PdfPlacedLineGeometry {
+    pub em_x_from_band: f64,
+    pub em_top_from_band: f64,
+    pub em_baseline_from_band: f64,
+    pub em_width: f64,
+    pub em_height: f64,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Serialize)]
+pub struct PdfSourceLineDelta {
+    pub em_x_minus_column_start: f64,
+    pub em_baseline_minus_source_baseline: f64,
+    pub band_y_minus_source_vertical_pos: f64,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Serialize)]
+pub struct PdfSourceLineTransform {
+    pub status: &'static str,
+    pub axis_class: &'static str,
+    pub source: Option<PdfSourceLineGeometry>,
+    pub placed: Option<PdfPlacedLineGeometry>,
+    pub delta: Option<PdfSourceLineDelta>,
+}
+
+impl PdfSourceLineTransform {
+    fn unavailable(status: &'static str) -> Self {
+        Self {
+            status,
+            axis_class: "unavailable",
+            source: None,
+            placed: None,
+            delta: None,
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug)]
 struct VisualRegionClassification {
     paint_status: &'static str,
     glyph_provenance: &'static str,
     placed_em_bounds_hwpunit: Option<PdfVisualBounds>,
+    source_line_transform: PdfSourceLineTransform,
 }
 
 /// Result of a PDF export: the bytes plus what font path (if any) backed the glyphs.
@@ -355,8 +407,84 @@ fn push_visual_region(
         clipped: left != x || top != y || right != raw_right || bottom != raw_bottom,
         glyph_provenance: classification.glyph_provenance,
         placed_em_bounds_hwpunit: classification.placed_em_bounds_hwpunit,
+        source_line_transform: classification.source_line_transform,
     });
     Ok(())
+}
+
+fn source_line_transform(
+    paragraph: &Paragraph,
+    block: &hwp_typeset::PlacedBlock,
+    glyph_provenance: &'static str,
+    placed_em_bounds_hwpunit: Option<PdfVisualBounds>,
+) -> PdfSourceLineTransform {
+    if paragraph.dirty.is_dirty() {
+        return PdfSourceLineTransform::unavailable("edited");
+    }
+    let [source] = paragraph.source_line_geometry.as_slice() else {
+        return PdfSourceLineTransform::unavailable(if paragraph.source_line_geometry.is_empty() {
+            "missing"
+        } else {
+            "multi-line-ambiguous"
+        });
+    };
+    if glyph_provenance != "source-text" {
+        return PdfSourceLineTransform::unavailable("non-source-text");
+    }
+    let Some(em) = placed_em_bounds_hwpunit else {
+        return PdfSourceLineTransform::unavailable("missing-placement");
+    };
+    let placed = PdfPlacedLineGeometry {
+        em_x_from_band: em.x - block.x,
+        em_top_from_band: em.y - block.y,
+        em_baseline_from_band: em.y + em.h - block.y,
+        em_width: em.w,
+        em_height: em.h,
+    };
+    let delta = PdfSourceLineDelta {
+        em_x_minus_column_start: placed.em_x_from_band - f64::from(source.column_start),
+        em_baseline_minus_source_baseline: placed.em_baseline_from_band
+            - f64::from(source.baseline),
+        band_y_minus_source_vertical_pos: block.y - f64::from(source.vertical_pos),
+    };
+    if ![
+        placed.em_x_from_band,
+        placed.em_top_from_band,
+        placed.em_baseline_from_band,
+        placed.em_width,
+        placed.em_height,
+        delta.em_x_minus_column_start,
+        delta.em_baseline_minus_source_baseline,
+        delta.band_y_minus_source_vertical_pos,
+    ]
+    .into_iter()
+    .all(f64::is_finite)
+    {
+        return PdfSourceLineTransform::unavailable("non-finite-placement");
+    }
+    let horizontal = delta.em_x_minus_column_start.abs() > f64::EPSILON;
+    let vertical = delta.em_baseline_minus_source_baseline.abs() > f64::EPSILON;
+    let axis_class = match (horizontal, vertical) {
+        (false, false) => "exact",
+        (true, false) => "horizontal-only",
+        (false, true) => "vertical-only",
+        (true, true) => "horizontal-and-vertical",
+    };
+    PdfSourceLineTransform {
+        status: "single-line",
+        axis_class,
+        source: Some(PdfSourceLineGeometry {
+            vertical_pos: source.vertical_pos,
+            height: source.height,
+            text_height: source.text_height,
+            baseline: source.baseline,
+            line_spacing: source.line_spacing,
+            column_start: source.column_start,
+            segment_width: source.segment_width,
+        }),
+        placed: Some(placed),
+        delta: Some(delta),
+    }
 }
 
 fn paragraph_expects_text_paint(paragraph: &Paragraph) -> bool {
@@ -494,6 +622,8 @@ fn visual_evidence(
                 continue;
             };
             let (glyph_provenance, placed_em_bounds_hwpunit) = text_glyph_evidence(page, block);
+            let source_line_transform =
+                source_line_transform(paragraph, block, glyph_provenance, placed_em_bounds_hwpunit);
             push_visual_region(
                 &mut regions,
                 &mut counters,
@@ -503,6 +633,7 @@ fn visual_evidence(
                     paint_status,
                     glyph_provenance,
                     placed_em_bounds_hwpunit,
+                    source_line_transform,
                 },
                 (page.width, page.height),
                 (block.x, block.y, block.w, block.h),
@@ -518,6 +649,7 @@ fn visual_evidence(
                     paint_status: "not-applicable",
                     glyph_provenance: "not-applicable",
                     placed_em_bounds_hwpunit: None,
+                    source_line_transform: PdfSourceLineTransform::unavailable("not-applicable"),
                 },
                 (page.width, page.height),
                 (table.x, table.y, table.w, table.h),
@@ -538,6 +670,7 @@ fn visual_evidence(
                     paint_status: "not-applicable",
                     glyph_provenance: "not-applicable",
                     placed_em_bounds_hwpunit: None,
+                    source_line_transform: PdfSourceLineTransform::unavailable("not-applicable"),
                 },
                 (page.width, page.height),
                 (image.x, image.y, image.w, image.h),
@@ -552,7 +685,7 @@ fn visual_evidence(
         });
     }
     Ok(PdfVisualEvidence {
-        schema_version: 3,
+        schema_version: 4,
         coordinate_space: "HWPUNIT",
         candidate_pdf_sha256,
         pages,
@@ -1472,7 +1605,7 @@ mod tests {
             "non-trivial PDF size, got {}",
             out.bytes.len()
         );
-        assert_eq!(out.visual_evidence.schema_version, 3);
+        assert_eq!(out.visual_evidence.schema_version, 4);
         assert_eq!(out.visual_evidence.coordinate_space, "HWPUNIT");
         assert_eq!(out.visual_evidence.pages.len(), out.pages);
         assert_eq!(
@@ -1718,6 +1851,126 @@ mod tests {
     }
 
     #[test]
+    fn source_line_transform_is_bounded_report_only_and_fail_closed() {
+        let source = SourceLineGeometry {
+            vertical_pos: 200,
+            height: 1_500,
+            text_height: 1_200,
+            baseline: 900,
+            line_spacing: 300,
+            column_start: 100,
+            segment_width: 40_000,
+        };
+        let block = hwp_typeset::PlacedBlock {
+            x: 1_000.0,
+            y: 200.0,
+            w: 40_000.0,
+            h: 1_500.0,
+            section: 0,
+            block: 0,
+            kind: BlockKind::Paragraph,
+        };
+        let em = PdfVisualBounds {
+            x: 1_100.0,
+            y: 0.0,
+            w: 1_200.0,
+            h: 1_100.0,
+        };
+        let mut paragraph = para("visible");
+        paragraph.source_line_geometry = vec![source];
+
+        let exact = source_line_transform(&paragraph, &block, "source-text", Some(em));
+        assert_eq!(exact.status, "single-line");
+        assert_eq!(exact.axis_class, "exact");
+        assert_eq!(exact.source.unwrap().segment_width, 40_000);
+        assert_eq!(exact.delta.unwrap().band_y_minus_source_vertical_pos, 0.0);
+
+        let horizontal = source_line_transform(
+            &paragraph,
+            &block,
+            "source-text",
+            Some(PdfVisualBounds { x: 1_200.0, ..em }),
+        );
+        assert_eq!(horizontal.axis_class, "horizontal-only");
+
+        paragraph.source_line_geometry.push(source);
+        assert_eq!(
+            source_line_transform(&paragraph, &block, "source-text", Some(em)).status,
+            "multi-line-ambiguous"
+        );
+        paragraph.source_line_geometry.clear();
+        assert_eq!(
+            source_line_transform(&paragraph, &block, "source-text", Some(em)).status,
+            "missing"
+        );
+        paragraph.source_line_geometry.push(source);
+        paragraph.dirty.mark();
+        assert_eq!(
+            source_line_transform(&paragraph, &block, "source-text", Some(em)).status,
+            "edited"
+        );
+        paragraph.dirty = Dirty::default();
+        assert_eq!(
+            source_line_transform(&paragraph, &block, "generated-marker", Some(em)).status,
+            "non-source-text"
+        );
+        assert_eq!(
+            source_line_transform(&paragraph, &block, "source-text", None).status,
+            "missing-placement"
+        );
+        assert_eq!(
+            source_line_transform(
+                &paragraph,
+                &hwp_typeset::PlacedBlock {
+                    y: f64::NAN,
+                    ..block
+                },
+                "source-text",
+                Some(em),
+            )
+            .status,
+            "non-finite-placement"
+        );
+    }
+
+    #[test]
+    fn diagnostic_source_line_geometry_cannot_change_pdf_bytes() {
+        let baseline = doc_with(vec![Block::Paragraph(para("same layout and paint"))]);
+        let mut diagnostic = baseline.clone();
+        let Block::Paragraph(paragraph) = &mut diagnostic.sections[0].blocks[0] else {
+            unreachable!()
+        };
+        paragraph.source_line_geometry = vec![SourceLineGeometry {
+            vertical_pos: 100,
+            height: 1_500,
+            text_height: 1_200,
+            baseline: 900,
+            line_spacing: 300,
+            column_start: 0,
+            segment_width: 40_000,
+        }];
+
+        let baseline_pdf =
+            export_pdf(&baseline, &ApproxFontMetrics, &PdfOptions::default()).unwrap();
+        let diagnostic_pdf =
+            export_pdf(&diagnostic, &ApproxFontMetrics, &PdfOptions::default()).unwrap();
+        assert_eq!(baseline_pdf.bytes, diagnostic_pdf.bytes);
+        assert_eq!(baseline_pdf.pages, diagnostic_pdf.pages);
+        assert_eq!(
+            baseline_pdf.visual_evidence.pages[0].regions[0]
+                .source_line_transform
+                .status,
+            "missing"
+        );
+        assert_eq!(
+            diagnostic_pdf.visual_evidence.pages[0].regions[0]
+                .source_line_transform
+                .status,
+            "single-line"
+        );
+    }
+
+    #[test]
     fn clipped_visual_region_keeps_paint_status_and_bounded_geometry() {
         let mut regions = Vec::new();
         let mut counters = [0usize; 4];
@@ -1731,6 +1984,7 @@ mod tests {
                 paint_status: "painted",
                 glyph_provenance: "source-text",
                 placed_em_bounds_hwpunit: None,
+                source_line_transform: PdfSourceLineTransform::unavailable("missing-placement"),
             },
             (100.0, 200.0),
             (-10.0, 180.0, 50.0, 40.0),

--- a/crates/hwp-hwp5/src/semantic.rs
+++ b/crates/hwp-hwp5/src/semantic.rs
@@ -1117,6 +1117,8 @@ fn attach_source_adjacent_table_spacing(
 #[derive(Default)]
 struct ParsedLineMetrics {
     render: Vec<SourceLineMetric>,
+    /// Full source-neutral line geometry for diagnostics only. The typesetter never reads it.
+    diagnostic: Vec<SourceLineGeometry>,
     /// A pure one-line HWP5 table host may own an additional gap after its final hosted table.
     /// Kept private until the paragraph/control structure proves that it is such a host.
     single_positive_host_line: Option<HostLineMetric>,
@@ -1455,10 +1457,11 @@ fn parse_paragraph(
         // Stored line boxes are only an authored-height hint for a true blank spacer.
         // They never dictate line breaks for visible text or a control-host paragraph.
         source_line_metrics: if decoded.chars.is_empty() && decoded.structural_controls.is_empty() {
-            line_metrics.render
+            line_metrics.render.clone()
         } else {
             Vec::new()
         },
+        source_line_geometry: line_metrics.diagnostic,
         provenance: Provenance {
             source: Some(SourceFormat::Hwp5),
             raw: None,
@@ -3153,6 +3156,7 @@ fn parse_line_metrics(
     }
     let mut prior_start = None;
     let mut metrics = Vec::with_capacity(actual);
+    let mut diagnostic = Vec::with_capacity(actual);
     let mut all_zero_height = true;
     let mut single_positive_host_line = None;
     for entry in bytes.chunks_exact(36) {
@@ -3177,6 +3181,7 @@ fn parse_line_metrics(
         let text_height = read_i32(entry, 12).expect("chunk length checked");
         let baseline = read_i32(entry, 16).expect("chunk length checked");
         let line_spacing = read_i32(entry, 20).expect("chunk length checked");
+        let column_start = read_i32(entry, 24).expect("chunk length checked");
         let segment_width = read_i32(entry, 28).expect("chunk length checked");
         if [
             vertical_pos,
@@ -3184,6 +3189,7 @@ fn parse_line_metrics(
             text_height,
             baseline,
             line_spacing,
+            column_start,
             segment_width,
         ]
         .into_iter()
@@ -3193,6 +3199,25 @@ fn parse_line_metrics(
                 &record,
                 Some(section),
                 "PARA_LINE_SEG has a negative geometry field",
+            ));
+        }
+        const MAX_LINE_GEOMETRY_HWPUNIT: HwpUnit = 10_000_000;
+        if [
+            vertical_pos,
+            height,
+            text_height,
+            baseline,
+            line_spacing,
+            column_start,
+            segment_width,
+        ]
+        .into_iter()
+        .any(|value| value > MAX_LINE_GEOMETRY_HWPUNIT)
+        {
+            return Err(malformed(
+                &record,
+                Some(section),
+                "PARA_LINE_SEG geometry exceeds the bounded range",
             ));
         }
         all_zero_height &= height == 0 && text_height == 0;
@@ -3208,13 +3233,24 @@ fn parse_line_metrics(
             text_height,
             baseline,
         });
+        diagnostic.push(SourceLineGeometry {
+            vertical_pos,
+            height,
+            text_height,
+            baseline,
+            line_spacing,
+            column_start,
+            segment_width,
+        });
     }
     if all_zero_height {
         metrics.clear();
+        diagnostic.clear();
         single_positive_host_line = None;
     }
     Ok(ParsedLineMetrics {
         render: metrics,
+        diagnostic,
         single_positive_host_line,
     })
 }

--- a/crates/hwp-hwp5/tests/layout_semantic.rs
+++ b/crates/hwp-hwp5/tests/layout_semantic.rs
@@ -31,7 +31,10 @@ enum Mutation {
     BadLineCount,
     BadLineBoundary,
     BadLineLength,
+    OversizeLineGeometry,
     ZeroHeightLine,
+    VisibleLineGeometry,
+    MultiLineGeometry,
     UnsupportedSectionChild,
     DuplicatePageDef,
     BadControlFrame,
@@ -215,6 +218,42 @@ fn parses_page_setup_and_blank_source_line_metrics() {
     assert_eq!(blank.source_line_metrics[0].height, 1_500);
     assert_eq!(blank.source_line_metrics[0].text_height, 1_200);
     assert_eq!(blank.source_line_metrics[0].baseline, 900);
+    assert_eq!(blank.source_line_geometry.len(), 1);
+    let source = blank.source_line_geometry[0];
+    assert_eq!(source.vertical_pos, 100);
+    assert_eq!(source.height, 1_500);
+    assert_eq!(source.text_height, 1_200);
+    assert_eq!(source.baseline, 900);
+    assert_eq!(source.line_spacing, 300);
+    assert_eq!(source.column_start, 0);
+    assert_eq!(source.segment_width, 40_000);
+}
+
+#[test]
+fn preserves_nonempty_line_geometry_without_promoting_it_to_layout_metrics() {
+    let doc = OwnHwp5Parser::new()
+        .parse(&fixture(Mutation::VisibleLineGeometry))
+        .unwrap();
+    let Block::Paragraph(paragraph) = &doc.sections[0].blocks[1] else {
+        panic!("expected visible paragraph")
+    };
+    assert!(paragraph.source_line_metrics.is_empty());
+    assert_eq!(paragraph.source_line_geometry.len(), 1);
+    assert_eq!(paragraph.source_line_geometry[0].baseline, 900);
+}
+
+#[test]
+fn preserves_multiple_source_lines_as_diagnostic_ambiguity() {
+    let doc = OwnHwp5Parser::new()
+        .parse(&fixture(Mutation::MultiLineGeometry))
+        .unwrap();
+    let Block::Paragraph(paragraph) = &doc.sections[0].blocks[1] else {
+        panic!("expected visible paragraph")
+    };
+    assert!(paragraph.source_line_metrics.is_empty());
+    assert_eq!(paragraph.source_line_geometry.len(), 2);
+    assert_eq!(paragraph.source_line_geometry[0].vertical_pos, 100);
+    assert_eq!(paragraph.source_line_geometry[1].vertical_pos, 1_600);
 }
 
 #[test]
@@ -275,6 +314,20 @@ fn zero_height_line_segments_are_non_authoritative() {
         panic!("expected blank paragraph")
     };
     assert!(blank.source_line_metrics.is_empty());
+    assert!(blank.source_line_geometry.is_empty());
+}
+
+#[test]
+fn rejects_line_geometry_outside_the_bounded_range() {
+    assert!(matches!(
+        OwnHwp5Parser::new().parse(&fixture(Mutation::OversizeLineGeometry)),
+        Err(Error::MalformedRecord {
+            tag: TAG_PARA_LINE_SEG,
+            section: Some(0),
+            reason: "PARA_LINE_SEG geometry exceeds the bounded range",
+            ..
+        })
+    ));
 }
 
 #[test]
@@ -2012,13 +2065,23 @@ fn fixture(mutation: Mutation) -> Vec<u8> {
         column.extend_from_slice(&0x0000_00ffu32.to_le_bytes());
         push_record(&mut body, TAG_CTRL_HEADER, 1, &column);
     } else {
-        let declared_lines = if matches!(mutation, Mutation::BadLineCount) {
+        let declared_lines = if matches!(
+            mutation,
+            Mutation::BadLineCount | Mutation::MultiLineGeometry
+        ) {
             2
         } else {
             1
         };
-        push_para_header(&mut body, 1, 0, 1, declared_lines);
-        push_record(&mut body, TAG_PARA_TEXT, 1, &utf16_bytes(&[0x000d]));
+        let paragraph_text = if matches!(mutation, Mutation::VisibleLineGeometry) {
+            vec!['X' as u16, 0x000d]
+        } else if matches!(mutation, Mutation::MultiLineGeometry) {
+            vec!['A' as u16, 'B' as u16, 0x000d]
+        } else {
+            vec![0x000d]
+        };
+        push_para_header(&mut body, paragraph_text.len() as u32, 0, 1, declared_lines);
+        push_record(&mut body, TAG_PARA_TEXT, 1, &utf16_bytes(&paragraph_text));
         push_record(&mut body, TAG_PARA_CHAR_SHAPE, 1, &shape_refs(&[(0, 0)]));
         let start = if matches!(mutation, Mutation::BadLineBoundary) {
             1
@@ -2031,8 +2094,16 @@ fn fixture(mutation: Mutation) -> Vec<u8> {
             (1_500, 1_200, 900)
         };
         let mut line = line_seg(start, height, text_height, baseline);
+        if matches!(mutation, Mutation::OversizeLineGeometry) {
+            line[24..28].copy_from_slice(&10_000_001i32.to_le_bytes());
+        }
         if matches!(mutation, Mutation::BadLineLength) {
             line.pop();
+        }
+        if matches!(mutation, Mutation::MultiLineGeometry) {
+            let mut second = line_seg(1, 1_500, 1_200, 900);
+            second[4..8].copy_from_slice(&1_600i32.to_le_bytes());
+            line.extend(second);
         }
         push_record(&mut body, TAG_PARA_LINE_SEG, 1, &line);
     }

--- a/crates/hwp-jsx/src/lib.rs
+++ b/crates/hwp-jsx/src/lib.rs
@@ -987,6 +987,7 @@ fn parse_para(el: &JsxElement) -> Result<Paragraph> {
         style_name: el.attrs.get("data-style").cloned(),
         runs,
         source_line_metrics: Vec::new(),
+        source_line_geometry: Vec::new(),
         source: el.attrs.get("data-src").and_then(|s| decode_para_source(s)),
         provenance: el
             .attrs

--- a/crates/hwp-model/src/document.rs
+++ b/crates/hwp-model/src/document.rs
@@ -276,6 +276,10 @@ pub struct Paragraph {
     /// content. Binary forms often use empty spacer paragraphs whose line box is 1500 HWPUNIT even when
     /// no char-shape ref remains; dropping that fact pulled later inline tables hundreds of pixels upward.
     pub source_line_metrics: Vec<SourceLineMetric>,
+    /// Source-neutral HWP5 `PARA_LINE_SEG` geometry retained only for diagnostics. Unlike
+    /// [`source_line_metrics`], this is never consulted by layout, line breaking, pagination, paint,
+    /// or editing. It contains no text offset, flag bits, glyph, font, or binary provenance.
+    pub source_line_geometry: Vec<SourceLineGeometry>,
     /// Provenance for a TOP-LEVEL paragraph parsed from HWPX — enables in-place (non-verbatim)
     /// re-emit: if this paragraph is edited (dirty) the serializer replaces exactly its byte span;
     /// untouched paragraphs ride along byte-verbatim. `None` ⇒ synthesized/appended (legacy path).
@@ -290,6 +294,17 @@ pub struct SourceLineMetric {
     pub height: HwpUnit,
     pub text_height: HwpUnit,
     pub baseline: HwpUnit,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct SourceLineGeometry {
+    pub vertical_pos: HwpUnit,
+    pub height: HwpUnit,
+    pub text_height: HwpUnit,
+    pub baseline: HwpUnit,
+    pub line_spacing: HwpUnit,
+    pub column_start: HwpUnit,
+    pub segment_width: HwpUnit,
 }
 
 /// Where a parsed top-level paragraph came from in the section XML, for surgical re-emit.
@@ -956,6 +971,7 @@ impl SemanticDoc {
                 + prov(&p.provenance)
                 + pass(&p.passthrough)
                 + p.runs.len() * size_of::<Run>()
+                + p.source_line_geometry.len() * size_of::<SourceLineGeometry>()
                 + p.runs
                     .iter()
                     .map(|r| {

--- a/crates/hwp-rhwp/src/lift.rs
+++ b/crates/hwp-rhwp/src/lift.rs
@@ -245,6 +245,7 @@ impl<'a> Lifter<'a> {
             } else {
                 Vec::new()
             },
+            source_line_geometry: Vec::new(),
             provenance: Provenance {
                 source: Some(SourceFormat::Hwp5),
                 raw: None,

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -3,7 +3,31 @@
 > 새 세션·compact 후 **이 파일 하나만 읽으면 재개할 수 있어야 한다.**
 > 갱신 시점: 작업 단위 완료 · 결정 확정 · 머지 직후 (보고보다 먼저). 프로토콜: `AGENTS.md` §세션 연속성.
 
-- 갱신: 2026-08-25 · Codex(sol) — **#231 구현 · PR #232 CI 대기**.
+- 갱신: 2026-08-25 · Codex(sol) — **#233 source-line transform 구현·canonical 단일축 확정**.
+  strict first-party HWP5 parser가 이미 framing하는 `PARA_LINE_SEG`에서 vertical/height/text-height/
+  baseline/spacing/column-start/segment-width만 최대 **10,000,000 HWPUNIT**로 검증해 diagnostic-only
+  IR에 보존한다. text offset·raw flags·본문/scalar·field payload·font/path/bytes는 보존/출력하지 않는다.
+  production rhwp-base에는 whole-document block topology와 run-boundary-neutral typed inline identity,
+  기존 geometry conflict를 전수 검증한 뒤 atomic 보강한다. rhwp lift 자체는 geometry **0**이며
+  `external/rhwp`는 무수정이다. multi-line/edited/missing/non-source/stale/nonfinite/hostile은 fail-closed다.
+  visual schema **v4**는 clean single source line과 같은 placement의 EM을 paragraph-band 상대 좌표로
+  비교하고, score/alignment/threshold/pass에는 입력하지 않는다. Rust parser **52**·core **10**·PDF
+  **48**, Python **72**, Node **4** focused green이며 geometry 유무 PDF bytes exact 회귀를 잠갔다.
+  canonical 독립 2회는 candidate PDF SHA `61ab5f3a…` 불변, evidence `d390c1d3…`, report
+  `0d2a83fc…`, HTML `863c2fe4…` exact다. 8쪽·60 scored·42 intentional blank·T3/`pass=null`과 기존
+  residual은 불변이다. painted text 28 = clean single-line **27** + multi-line ambiguous **1**;
+  transform axis는 exact 2/horizontal-only 25. geometry-dominant **10/10**은 source-text,
+  source baseline delta **0**, column-start→placed EM x delta **+1008 HWPUNIT**로 동일해 다음 단일
+  correction 축을 **horizontal paragraph start transform**으로 확정했다. 아직 renderer는 수정하지
+  않았다. `scripts/verify-local.sh --full`은 Rust/Wasm·AI120·8/18/24+98.9%·public corpus84·
+  oracle82·JS build·Vitest **1,012**·Chromium **85 pass/3 intentional skip**까지 최종 exit 0이다.
+  초기 E2E 원자성 실패는 worktree Wasm과 main-linked JS 패키지가 섞인 검증 환경 문제였고, 내부
+  패키지 링크를 현재 worktree로 맞춘 뒤 격리 및 full 모두 green으로 재현했다. **중단 계약:** #233
+  privacy/vendor 감사→commit/push→PR `Closes #233`→필수 CI/댓글 green 자율 병합→#93/#114 동기화까지만
+  완료하고 작업을 끊는다. 다음 세션은 +1008의 para-shape indent/line-start 소유권을 synthetic으로
+  분리하는 correction child를 issue-first 착수하되, 이번 세션에서는 새 이슈나 renderer 수정을 시작하지 않는다.
+
+- 갱신: 2026-08-25 · Codex(sol) — **#232 병합 · #233 source-line transform 착수**.
   first-party `PlacedGlyph`에 source-text/generated-marker/page-decoration/unknown origin을 붙이고,
   visual-region schema v3가 같은 placement의 page-clipped aggregate EM bounds와 mixed 판정을 strict하게
   운반한다. painted text의 null bounds, expected-missing의 stale provenance/bounds, non-text claim과 old/
@@ -17,10 +41,15 @@
   full은 Rust/rhwp, AI120, 8/18/24+98.9%, public corpus84, oracle82, wasm/licenses, JS build와 Vitest
   **1,012**까지 green이다. sandbox port EPERM 뒤 권한 환경 Chromium도 **83 pass·3 intentional
   skip·2 retry-pass flaky**로 exit 0이며, flakes는 hidden textarea visibility와 stale status-toast
-  timing이다. privacy/vendor/diff audit 뒤 exact head `68e495a`를 push하고 PR **#232**(`Closes #231`)를
-  열었다. **다음:** issue-link/build-test/licenses와 review/comment 변화 추적→green/CLEAN이면 protected
-  main에 자율 merge→#93/#114 sync→해당 transform의 source-neutral parser/placement 비교 child를
-  issue-first 착수.
+  timing이다. PR #232 exact head `e5869e7`은 issue-link **4s**·licenses **2m45s**·build-test **9m46s**
+  green, CLEAN/MERGEABLE, 댓글/review 0으로 protected main `e6baed82`에 squash 병합됐다. #231은
+  close되고 원격 branch도 삭제했으며 #93/#114에 content-free 결과를 동기화했다. 후속 P0 #233을
+  issue-first 등재하고 exact main의 `codex/issue-233-source-line-transform` worktree를 만들었다. 목표는
+  first-party HWP5가 이미 strict framing하는 `PARA_LINE_SEG`의 vertical/baseline·column start/segment
+  width를 non-empty text에는 **report-only untrusted hint**로 보존해 #231 placed paragraph/glyph와
+  비교하는 것이다. 기존 empty-spacer 적용 외 layout authority 승격, renderer 수정, raw flag/text offset,
+  원문/scalar/address/font/path/bytes 노출, rhwp 수정은 금지한다. **다음:** owned parser/model/visual join
+  지도화→valid/ambiguous/stale/hostile RED fixtures→최소 diagnostic-only evidence→canonical 10개 재측정.
 
 - 갱신: 2026-08-25 · Codex(sol) — **#228 병합 · #229 text residual classifier 착수**.
   #227 exact head `8b704c51`은 issue-link **2s**·licenses **2m3s**·build-test **9m25s** green,

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -5,6 +5,12 @@
 
 ---
 
+## 2026-08-25 (Codex sol) · #233 HWP5 source-line transform
+- strict owned diagnostic geometry와 visual schema v4를 구현하고 rhwp lift ownership=0을 잠갔다.
+- canonical 2회 exact; geometry 10/10은 baseline delta 0·horizontal start delta +1008 HU였다.
+- PDF bytes/score/layout 불변, full green: Vitest1,012·Chromium85 pass/3 intentional skip.
+- 다음: PR/CI/merge·#93/#114 sync 후 중단; 재개 시 horizontal paragraph-start correction child.
+
 ## 2026-08-25 (Codex sol) · #231 source-neutral glyph provenance
 - PlacedGlyph origin과 visual schema v3 aggregate EM bounds를 strict·content-free로 구현했다.
 - canonical geometry 10/10은 source-text·1200² EM·band 대비 (+1008,-180) HU로 일치했다.

--- a/docs/PDF-VISUAL-ORACLE.md
+++ b/docs/PDF-VISUAL-ORACLE.md
@@ -321,7 +321,7 @@ otherwise white, globally similar page.
 
 ### Semantic regions
 
-When `--candidate-regions` is supplied, visual-region schema v3 divides the candidate placement into
+When `--candidate-regions` is supplied, visual-region schema v4 divides the candidate placement into
 four content-free categories: paint-backed paragraph bands (`text`), placed table boxes (`table`), raster images
 (`image`), and SVG-backed equations/charts/other objects (`object`). IDs and HWPUNIT geometry are
 present; source text, paths, binary identifiers, and font paths are absent.
@@ -341,6 +341,14 @@ limited to `source-text`, `generated-marker`, `page-decoration`, `mixed`, and `u
 `unknown` with null bounds. The strict loader rejects stale versions, unknown fields, and contradictory
 paint/provenance claims. It never reads PDF text and emits no scalar, source text, field payload, model
 address, font identity, path, raw byte, or private hash.
+
+Schema v4 adds one strictly bounded, report-only HWP5 source-line comparison. A clean paragraph with
+exactly one owned `PARA_LINE_SEG` and source-text paint may expose only seven source-neutral geometry
+values plus paragraph-band-relative EM geometry and three deltas. Missing, edited, multi-line,
+non-source-text, missing-placement, non-finite, and non-text cases carry an explicit status with null
+geometry. The loader rejects stale/unknown fields, values outside 10,000,000 HWPUNIT, non-positive EM
+boxes, and axis labels that disagree with the horizontal/baseline deltas. This stored geometry is
+untrusted evidence: it never enters reflow, pagination, paint, score, alignment, thresholds, or pass.
 
 The manifest must be strict UTF-8 JSON with exactly the known fields, ordered one-based pages, finite
 positive in-page geometry, unique per-page IDs, matching MediaBox dimensions, and an exact SHA-256
@@ -627,6 +635,33 @@ Two independent runs preserved candidate PDF SHA-256
 `0b23fb3f2bfff43e9d700f91ad6dd9c4b452d7f8237ee13de9086bdd1adcf96d`. The document remains eight
 pages with 60 scored regions and 42 intentional blanks; all prior metrics, T3 authority,
 `policy.pass=null`, PDF bytes, and rhwp remain unchanged.
+
+### First-party HWP5 source-line transform (2026-08-25, #233)
+
+The strict first-party parser now retains bounded typed line geometry for non-empty HWP5 paragraphs
+without promoting stored Hancom lines to layout authority. Production HWP5 keeps rhwp only as the
+bootstrap decoder, then atomically attaches this metadata after whole-document block topology,
+run-boundary-neutral inline identity, and existing typed values all agree. The rhwp lift owns none of
+the new field and the vendored tree is unchanged. Synthetic tests cover a valid visible line,
+multi-line ambiguity, count/boundary/length mismatches, zero and oversized geometry, edited and
+missing placement, unknown schema fields, and atomic content/topology/conflict rejection. Adding or
+removing the diagnostic field produces byte-identical PDF output.
+
+On the canonical public pair, 27 of 28 painted text regions have one clean source line and one is
+explicitly multi-line ambiguous. Of the 27, two transforms are exact and 25 are horizontal-only. All
+ten geometry-dominant source-text residuals form one consistent class: source baseline delta is
+exactly 0 HWPUNIT while the placed EM begins 1008 HWPUNIT right of the stored column start. Their
+previous report-only reference offsets remain `(18,22)`, `(12,22)`, `(12,16)`, and `(12,-4)` px by
+page. This supports exactly one next correction investigation—paragraph horizontal start/indent
+ownership—without yet changing the renderer.
+
+Two independent runs preserved candidate PDF SHA-256
+`61ab5f3a9329c9d78376813d63cffb62aa9f495962dda5bae97f402baa0789fb` and produced identical visual
+evidence SHA-256 `d390c1d3be54913565b0dcd1cf906c1ef6745d464ea7127361e6eafc84ed824b`, report SHA-256
+`0d2a83fcd8a2e802967d1c936a47c9d0e0a6f516e3b844ce81cc3f96bab0cdbc`, and HTML SHA-256
+`863c2fe47075e794d9fba5fc7b3b093205a0262ef1a859b40b17d136361be40d`. The document remains eight
+pages with 60 scored regions and 42 intentional blanks; all prior scores, T3 authority,
+`policy.pass=null`, layout/PDF bytes, and reference rules are unchanged.
 
 ## Tests
 

--- a/scripts/pdf-visual-check.py
+++ b/scripts/pdf-visual-check.py
@@ -85,11 +85,12 @@ HARD_MAX_REPORT_BYTES = 2 * GIB
 HARD_MAX_SUBPROCESS_OUTPUT_BYTES = 4 * MIB
 HARD_SUBPROCESS_TIMEOUT_SECONDS = 300.0
 
-VISUAL_REGION_SCHEMA_VERSION = 3
+VISUAL_REGION_SCHEMA_VERSION = 4
 MAX_VISUAL_REGION_MANIFEST_BYTES = 8 * MIB
 MAX_VISUAL_REGIONS_TOTAL = 10_000
 MAX_VISUAL_REGIONS_PER_PAGE = 2_000
 MAX_VISUAL_REGION_PAGE_AREA_MULTIPLIER = 16
+MAX_SOURCE_LINE_GEOMETRY_HWPUNIT = 10_000_000
 VISUAL_REGION_CATEGORIES = frozenset({"text", "table", "image", "object"})
 MAX_VERTICAL_TRACE_PX = 128
 HARD_MAX_VERTICAL_TRACE_WORK_PER_PAGE = 50_000_000
@@ -502,6 +503,7 @@ def _load_visual_regions(
                     "clipped",
                     "glyph_provenance",
                     "placed_em_bounds_hwpunit",
+                    "source_line_transform",
                 },
                 label,
             )
@@ -548,6 +550,125 @@ def _load_visual_regions(
                 raise VisualCheckError(
                     f"{label} non-text region cannot claim placed glyph provenance"
                 )
+            transform = _exact_object_keys(
+                region["source_line_transform"],
+                {"status", "axis_class", "source", "placed", "delta"},
+                f"{label}.source_line_transform",
+            )
+            transform_status = transform["status"]
+            transform_axis = transform["axis_class"]
+            unavailable_statuses = {
+                "missing",
+                "multi-line-ambiguous",
+                "edited",
+                "non-source-text",
+                "missing-placement",
+                "non-finite-placement",
+            }
+            if category != "text":
+                if transform_status != "not-applicable":
+                    raise VisualCheckError(
+                        f"{label} non-text source_line_transform must be not-applicable"
+                    )
+                unavailable_statuses = unavailable_statuses | {"not-applicable"}
+            elif transform_status not in unavailable_statuses | {"single-line"}:
+                raise VisualCheckError(
+                    f"{label}.source_line_transform.status is invalid"
+                )
+            if transform_status != "single-line":
+                if (
+                    transform_axis != "unavailable"
+                    or transform["source"] is not None
+                    or transform["placed"] is not None
+                    or transform["delta"] is not None
+                ):
+                    raise VisualCheckError(
+                        f"{label} unavailable source_line_transform must not claim geometry"
+                    )
+            else:
+                if category != "text" or glyph_provenance != "source-text":
+                    raise VisualCheckError(
+                        f"{label} single-line transform requires source-text provenance"
+                    )
+                if transform_axis not in {
+                    "exact",
+                    "horizontal-only",
+                    "vertical-only",
+                    "horizontal-and-vertical",
+                }:
+                    raise VisualCheckError(
+                        f"{label}.source_line_transform.axis_class is invalid"
+                    )
+                source = _exact_object_keys(
+                    transform["source"],
+                    {
+                        "vertical_pos",
+                        "height",
+                        "text_height",
+                        "baseline",
+                        "line_spacing",
+                        "column_start",
+                        "segment_width",
+                    },
+                    f"{label}.source_line_transform.source",
+                )
+                for key, value in source.items():
+                    if (
+                        isinstance(value, bool)
+                        or not isinstance(value, int)
+                        or value < 0
+                        or value > MAX_SOURCE_LINE_GEOMETRY_HWPUNIT
+                    ):
+                        raise VisualCheckError(
+                            f"{label}.source_line_transform.source.{key} is outside the bounded range"
+                        )
+                placed = _exact_object_keys(
+                    transform["placed"],
+                    {
+                        "em_x_from_band",
+                        "em_top_from_band",
+                        "em_baseline_from_band",
+                        "em_width",
+                        "em_height",
+                    },
+                    f"{label}.source_line_transform.placed",
+                )
+                delta = _exact_object_keys(
+                    transform["delta"],
+                    {
+                        "em_x_minus_column_start",
+                        "em_baseline_minus_source_baseline",
+                        "band_y_minus_source_vertical_pos",
+                    },
+                    f"{label}.source_line_transform.delta",
+                )
+                for group_name, group in (("placed", placed), ("delta", delta)):
+                    for key, value in group.items():
+                        numeric = _finite_number(
+                            value, f"{label}.source_line_transform.{group_name}.{key}"
+                        )
+                        if abs(numeric) > MAX_SOURCE_LINE_GEOMETRY_HWPUNIT:
+                            raise VisualCheckError(
+                                f"{label}.source_line_transform.{group_name}.{key} is outside the bounded range"
+                            )
+                if placed["em_width"] <= 0 or placed["em_height"] <= 0:
+                    raise VisualCheckError(
+                        f"{label}.source_line_transform placed EM must be positive"
+                    )
+                horizontal = abs(float(delta["em_x_minus_column_start"])) > 1e-9
+                vertical = (
+                    abs(float(delta["em_baseline_minus_source_baseline"])) > 1e-9
+                )
+                expected_axis = {
+                    (False, False): "exact",
+                    (True, False): "horizontal-only",
+                    (False, True): "vertical-only",
+                    (True, True): "horizontal-and-vertical",
+                }[(horizontal, vertical)]
+                if transform_axis != expected_axis:
+                    raise VisualCheckError(
+                        f"{label}.source_line_transform.axis_class disagrees with deltas"
+                    )
             if not isinstance(region["clipped"], bool):
                 raise VisualCheckError(f"{label}.clipped must be boolean")
             x = _finite_number(region["x"], f"{label}.x")
@@ -2592,6 +2713,7 @@ def _score_visual_regions(
             "paint_status": region["paint_status"],
             "glyph_provenance": region["glyph_provenance"],
             "placed_em_bounds_hwpunit": region["placed_em_bounds_hwpunit"],
+            "source_line_transform": region["source_line_transform"],
             "source_bounds_hwpunit": {
                 "x": region["x"],
                 "y": region["y"],
@@ -2740,6 +2862,8 @@ def _render_html(report: Mapping[str, Any]) -> str:
                 f"<td>{html.escape(str(region.get('text_residual', {}).get('classification') or 'not-applicable'))}</td>"
                 f"<td>{html.escape(str(region.get('glyph_provenance', 'not-applicable')))}</td>"
                 f"<td>{_format_metric(region.get('placed_em_bounds_hwpunit'))}</td>"
+                f"<td>{html.escape(str(region.get('source_line_transform', {}).get('status', 'unavailable')))}</td>"
+                f"<td>{html.escape(str(region.get('source_line_transform', {}).get('axis_class', 'unavailable')))}</td>"
                 f"<td>{_format_metric(region.get('text_residual', {}).get('best_local_ink_f1'))}</td>"
                 f"<td>{_format_metric(region.get('text_residual', {}).get('local_gain'))}</td>"
                 "</tr>"
@@ -2751,6 +2875,7 @@ def _render_html(report: Mapping[str, Any]) -> str:
                 "<th>Ink F1</th><th>Edge F1</th><th>Vertical trace</th>"
                 "<th>Offset hypothesis (px)</th><th>Text residual</th>"
                 "<th>Glyph provenance</th><th>Placed EM bounds (HWPUNIT)</th>"
+                "<th>Source line</th><th>Transform axis</th>"
                 "<th>Best local ink F1</th><th>Local gain</th></tr>"
                 f"{region_rows}</table>"
             )
@@ -2946,6 +3071,10 @@ def _summarize_pages(pages: Sequence[Mapping[str, Any]]) -> Dict[str, Any]:
     text_residual_hypotheses: List[Dict[str, Any]] = []
     glyph_provenance_counts: Dict[str, int] = {}
     text_residual_by_glyph_provenance: Dict[str, Dict[str, int]] = {}
+    source_line_transform_status_counts: Dict[str, int] = {}
+    source_line_axis_counts: Dict[str, int] = {}
+    geometry_residual_source_line_candidates: List[Dict[str, Any]] = []
+    geometry_residual_hypotheses = 0
     for page in pages:
         for region in page.get("semantic_regions", []):
             trace_status = region.get("vertical_trace", {}).get("status")
@@ -2954,15 +3083,39 @@ def _summarize_pages(pages: Sequence[Mapping[str, Any]]) -> Dict[str, Any]:
             text_residual = region.get("text_residual", {})
             residual_classification = text_residual.get("classification")
             glyph_provenance = region.get("glyph_provenance")
+            source_line_transform = region.get("source_line_transform", {})
             if region.get("category") == "text" and glyph_provenance is not None:
                 glyph_provenance_counts[glyph_provenance] = (
                     glyph_provenance_counts.get(glyph_provenance, 0) + 1
                 )
+                transform_status = source_line_transform.get("status")
+                if transform_status is not None:
+                    source_line_transform_status_counts[transform_status] = (
+                        source_line_transform_status_counts.get(transform_status, 0) + 1
+                    )
+                transform_axis = source_line_transform.get("axis_class")
+                if transform_status == "single-line" and transform_axis is not None:
+                    source_line_axis_counts[transform_axis] = (
+                        source_line_axis_counts.get(transform_axis, 0) + 1
+                    )
             if residual_classification is not None:
                 text_residual_classification_counts[residual_classification] = (
                     text_residual_classification_counts.get(residual_classification, 0) + 1
                 )
                 if text_residual.get("status") == "hypothesis":
+                    if residual_classification == "geometry-dominant":
+                        geometry_residual_hypotheses += 1
+                        if (
+                            glyph_provenance == "source-text"
+                            and source_line_transform.get("status") == "single-line"
+                        ):
+                            geometry_residual_source_line_candidates.append(
+                                {
+                                    "page": page["page"],
+                                    "id": region["id"],
+                                    "axis_class": source_line_transform.get("axis_class"),
+                                }
+                            )
                     provenance_counts = text_residual_by_glyph_provenance.setdefault(
                         str(glyph_provenance), {}
                     )
@@ -2978,6 +3131,7 @@ def _summarize_pages(pages: Sequence[Mapping[str, Any]]) -> Dict[str, Any]:
                             "placed_em_bounds_hwpunit": region.get(
                                 "placed_em_bounds_hwpunit"
                             ),
+                            "source_line_transform": source_line_transform,
                             "best_offset_px": text_residual.get("best_offset_px"),
                             "positioned_ink_f1": text_residual.get("positioned_ink_f1"),
                             "best_local_ink_f1": text_residual.get("best_local_ink_f1"),
@@ -3037,6 +3191,25 @@ def _summarize_pages(pages: Sequence[Mapping[str, Any]]) -> Dict[str, Any]:
         )
     region_entries.sort(key=region_key)
 
+    source_line_single_axis_hypothesis = None
+    if (
+        geometry_residual_hypotheses > 0
+        and len(geometry_residual_source_line_candidates)
+        == geometry_residual_hypotheses
+    ):
+        axes = {
+            candidate["axis_class"]
+            for candidate in geometry_residual_source_line_candidates
+        }
+        if len(axes) == 1:
+            axis = next(iter(axes))
+            if axis in {"horizontal-only", "vertical-only"}:
+                source_line_single_axis_hypothesis = {
+                    "axis": axis,
+                    "regions": geometry_residual_hypotheses,
+                    "basis": "all geometry-dominant source-text regions have one clean source line and the same transform axis",
+                }
+
     return {
         "total_pages": len(pages),
         "scored_pages": len(scored),
@@ -3056,6 +3229,9 @@ def _summarize_pages(pages: Sequence[Mapping[str, Any]]) -> Dict[str, Any]:
         "text_residual_hypotheses": text_residual_hypotheses,
         "glyph_provenance_counts": glyph_provenance_counts,
         "text_residual_by_glyph_provenance": text_residual_by_glyph_provenance,
+        "source_line_transform_status_counts": source_line_transform_status_counts,
+        "source_line_axis_counts": source_line_axis_counts,
+        "source_line_single_axis_hypothesis": source_line_single_axis_hypothesis,
     }
 
 
@@ -3457,6 +3633,9 @@ def _run_visual_check_from_snapshots(
             "text_residual_hypotheses": [],
             "glyph_provenance_counts": {},
             "text_residual_by_glyph_provenance": {},
+            "source_line_transform_status_counts": {},
+            "source_line_axis_counts": {},
+            "source_line_single_axis_hypothesis": None,
             "pixel_comparison_attempted": False,
         }
         _write_report(output_dir, report, {}, limits)
@@ -3567,6 +3746,7 @@ def _run_visual_check_from_snapshots(
                         "placed_em_bounds_hwpunit": region[
                             "placed_em_bounds_hwpunit"
                         ],
+                        "source_line_transform": region["source_line_transform"],
                         "source_bounds_hwpunit": {
                             key: region[key] for key in ("x", "y", "w", "h")
                         },

--- a/scripts/tests/test_pdf_visual_check.py
+++ b/scripts/tests/test_pdf_visual_check.py
@@ -72,6 +72,46 @@ def default_limits(**overrides):
     return pdf_visual_check.ResourceLimits(**values)
 
 
+def unavailable_source_line(status="missing"):
+    return {
+        "status": status,
+        "axis_class": "unavailable",
+        "source": None,
+        "placed": None,
+        "delta": None,
+    }
+
+
+def single_source_line(axis="horizontal-only"):
+    horizontal = 100.0 if axis in {"horizontal-only", "horizontal-and-vertical"} else 0.0
+    vertical = 200.0 if axis in {"vertical-only", "horizontal-and-vertical"} else 0.0
+    return {
+        "status": "single-line",
+        "axis_class": axis,
+        "source": {
+            "vertical_pos": 2000,
+            "height": 1500,
+            "text_height": 1200,
+            "baseline": 900,
+            "line_spacing": 300,
+            "column_start": 0,
+            "segment_width": 10000,
+        },
+        "placed": {
+            "em_x_from_band": horizontal,
+            "em_top_from_band": -100.0,
+            "em_baseline_from_band": 900.0 + vertical,
+            "em_width": 900.0,
+            "em_height": 1000.0,
+        },
+        "delta": {
+            "em_x_minus_column_start": horizontal,
+            "em_baseline_minus_source_baseline": vertical,
+            "band_y_minus_source_vertical_pos": 0.0,
+        },
+    }
+
+
 class MetricTests(unittest.TestCase):
     def test_identical_images_are_exact_without_translation(self):
         image = gray_image(16, 16, rectangle(4, 4, 9, 9))
@@ -106,7 +146,7 @@ class VisualRegionTests(unittest.TestCase):
 
     def manifest(self, candidate_sha256: str):
         return {
-            "schema_version": 3,
+            "schema_version": 4,
             "coordinate_space": "HWPUNIT",
             "candidate_pdf_sha256": candidate_sha256,
             "pages": [
@@ -132,6 +172,7 @@ class VisualRegionTests(unittest.TestCase):
                                 "w": 900.0,
                                 "h": 1000.0,
                             },
+                            "source_line_transform": single_source_line(),
                         }
                     ],
                 }
@@ -216,6 +257,7 @@ class VisualRegionTests(unittest.TestCase):
                     "w": 1.0,
                     "h": 1.0,
                 },
+                "source_line_transform": unavailable_source_line(),
             }
             for index in range(
                 1, pdf_visual_check.MAX_VISUAL_REGION_PAGE_AREA_MULTIPLIER + 2
@@ -224,6 +266,63 @@ class VisualRegionTests(unittest.TestCase):
 
         with self.assertRaisesRegex(pdf_visual_check.VisualCheckError, "scoring budget"):
             self.load(document, candidate_sha256)
+
+    def test_source_line_transform_rejects_unknown_stale_hostile_and_axis_mismatch(self):
+        candidate_sha256 = "a" * 64
+        mutations = (
+            (
+                lambda transform: transform.update({"unknown": True}),
+                "fields differ",
+            ),
+            (
+                lambda transform: transform["source"].update(
+                    {"segment_width": 10_000_001}
+                ),
+                "outside the bounded range",
+            ),
+            (
+                lambda transform: transform["delta"].update(
+                    {"em_x_minus_column_start": float("inf")}
+                ),
+                "non-finite",
+            ),
+            (
+                lambda transform: transform.update({"axis_class": "vertical-only"}),
+                "disagrees with deltas",
+            ),
+            (
+                lambda transform: transform.update(
+                    {
+                        "status": "multi-line-ambiguous",
+                        "axis_class": "unavailable",
+                    }
+                ),
+                "must not claim geometry",
+            ),
+        )
+        for mutation, pattern in mutations:
+            with self.subTest(pattern=pattern):
+                document = self.manifest(candidate_sha256)
+                mutation(
+                    document["pages"][0]["regions"][0]["source_line_transform"]
+                )
+                with self.assertRaisesRegex(pdf_visual_check.VisualCheckError, pattern):
+                    self.load(document, candidate_sha256)
+
+        for status in (
+            "missing",
+            "multi-line-ambiguous",
+            "edited",
+            "non-source-text",
+            "missing-placement",
+            "non-finite-placement",
+        ):
+            with self.subTest(status=status):
+                document = self.manifest(candidate_sha256)
+                document["pages"][0]["regions"][0][
+                    "source_line_transform"
+                ] = unavailable_source_line(status)
+                self.load(document, candidate_sha256)
 
     def test_manifest_accepts_typed_origins_and_rejects_stale_or_nontext_claims(self):
         candidate_sha256 = "a" * 64
@@ -237,6 +336,10 @@ class VisualRegionTests(unittest.TestCase):
             with self.subTest(provenance=provenance):
                 document = self.manifest(candidate_sha256)
                 document["pages"][0]["regions"][0]["glyph_provenance"] = provenance
+                if provenance != "source-text":
+                    document["pages"][0]["regions"][0][
+                        "source_line_transform"
+                    ] = unavailable_source_line("non-source-text")
                 self.load(document, candidate_sha256)
 
         stale = self.manifest(candidate_sha256)
@@ -252,6 +355,9 @@ class VisualRegionTests(unittest.TestCase):
         missing_region["paint_status"] = "expected-missing"
         missing_region["glyph_provenance"] = "unknown"
         missing_region["placed_em_bounds_hwpunit"] = None
+        missing_region["source_line_transform"] = unavailable_source_line(
+            "missing-placement"
+        )
         self.load(missing, candidate_sha256)
 
         stale_bounds = self.manifest(candidate_sha256)
@@ -264,7 +370,10 @@ class VisualRegionTests(unittest.TestCase):
         nontext = self.manifest(candidate_sha256)
         nontext_region = nontext["pages"][0]["regions"][0]
         nontext_region.update(
-            id="table-0001", category="table", paint_status="not-applicable"
+            id="table-0001",
+            category="table",
+            paint_status="not-applicable",
+            source_line_transform=unavailable_source_line("not-applicable"),
         )
         with self.assertRaisesRegex(
             pdf_visual_check.VisualCheckError, "non-text region cannot claim"
@@ -304,6 +413,7 @@ class VisualRegionTests(unittest.TestCase):
                     "clipped": False,
                     "glyph_provenance": "not-applicable",
                     "placed_em_bounds_hwpunit": None,
+                    "source_line_transform": unavailable_source_line("not-applicable"),
                 }
             ],
         }
@@ -328,6 +438,9 @@ class VisualRegionTests(unittest.TestCase):
         page["regions"][0]["id"] = "text-0001"
         page["regions"][0]["paint_status"] = "expected-missing"
         page["regions"][0]["glyph_provenance"] = "unknown"
+        page["regions"][0]["source_line_transform"] = unavailable_source_line(
+            "missing-placement"
+        )
         explicit_missing = pdf_visual_check._score_visual_regions(
             page, reference, candidate, 10, 10, {"dx": 0, "dy": 0}, 100_000
         )
@@ -578,6 +691,7 @@ class TextResidualTraceTests(unittest.TestCase):
         self.assertEqual(missing["classification"], "unscorable")
 
     def test_summary_counts_classes_and_keeps_only_content_free_hypotheses(self):
+        transform = single_source_line("horizontal-only")
         residual = {
             "status": "hypothesis",
             "classification": "geometry-dominant",
@@ -604,6 +718,7 @@ class TextResidualTraceTests(unittest.TestCase):
                                 "w": 3.0,
                                 "h": 4.0,
                             },
+                            "source_line_transform": transform,
                             "text_residual": residual,
                         },
                         {
@@ -612,6 +727,7 @@ class TextResidualTraceTests(unittest.TestCase):
                             "metrics": None,
                             "glyph_provenance": "unknown",
                             "placed_em_bounds_hwpunit": None,
+                            "source_line_transform": unavailable_source_line(),
                             "text_residual": {
                                 "status": "ambiguous",
                                 "classification": "ambiguous",
@@ -640,6 +756,7 @@ class TextResidualTraceTests(unittest.TestCase):
                         "w": 3.0,
                         "h": 4.0,
                     },
+                    "source_line_transform": transform,
                     "best_offset_px": {"dx": 3, "dy": 2},
                     "positioned_ink_f1": 0.1,
                     "best_local_ink_f1": 0.95,
@@ -656,6 +773,48 @@ class TextResidualTraceTests(unittest.TestCase):
             summary["text_residual_by_glyph_provenance"],
             {"source-text": {"geometry-dominant": 1}},
         )
+        self.assertEqual(
+            summary["source_line_transform_status_counts"],
+            {"single-line": 1, "missing": 1},
+        )
+        self.assertEqual(summary["source_line_axis_counts"], {"horizontal-only": 1})
+        self.assertEqual(
+            summary["source_line_single_axis_hypothesis"],
+            {
+                "axis": "horizontal-only",
+                "regions": 1,
+                "basis": "all geometry-dominant source-text regions have one clean source line and the same transform axis",
+            },
+        )
+
+    def test_summary_withholds_single_axis_when_geometry_cohort_is_inconsistent(self):
+        def region(region_id, axis):
+            return {
+                "id": region_id,
+                "category": "text",
+                "metrics": None,
+                "glyph_provenance": "source-text",
+                "placed_em_bounds_hwpunit": None,
+                "source_line_transform": single_source_line(axis),
+                "text_residual": {
+                    "status": "hypothesis",
+                    "classification": "geometry-dominant",
+                },
+            }
+
+        summary = pdf_visual_check._summarize_pages(
+            [
+                {
+                    "page": 1,
+                    "metrics": None,
+                    "semantic_regions": [
+                        region("text-0001", "horizontal-only"),
+                        region("text-0002", "vertical-only"),
+                    ],
+                }
+            ]
+        )
+        self.assertIsNone(summary["source_line_single_axis_hypothesis"])
 
 
 class MetricRegressionTests(unittest.TestCase):


### PR DESCRIPTION
Closes #233

## Summary
- preserve seven bounded HWP5 PARA_LINE_SEG geometry fields as diagnostic-only first-party IR, then atomically enrich the production rhwp-base document without giving rhwp ownership
- publish strict visual-evidence schema v4 transform statuses and source-to-placed EM deltas without affecting layout, PDF bytes, scores, thresholds, or pass policy
- classify canonical geometry residuals to one horizontal paragraph-start axis: 10/10 geometry-dominant source-text regions have +1008 HWPUNIT x delta and zero baseline delta

## Safety
- external/rhwp unchanged and rhwp lift geometry remains zero
- no source text, offsets, raw flags, paths, font provenance, or binary identifiers are emitted
- multi-line, edited, missing, stale, non-finite, and hostile inputs fail closed

## Verification
- scripts/verify-local.sh --full: green
- Vitest: 1,012 passed
- Playwright: 85 passed, 3 intentional skipped
- canonical two-run PDF/evidence/report/HTML hashes exact; PDF SHA unchanged; 8/18/24 and 98.9%+ gates unchanged